### PR TITLE
refactor: remove unused execution_order field from PackageManifest (CLOACI-I-0011)

### DIFF
--- a/crates/cloacina/src/packaging/manifest.rs
+++ b/crates/cloacina/src/packaging/manifest.rs
@@ -244,7 +244,6 @@ pub fn generate_manifest(
             architecture,
         },
         tasks,
-        execution_order: vec![], // TODO: Generate from task dependencies based on extracted tasks
         graph: graph_data,
     };
 

--- a/crates/cloacina/src/packaging/tests.rs
+++ b/crates/cloacina/src/packaging/tests.rs
@@ -319,7 +319,6 @@ pub fn regular_function() -> String {
                     source_location: "src/lib.rs:20".to_string(),
                 },
             ],
-            execution_order: vec!["task1".to_string(), "task2".to_string()],
             graph: None,
         };
 
@@ -346,10 +345,6 @@ pub fn regular_function() -> String {
         assert_eq!(
             deserialized.tasks[1].dependencies,
             original_manifest.tasks[1].dependencies
-        );
-        assert_eq!(
-            deserialized.execution_order,
-            original_manifest.execution_order
         );
     }
 

--- a/crates/cloacina/src/packaging/types.rs
+++ b/crates/cloacina/src/packaging/types.rs
@@ -59,8 +59,6 @@ pub struct PackageManifest {
     pub library: LibraryInfo,
     /// Task information
     pub tasks: Vec<TaskInfo>,
-    /// Task execution order
-    pub execution_order: Vec<String>,
     /// Workflow graph data (optional)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub graph: Option<crate::WorkflowGraphData>,

--- a/crates/cloacina/tests/integration/packaging.rs
+++ b/crates/cloacina/tests/integration/packaging.rs
@@ -325,7 +325,6 @@ fn test_package_manifest_serialization() {
             description: "Test task".to_string(),
             source_location: "src/lib.rs:5".to_string(),
         }],
-        execution_order: vec!["test_task".to_string()],
         graph: None,
     };
 


### PR DESCRIPTION
## Summary

Remove the `execution_order` field from `PackageManifest` - it was vestigial code that was:
- Never populated (always `vec![]` with a TODO comment)
- Never consumed by any runtime code

Task execution order is computed dynamically at runtime via topological sort on the dependency graph, which also preserves parallelism information (execution levels) that a flat list would lose.

## Changes

- Remove `execution_order: Vec<String>` field from `PackageManifest` struct
- Remove the assignment and TODO comment in `generate_manifest()`
- Update unit and integration tests

## Test plan

- [x] All 181 unit tests pass
- [x] `cargo check` passes
- [x] Pre-commit hooks pass