### PR TITLE
fix: add proper error handling for async runtime shutdown (CLOACI-I-0012)

### DIFF
--- a/bindings/cloaca-backend/Cargo.toml
+++ b/bindings/cloaca-backend/Cargo.toml
@@ -18,6 +18,7 @@ serde_json = "1.0"
 pythonize = "0.25"
 async-trait = "0.1"
 chrono = "0.4"
+thiserror = "2"
 tokio = { version = "1", features = ["rt", "sync"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }


### PR DESCRIPTION
## Summary

- Add `ShutdownError` enum with `ChannelClosed`, `ThreadPanic`, and `Timeout` variants
- Implement 5-second timeout for thread join to prevent hangs
- Add structured logging (tracing) throughout shutdown path
- Surface shutdown errors to Python as `ValueError` exceptions
- Add `thiserror` dependency for error derive macros

## Problem

Previously, async runtime shutdown silently ignored errors:
```rust
let _ = self.tx.send(RuntimeMessage::Shutdown);  // Silent failure
let _ = handle.join();  // Silent failure, no timeout
```

This could lead to:
- Resource leaks if shutdown signal wasn't received
- Silent hangs if thread was stuck
- No visibility into shutdown failures

## Solution

Proper error handling with timeout and logging:
- Channel send failures are logged (but we continue to attempt join)
- Thread join has 5-second timeout
- All errors logged via tracing
- Python callers get exceptions on failure

## Test plan

- [x] All 181 unit tests pass (`angreal cloacina unit`)
- [x] `cargo check` passes
- [x] Pre-commit hooks pass