### PR TITLE
fix: use cloacina::cloacina_workflow path in task macro for external crates

### DIFF
--- a/crates/cloacina-macros/src/tasks.rs
+++ b/crates/cloacina-macros/src/tasks.rs
@@ -198,22 +198,21 @@ pub fn generate_retry_policy_code(attrs: &TaskAttributes) -> TokenStream2 {
     let with_jitter = attrs.retry_jitter.unwrap_or(true);
 
     // Generate backoff strategy
-    // Use absolute path ::cloacina_workflow to work with both direct dependencies
-    // and indirect dependencies through cloacina's re-export
+    // Use absolute path through cloacina's re-export to work with external crates
     let backoff_strategy = match attrs.retry_backoff.as_deref() {
         Some("fixed") => quote! {
-            ::cloacina_workflow::BackoffStrategy::Fixed
+            ::cloacina::cloacina_workflow::BackoffStrategy::Fixed
         },
         Some("linear") => quote! {
-            ::cloacina_workflow::BackoffStrategy::Linear { multiplier: 1.0 }
+            ::cloacina::cloacina_workflow::BackoffStrategy::Linear { multiplier: 1.0 }
         },
         Some("exponential") | None => quote! {
-            ::cloacina_workflow::BackoffStrategy::Exponential { base: 2.0, multiplier: 1.0 }
+            ::cloacina::cloacina_workflow::BackoffStrategy::Exponential { base: 2.0, multiplier: 1.0 }
         },
         Some(_other) => {
             // Custom backoff - for now, default to exponential
             quote! {
-                ::cloacina_workflow::BackoffStrategy::Exponential { base: 2.0, multiplier: 1.0 }
+                ::cloacina::cloacina_workflow::BackoffStrategy::Exponential { base: 2.0, multiplier: 1.0 }
             }
         }
     };
@@ -221,19 +220,19 @@ pub fn generate_retry_policy_code(attrs: &TaskAttributes) -> TokenStream2 {
     // Generate retry condition
     let retry_condition = match attrs.retry_condition.as_deref() {
         Some("never") => quote! {
-            vec![::cloacina_workflow::RetryCondition::Never]
+            vec![::cloacina::cloacina_workflow::RetryCondition::Never]
         },
         Some("all") | None => quote! {
-            vec![::cloacina_workflow::RetryCondition::AllErrors]
+            vec![::cloacina::cloacina_workflow::RetryCondition::AllErrors]
         },
         Some("transient") => quote! {
-            vec![::cloacina_workflow::RetryCondition::TransientOnly]
+            vec![::cloacina::cloacina_workflow::RetryCondition::TransientOnly]
         },
         Some(patterns) => {
             // Parse comma-separated patterns
             let pattern_list: Vec<&str> = patterns.split(',').map(|s| s.trim()).collect();
             quote! {
-                vec![::cloacina_workflow::RetryCondition::ErrorPattern {
+                vec![::cloacina::cloacina_workflow::RetryCondition::ErrorPattern {
                     patterns: vec![#(#pattern_list.to_string()),*]
                 }]
             }
@@ -241,7 +240,7 @@ pub fn generate_retry_policy_code(attrs: &TaskAttributes) -> TokenStream2 {
     };
 
     quote! {
-        ::cloacina_workflow::RetryPolicy {
+        ::cloacina::cloacina_workflow::RetryPolicy {
             max_attempts: #max_attempts,
             initial_delay: std::time::Duration::from_millis(#initial_delay_ms as u64),
             max_delay: std::time::Duration::from_millis(#max_delay_ms as u64),
@@ -654,7 +653,7 @@ pub fn generate_task_impl(attrs: TaskAttributes, input: ItemFn) -> TokenStream2 
         // Generate the task struct
         #[derive(Debug)]
         #fn_vis struct #task_struct_name {
-            dependencies: Vec<::cloacina_workflow::TaskNamespace>,
+            dependencies: Vec<::cloacina::cloacina_workflow::TaskNamespace>,
         }
 
         impl #task_struct_name {
@@ -664,7 +663,7 @@ pub fn generate_task_impl(attrs: TaskAttributes, input: ItemFn) -> TokenStream2 
                 }
             }
 
-            pub fn with_dependencies(mut self, dependencies: Vec<::cloacina_workflow::TaskNamespace>) -> Self {
+            pub fn with_dependencies(mut self, dependencies: Vec<::cloacina::cloacina_workflow::TaskNamespace>) -> Self {
                 self.dependencies = dependencies;
                 self
             }
@@ -679,7 +678,7 @@ pub fn generate_task_impl(attrs: TaskAttributes, input: ItemFn) -> TokenStream2 
             }
 
             /// Create the retry policy based on macro attributes
-            pub fn create_retry_policy(&self) -> ::cloacina_workflow::RetryPolicy {
+            pub fn create_retry_policy(&self) -> ::cloacina::cloacina_workflow::RetryPolicy {
                 #generate_retry_policy
             }
 
@@ -691,14 +690,14 @@ pub fn generate_task_impl(attrs: TaskAttributes, input: ItemFn) -> TokenStream2 
 
 
         #[async_trait::async_trait]
-        impl ::cloacina_workflow::Task for #task_struct_name {
-            async fn execute(&self, mut context: ::cloacina_workflow::Context<serde_json::Value>)
-                -> Result<::cloacina_workflow::Context<serde_json::Value>, ::cloacina_workflow::TaskError> {
+        impl ::cloacina::cloacina_workflow::Task for #task_struct_name {
+            async fn execute(&self, mut context: ::cloacina::cloacina_workflow::Context<serde_json::Value>)
+                -> Result<::cloacina::cloacina_workflow::Context<serde_json::Value>, ::cloacina::cloacina_workflow::TaskError> {
 
                 // Convert the result to our expected format
                 match #execute_body {
                     Ok(()) => Ok(context),
-                    Err(e) => Err(::cloacina_workflow::TaskError::ExecutionFailed {
+                    Err(e) => Err(::cloacina::cloacina_workflow::TaskError::ExecutionFailed {
                         message: format!("{:?}", e),
                         task_id: #task_id.to_string(),
                         timestamp: chrono::Utc::now(),
@@ -710,11 +709,11 @@ pub fn generate_task_impl(attrs: TaskAttributes, input: ItemFn) -> TokenStream2 
                 #task_id
             }
 
-            fn dependencies(&self) -> &[::cloacina_workflow::TaskNamespace] {
+            fn dependencies(&self) -> &[::cloacina::cloacina_workflow::TaskNamespace] {
                 &self.dependencies
             }
 
-            fn retry_policy(&self) -> ::cloacina_workflow::RetryPolicy {
+            fn retry_policy(&self) -> ::cloacina::cloacina_workflow::RetryPolicy {
                 self.create_retry_policy()
             }
 


### PR DESCRIPTION
## Summary

- Fixed task macro to use `::cloacina::cloacina_workflow::*` paths instead of `::cloacina_workflow::*`
- External crates that depend on `cloacina` (not directly on `cloacina_workflow`) can now compile when using the `#[task]` macro
- This fixes the performance examples which were failing with "could not find cloacina_workflow in the list of imported crates"

## Test plan

- [x] Run `angreal performance quick` locally - all tests pass
- [ ] CI performance tests should now pass