### PR TITLE
feat: runtime registry unification via inventory (I-0096)

### DIFF
--- a/.metis/.index-dirty
+++ b/.metis/.index-dirty
@@ -1,8 +1,0 @@
-/Users/dstorey/Desktop/cloacina/crates/cloacina/src/database/schema.rs
-/Users/dstorey/Desktop/cloacina/crates/cloacina/src/dal/unified/models.rs
-/Users/dstorey/Desktop/cloacina/crates/cloacina/src/models/workflow_packages.rs
-/Users/dstorey/Desktop/cloacina/crates/cloacina/src/dal/unified/workflow_packages.rs
-/Users/dstorey/Desktop/cloacina/crates/cloacina/src/registry/workflow_registry/database.rs
-/Users/dstorey/Desktop/cloacina/crates/cloacina/src/registry/workflow_registry/mod.rs
-/Users/dstorey/Desktop/cloacina/crates/cloacina/tests/integration/dal/workflow_packages.rs
-/Users/dstorey/Desktop/cloacina/crates/cloacina/tests/integration/dal/workflow_registry.rs

--- a/.metis/.index-dirty
+++ b/.metis/.index-dirty
@@ -1,0 +1,5 @@
+/Users/dstorey/Desktop/cloacina/crates/cloacina-macros/src/workflow_attr.rs
+/Users/dstorey/Desktop/cloacina/crates/cloacina/src/runtime.rs
+/Users/dstorey/Desktop/cloacina/crates/cloacina/src/execution_planner/mod.rs
+/Users/dstorey/Desktop/cloacina/crates/cloacina/src/runner/default_runner/config.rs
+/Users/dstorey/Desktop/cloacina/crates/cloacina/src/runner/default_runner/mod.rs

--- a/.metis/.index-dirty
+++ b/.metis/.index-dirty
@@ -3,3 +3,6 @@
 /Users/dstorey/Desktop/cloacina/crates/cloacina/src/execution_planner/mod.rs
 /Users/dstorey/Desktop/cloacina/crates/cloacina/src/runner/default_runner/config.rs
 /Users/dstorey/Desktop/cloacina/crates/cloacina/src/runner/default_runner/mod.rs
+/Users/dstorey/Desktop/cloacina/crates/cloacina/src/registry/reconciler/mod.rs
+/Users/dstorey/Desktop/cloacina/crates/cloacina/src/registry/reconciler/loading.rs
+/Users/dstorey/Desktop/cloacina/crates/cloacina/src/runner/default_runner/services.rs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ categories = []
 [workspace.dependencies]
 async-trait = { version = "0.1" }
 ctor = { version = "0.2" }
+inventory = { version = "0.3" }
 once_cell = { version = "1.19.0" }
 serde_json = { version = "1.0" }
 cloacina-macros = { version = "0.5.1", path = "crates/cloacina-macros" }

--- a/crates/cloacina-macros/src/computation_graph/codegen.rs
+++ b/crates/cloacina-macros/src/computation_graph/codegen.rs
@@ -292,6 +292,23 @@ pub fn generate(ir: &GraphIR, module: &ItemMod) -> syn::Result<TokenStream> {
                     },
                 );
             }
+
+            #[cfg(not(test))]
+            #[cfg(not(feature = "packaged"))]
+            crate::inventory::submit! {
+                crate::ComputationGraphEntry {
+                    name: #mod_name_str,
+                    constructor: || crate::ComputationGraphRegistration {
+                        graph_fn: std::sync::Arc::new(|cache: crate::computation_graph::InputCache| {
+                            Box::pin(async move {
+                                #compiled_fn_name(&cache).await
+                            })
+                        }),
+                        accumulator_names: vec![#(#accumulator_names.to_string()),*],
+                        reaction_mode: #reaction_mode_str.to_string(),
+                    },
+                }
+            }
         };
         (fn_body, ctor)
     } else {
@@ -325,6 +342,23 @@ pub fn generate(ir: &GraphIR, module: &ItemMod) -> syn::Result<TokenStream> {
                         }
                     },
                 );
+            }
+
+            #[cfg(not(test))]
+            #[cfg(not(feature = "packaged"))]
+            cloacina::inventory::submit! {
+                cloacina::ComputationGraphEntry {
+                    name: #mod_name_str,
+                    constructor: || cloacina_computation_graph::ComputationGraphRegistration {
+                        graph_fn: std::sync::Arc::new(|cache: cloacina_computation_graph::InputCache| {
+                            Box::pin(async move {
+                                #compiled_fn_name(&cache).await
+                            })
+                        }),
+                        accumulator_names: vec![#(#accumulator_names.to_string()),*],
+                        reaction_mode: #reaction_mode_str.to_string(),
+                    },
+                }
             }
         };
         (fn_body, ctor)

--- a/crates/cloacina-macros/src/trigger_attr.rs
+++ b/crates/cloacina-macros/src/trigger_attr.rs
@@ -260,6 +260,13 @@ fn generate_custom_trigger(attrs: TriggerAttributes, input_fn: ItemFn) -> TokenS
                 || std::sync::Arc::new(#struct_name),
             );
         }
+
+        cloacina::inventory::submit! {
+            cloacina::TriggerEntry {
+                name: #trigger_name,
+                constructor: || std::sync::Arc::new(#struct_name) as std::sync::Arc<dyn cloacina::trigger::Trigger>,
+            }
+        }
     };
 
     // Packaged mode: just record metadata (trigger goes into manifest)
@@ -379,6 +386,13 @@ fn generate_cron_trigger(attrs: TriggerAttributes, input_fn: ItemFn) -> TokenStr
                 #trigger_name,
                 || std::sync::Arc::new(#struct_name::new()),
             );
+        }
+
+        cloacina::inventory::submit! {
+            cloacina::TriggerEntry {
+                name: #trigger_name,
+                constructor: || std::sync::Arc::new(#struct_name::new()) as std::sync::Arc<dyn cloacina::trigger::Trigger>,
+            }
         }
     };
 

--- a/crates/cloacina-macros/src/workflow_attr.rs
+++ b/crates/cloacina-macros/src/workflow_attr.rs
@@ -538,13 +538,30 @@ fn generate_embedded_registration(
     };
 
     // Inventory entries for the workflow itself and each contained task.
-    // These land at module scope and are read by `Runtime::new()` post-main
-    // (T-0506). Emitted alongside the existing `#[ctor]` registration so
-    // nothing observable changes until inventory-based seeding takes over.
+    // The TaskEntry constructor mirrors the full construction performed by the
+    // legacy `register_task_constructor` closure — trigger-rule rewriting,
+    // dep-namespace resolution, and the TaskWithNamespacedTriggers wrapper —
+    // so `Runtime::new()` can seed tasks directly from inventory without
+    // relying on the old global-registry side-effect path (T-0506).
+    let rewrite_trigger_rules_for_inventory = generate_trigger_rules_rewrite(tenant, workflow_name);
     let task_inventory_entries: Vec<TokenStream2> = detected_tasks
         .iter()
         .map(|(task_id, fn_name)| {
             let constructor_name = syn::Ident::new(&format!("{}_task", fn_name), fn_name.span());
+            let task_str = fn_name.to_string();
+            let parts: Vec<&str> = task_str.split('_').collect();
+            let pascal_case = parts
+                .iter()
+                .map(|part| {
+                    let mut chars = part.chars();
+                    match chars.next() {
+                        None => String::new(),
+                        Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+                    }
+                })
+                .collect::<String>();
+            let struct_name = syn::Ident::new(&format!("{}Task", pascal_case), fn_name.span());
+            let rewrite_body = rewrite_trigger_rules_for_inventory.clone();
             quote! {
                 cloacina::inventory::submit! {
                     cloacina::TaskEntry {
@@ -556,7 +573,61 @@ fn generate_embedded_registration(
                         ),
                         constructor: || {
                             let task = #mod_path_prefix::#constructor_name();
-                            std::sync::Arc::new(task)
+                            let rewritten_trigger_rules = {
+                                let task_ref = &task;
+                                #rewrite_body
+                            };
+
+                            let dep_ids = #mod_path_prefix::#struct_name::dependency_task_ids();
+                            let pkg_name = env!("CARGO_PKG_NAME");
+                            let dep_namespaces: Vec<cloacina::TaskNamespace> = dep_ids
+                                .iter()
+                                .map(|dep_id| cloacina::TaskNamespace::new(
+                                    #tenant,
+                                    pkg_name,
+                                    #workflow_name,
+                                    dep_id,
+                                ))
+                                .collect();
+
+                            let task_with_deps = task.with_dependencies(dep_namespaces);
+
+                            struct TaskWithNamespacedTriggers<T> {
+                                inner: T,
+                                rewritten_trigger_rules: serde_json::Value,
+                            }
+
+                            #[async_trait::async_trait]
+                            impl<T: cloacina::Task> cloacina::Task for TaskWithNamespacedTriggers<T> {
+                                async fn execute(
+                                    &self,
+                                    context: cloacina::Context<serde_json::Value>,
+                                ) -> Result<cloacina::Context<serde_json::Value>, cloacina::TaskError>
+                                {
+                                    self.inner.execute(context).await
+                                }
+                                fn id(&self) -> &str { self.inner.id() }
+                                fn dependencies(&self) -> &[cloacina::TaskNamespace] {
+                                    self.inner.dependencies()
+                                }
+                                fn retry_policy(&self) -> cloacina::retry::RetryPolicy {
+                                    self.inner.retry_policy()
+                                }
+                                fn trigger_rules(&self) -> serde_json::Value {
+                                    self.rewritten_trigger_rules.clone()
+                                }
+                                fn code_fingerprint(&self) -> Option<String> {
+                                    self.inner.code_fingerprint()
+                                }
+                                fn requires_handle(&self) -> bool {
+                                    self.inner.requires_handle()
+                                }
+                            }
+
+                            std::sync::Arc::new(TaskWithNamespacedTriggers {
+                                inner: task_with_deps,
+                                rewritten_trigger_rules,
+                            })
                                 as std::sync::Arc<dyn cloacina::Task>
                         },
                     }

--- a/crates/cloacina-macros/src/workflow_attr.rs
+++ b/crates/cloacina-macros/src/workflow_attr.rs
@@ -537,6 +537,34 @@ fn generate_embedded_registration(
         quote! {}
     };
 
+    // Inventory entries for the workflow itself and each contained task.
+    // These land at module scope and are read by `Runtime::new()` post-main
+    // (T-0506). Emitted alongside the existing `#[ctor]` registration so
+    // nothing observable changes until inventory-based seeding takes over.
+    let task_inventory_entries: Vec<TokenStream2> = detected_tasks
+        .iter()
+        .map(|(task_id, fn_name)| {
+            let constructor_name = syn::Ident::new(&format!("{}_task", fn_name), fn_name.span());
+            quote! {
+                cloacina::inventory::submit! {
+                    cloacina::TaskEntry {
+                        namespace: || cloacina::TaskNamespace::new(
+                            #tenant,
+                            env!("CARGO_PKG_NAME"),
+                            #workflow_name,
+                            #task_id,
+                        ),
+                        constructor: || {
+                            let task = #mod_path_prefix::#constructor_name();
+                            std::sync::Arc::new(task)
+                                as std::sync::Arc<dyn cloacina::Task>
+                        },
+                    }
+                }
+            }
+        })
+        .collect();
+
     quote! {
         fn #workflow_constructor_name() -> cloacina::Workflow {
             let pkg_name = env!("CARGO_PKG_NAME");
@@ -564,6 +592,15 @@ fn generate_embedded_registration(
                 #workflow_constructor_name
             );
         }
+
+        cloacina::inventory::submit! {
+            cloacina::WorkflowEntry {
+                name: #workflow_name,
+                constructor: #workflow_constructor_name,
+            }
+        }
+
+        #(#task_inventory_entries)*
     }
 }
 

--- a/crates/cloacina/Cargo.toml
+++ b/crates/cloacina/Cargo.toml
@@ -28,6 +28,7 @@ extension-module = ["pyo3/extension-module"]
 [dependencies]
 # Workspace dependencies
 async-trait.workspace = true
+inventory.workspace = true
 once_cell.workspace = true
 serde_json.workspace = true
 

--- a/crates/cloacina/src/execution_planner/mod.rs
+++ b/crates/cloacina/src/execution_planner/mod.rs
@@ -260,11 +260,7 @@ impl TaskScheduler {
 
         Self {
             dal,
-            runtime: {
-                let rt = Runtime::new();
-                rt.seed_from_globals();
-                Arc::new(rt)
-            },
+            runtime: Arc::new(Runtime::new()),
             instance_id: Uuid::new_v4(),
             poll_interval,
             dispatcher: None,

--- a/crates/cloacina/src/inventory_entries.rs
+++ b/crates/cloacina/src/inventory_entries.rs
@@ -1,0 +1,89 @@
+/*
+ *  Copyright 2026 Colliery Software
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+//! Inventory entry types for linker-collected registry seeding.
+//!
+//! The macros (`#[task]`, `#[workflow]`, `#[trigger]`, `#[computation_graph]`,
+//! and the stream-backend registration helper) emit
+//! `inventory::submit!` statements of these types instead of `#[ctor]`
+//! constructors. The runtime reads them post-`main()` via `inventory::iter`,
+//! eliminating the initialization-ordering bug that sank I-0095.
+//!
+//! Function pointers — not `Box<dyn Fn>` — are used because `inventory` stores
+//! entries in a linker section with `'static` + `Sized` bounds. Zero-capture
+//! closures at the macro call site coerce to `fn` pointers automatically, so
+//! the ergonomics stay identical.
+//!
+//! Nothing in this file reads inventory yet. That wiring lands in T-0506
+//! together with the removal of the global static registries.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use crate::computation_graph::stream_backend::{StreamBackend, StreamConfig, StreamError};
+use crate::task::{Task, TaskNamespace};
+use crate::trigger::Trigger;
+use crate::workflow::Workflow;
+use cloacina_computation_graph::ComputationGraphRegistration;
+
+/// Task entry emitted by `#[task]`.
+pub struct TaskEntry {
+    /// Deferred construction of the task namespace (cannot be const because
+    /// `TaskNamespace` contains `String`).
+    pub namespace: fn() -> TaskNamespace,
+    /// Task constructor — instantiates a fresh task object on each call.
+    pub constructor: fn() -> Arc<dyn Task>,
+}
+inventory::collect!(TaskEntry);
+
+/// Workflow entry emitted by `#[workflow]`.
+pub struct WorkflowEntry {
+    pub name: &'static str,
+    pub constructor: fn() -> Workflow,
+}
+inventory::collect!(WorkflowEntry);
+
+/// Trigger entry emitted by `#[trigger]`.
+pub struct TriggerEntry {
+    pub name: &'static str,
+    pub constructor: fn() -> Arc<dyn Trigger>,
+}
+inventory::collect!(TriggerEntry);
+
+/// Computation graph entry emitted by `#[computation_graph]`.
+pub struct ComputationGraphEntry {
+    pub name: &'static str,
+    pub constructor: fn() -> ComputationGraphRegistration,
+}
+inventory::collect!(ComputationGraphEntry);
+
+/// Stream-backend entry emitted by the stream-backend registration helper.
+///
+/// The factory is a function pointer that takes an owned `StreamConfig` and
+/// returns a heap-allocated future; at seed time the runtime wraps the
+/// pointer into a `Box<dyn Fn(StreamConfig) -> Pin<Box<Future<..>>> + Send + Sync>`
+/// to match the shape of dynamically-registered backends.
+pub type StreamBackendFactoryFn =
+    fn(
+        StreamConfig,
+    ) -> Pin<Box<dyn Future<Output = Result<Box<dyn StreamBackend>, StreamError>> + Send>>;
+
+pub struct StreamBackendEntry {
+    pub type_name: &'static str,
+    pub factory: StreamBackendFactoryFn,
+}
+inventory::collect!(StreamBackendEntry);

--- a/crates/cloacina/src/lib.rs
+++ b/crates/cloacina/src/lib.rs
@@ -504,6 +504,7 @@ pub mod error;
 pub mod execution_planner;
 pub mod executor;
 pub mod graph;
+pub mod inventory_entries;
 pub mod logging;
 pub mod models;
 pub mod packaging;
@@ -512,6 +513,10 @@ pub mod registry;
 pub mod retry;
 pub mod runner;
 pub mod runtime;
+
+// Re-export the `inventory` crate so macros can emit `cloacina::inventory::submit!`
+// without requiring users to add `inventory` as a direct dependency.
+pub use inventory;
 pub mod security;
 pub mod task;
 pub mod trigger;
@@ -559,6 +564,10 @@ pub use executor::{
 };
 pub use graph::{
     DependencyEdge, GraphEdge, GraphMetadata, GraphNode, TaskNode, WorkflowGraph, WorkflowGraphData,
+};
+pub use inventory_entries::{
+    ComputationGraphEntry, StreamBackendEntry, StreamBackendFactoryFn, TaskEntry, TriggerEntry,
+    WorkflowEntry,
 };
 pub use retry::{BackoffStrategy, RetryCondition, RetryPolicy, RetryPolicyBuilder};
 pub use runner::DefaultRunnerBuilder;

--- a/crates/cloacina/src/registry/reconciler/loading.rs
+++ b/crates/cloacina/src/registry/reconciler/loading.rs
@@ -439,6 +439,15 @@ impl RegistryReconciler {
 
         let mut loaded_packages = self.loaded_packages.write().await;
         loaded_packages.insert(metadata.id, package_state);
+        drop(loaded_packages);
+
+        // If a Runtime is attached, re-seed it from the globals so the newly
+        // registered tasks/workflows/triggers/CGs are visible to executors.
+        // This is the transitional path: the package's #[ctor]s have already
+        // populated the globals; we copy them into the Runtime here.
+        if let Some(runtime) = &self.runtime {
+            runtime.seed_from_globals();
+        }
 
         Ok(())
     }
@@ -473,6 +482,23 @@ impl RegistryReconciler {
         // Unregister triggers from global trigger registry
         if !package_state.trigger_names.is_empty() {
             self.unregister_package_triggers(&package_state.trigger_names);
+        }
+
+        // Mirror removals through the runtime so executors drop the stale
+        // entries immediately.
+        if let Some(runtime) = &self.runtime {
+            for ns in &package_state.task_namespaces {
+                runtime.unregister_task(ns);
+            }
+            if let Some(workflow_name) = &package_state.workflow_name {
+                runtime.unregister_workflow(workflow_name);
+            }
+            for trigger_name in &package_state.trigger_names {
+                runtime.unregister_trigger(trigger_name);
+            }
+            if let Some(graph_name) = &package_state.graph_name {
+                runtime.unregister_computation_graph(graph_name);
+            }
         }
 
         // Unload computation graph from reactive scheduler

--- a/crates/cloacina/src/registry/reconciler/mod.rs
+++ b/crates/cloacina/src/registry/reconciler/mod.rs
@@ -164,6 +164,12 @@ pub struct RegistryReconciler {
     /// Configuration for reconciliation behavior
     pub(super) config: ReconcilerConfig,
 
+    /// Optional runtime handle. When set, the reconciler pushes
+    /// newly-loaded/unloaded registrations through the runtime so executors
+    /// looking up tasks/workflows/triggers/CGs/stream backends stay in sync
+    /// with dynamic package loads.
+    pub(super) runtime: Option<Arc<crate::Runtime>>,
+
     /// Tracking of currently loaded packages
     pub(super) loaded_packages: Arc<tokio::sync::RwLock<HashMap<WorkflowPackageId, PackageState>>>,
 
@@ -202,6 +208,7 @@ impl RegistryReconciler {
         Ok(Self {
             registry,
             config,
+            runtime: None,
             loaded_packages: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
             package_loader,
             task_registrar,
@@ -209,6 +216,14 @@ impl RegistryReconciler {
             interval,
             reactive_scheduler: Arc::new(tokio::sync::RwLock::new(None)),
         })
+    }
+
+    /// Attach a Runtime to this reconciler. Package load/unload operations
+    /// will push registrations through the runtime so executors see the
+    /// same view as the reconciler.
+    pub fn with_runtime(mut self, runtime: Arc<crate::Runtime>) -> Self {
+        self.runtime = Some(runtime);
+        self
     }
 
     /// Set the reactive scheduler for computation graph package routing.

--- a/crates/cloacina/src/runner/default_runner/config.rs
+++ b/crates/cloacina/src/runner/default_runner/config.rs
@@ -655,12 +655,8 @@ impl DefaultRunnerBuilder {
                 .map_err(|e| WorkflowExecutionError::DatabaseConnection { message: e })?;
         }
 
-        // Resolve runtime: use provided or seed a fresh one from the globals.
-        let runtime = Arc::new(self.runtime.unwrap_or_else(|| {
-            let rt = Runtime::new();
-            rt.seed_from_globals();
-            rt
-        }));
+        // Resolve runtime: use provided or a fresh inventory-seeded one.
+        let runtime = Arc::new(self.runtime.unwrap_or_else(Runtime::new));
 
         // Create scheduler with the scoped runtime
         let scheduler = TaskScheduler::with_poll_interval(

--- a/crates/cloacina/src/runner/default_runner/mod.rs
+++ b/crates/cloacina/src/runner/default_runner/mod.rs
@@ -197,12 +197,8 @@ impl DefaultRunner {
             .await
             .map_err(|e| WorkflowExecutionError::DatabaseConnection { message: e })?;
 
-        // Seed a scoped runtime from the process-global registries.
-        let runtime = Arc::new({
-            let rt = Runtime::new();
-            rt.seed_from_globals();
-            rt
-        });
+        // Fresh inventory-seeded runtime.
+        let runtime = Arc::new(Runtime::new());
 
         // Create scheduler with the scoped runtime
         let scheduler =

--- a/crates/cloacina/src/runner/default_runner/services.rs
+++ b/crates/cloacina/src/runner/default_runner/services.rs
@@ -321,6 +321,10 @@ impl DefaultRunner {
                 // the reconciler will see it because they share the same Arc.
                 registry_reconciler.set_reactive_scheduler_slot(self.reactive_scheduler.clone());
 
+                // Give the reconciler a handle to the runtime so package loads
+                // and unloads are mirrored into it.
+                registry_reconciler = registry_reconciler.with_runtime(self.runtime.clone());
+
                 // Start reconciler background service
                 let mut broadcast_shutdown_rx = shutdown_tx.subscribe();
                 let reconciler_span = self.create_runner_span("registry_reconciler");

--- a/crates/cloacina/src/runtime.rs
+++ b/crates/cloacina/src/runtime.rs
@@ -77,13 +77,32 @@ struct RuntimeInner {
 }
 
 impl Runtime {
-    /// Create an empty runtime. Every namespace starts with no entries.
+    /// Create a runtime seeded with every macro-registered entry from the
+    /// `inventory` crate (tasks, workflows, triggers, computation graphs,
+    /// stream backends).
     ///
-    /// In embedded mode, follow this with [`seed_from_globals`] to pick up
-    /// anything that was registered via the `#[ctor]` constructors emitted by
-    /// the macros. Once inventory-based seeding lands (T-0506) that helper
-    /// will go away.
+    /// `inventory` collects entries in a linker section and is read lazily
+    /// after `main()`, so every entry registered by the `#[task]`,
+    /// `#[workflow]`, `#[trigger]`, `#[computation_graph]`, and stream-backend
+    /// macros in the current binary is visible here. For a blank-slate runtime
+    /// (used by isolation-sensitive tests), use [`Runtime::empty`] instead.
     pub fn new() -> Self {
+        let rt = Self::empty();
+        rt.seed_from_inventory();
+        // Transitional: also seed from the process-global registries so
+        // anything registered dynamically via `register_*_constructor` (e.g.
+        // Python bindings, test fixtures) is still visible. Removed in T-0508
+        // when the globals themselves go away.
+        rt.seed_from_globals();
+        rt
+    }
+
+    /// Create an empty runtime with no registered entries in any namespace.
+    ///
+    /// Use this when you want complete isolation — no macro-registered tasks,
+    /// workflows, triggers, CGs, or stream backends are installed. Intended
+    /// for unit tests; production code should generally use [`Runtime::new`].
+    pub fn empty() -> Self {
         Self {
             inner: Arc::new(RuntimeInner {
                 tasks: RwLock::new(HashMap::new()),
@@ -92,6 +111,43 @@ impl Runtime {
                 computation_graphs: RwLock::new(HashMap::new()),
                 stream_backends: RwLock::new(HashMap::new()),
             }),
+        }
+    }
+
+    /// Populate the runtime from the `inventory` entries emitted by the
+    /// macros.
+    fn seed_from_inventory(&self) {
+        use crate::inventory_entries::{
+            ComputationGraphEntry, StreamBackendEntry, TaskEntry, TriggerEntry, WorkflowEntry,
+        };
+
+        for entry in inventory::iter::<TaskEntry> {
+            let ns = (entry.namespace)();
+            let ctor = entry.constructor;
+            self.register_task(ns, move || ctor());
+        }
+
+        for entry in inventory::iter::<WorkflowEntry> {
+            let ctor = entry.constructor;
+            self.register_workflow(entry.name.to_string(), move || ctor());
+        }
+
+        for entry in inventory::iter::<TriggerEntry> {
+            let ctor = entry.constructor;
+            self.register_trigger(entry.name.to_string(), move || ctor());
+        }
+
+        for entry in inventory::iter::<ComputationGraphEntry> {
+            let ctor = entry.constructor;
+            self.register_computation_graph(entry.name.to_string(), move || ctor());
+        }
+
+        for entry in inventory::iter::<StreamBackendEntry> {
+            let factory = entry.factory;
+            self.register_stream_backend(
+                entry.type_name.to_string(),
+                Box::new(move |config| factory(config)),
+            );
         }
     }
 
@@ -476,7 +532,7 @@ mod tests {
 
     #[test]
     fn register_and_unregister_workflow() {
-        let rt = Runtime::new();
+        let rt = Runtime::empty();
         assert!(!rt.unregister_workflow("nope"));
 
         let wf = crate::workflow::Workflow::new("unit-test-wf");
@@ -494,7 +550,7 @@ mod tests {
         // Triggers need a Trigger trait impl; skip full integration here and
         // cover the lifecycle via the workflow test. The shape of the API is
         // identical across namespaces.
-        let rt = Runtime::new();
+        let rt = Runtime::empty();
         assert!(!rt.unregister_trigger("missing"));
         assert!(rt.get_trigger("missing").is_none());
         assert!(rt.trigger_names().is_empty());
@@ -502,7 +558,7 @@ mod tests {
 
     #[test]
     fn register_and_unregister_task() {
-        let rt = Runtime::new();
+        let rt = Runtime::empty();
         let ns = TaskNamespace::new("t", "p", "w", "task_a");
         assert!(!rt.unregister_task(&ns));
         assert!(!rt.has_task(&ns));
@@ -510,7 +566,7 @@ mod tests {
 
     #[test]
     fn stream_backend_roundtrip_names_only() {
-        let rt = Runtime::new();
+        let rt = Runtime::empty();
         assert!(!rt.has_stream_backend("mock"));
         assert!(rt.stream_backend_names().is_empty());
         assert!(!rt.unregister_stream_backend("mock"));
@@ -518,8 +574,8 @@ mod tests {
 
     #[test]
     fn runtimes_are_independent() {
-        let rt1 = Runtime::new();
-        let rt2 = Runtime::new();
+        let rt1 = Runtime::empty();
+        let rt2 = Runtime::empty();
         let wf = crate::workflow::Workflow::new("iso");
         rt1.register_workflow("iso".to_string(), move || wf.clone());
 
@@ -529,7 +585,7 @@ mod tests {
 
     #[test]
     fn debug_format_reports_sizes() {
-        let rt = Runtime::new();
+        let rt = Runtime::empty();
         let debug = format!("{:?}", rt);
         assert!(debug.contains("computation_graphs: 0"));
         assert!(debug.contains("stream_backends: 0"));

--- a/crates/cloacina/tests/integration/workflow/macro_test.rs
+++ b/crates/cloacina/tests/integration/workflow/macro_test.rs
@@ -96,6 +96,51 @@ pub mod parallel_execution {
 }
 
 #[test]
+fn test_workflow_macro_emits_inventory_entries() {
+    // Smoke test for T-0505: confirm that `#[workflow]` and `#[task]` emit
+    // `inventory::submit!` entries in addition to the legacy `#[ctor]`
+    // registration. The runtime will read these once T-0506 lands.
+    let workflow_names: Vec<&'static str> = inventory::iter::<cloacina::WorkflowEntry>
+        .into_iter()
+        .map(|entry| entry.name)
+        .collect();
+    assert!(
+        workflow_names.contains(&"document_processing"),
+        "WorkflowEntry for document_processing should be present in inventory; saw {:?}",
+        workflow_names
+    );
+    assert!(
+        workflow_names.contains(&"parallel_execution"),
+        "WorkflowEntry for parallel_execution should be present in inventory; saw {:?}",
+        workflow_names
+    );
+
+    // Each task in the two workflows should appear in inventory too.
+    let task_namespaces: Vec<String> = inventory::iter::<cloacina::TaskEntry>
+        .into_iter()
+        .map(|entry| (entry.namespace)().to_string())
+        .collect();
+
+    let expected_ids = [
+        "fetch_document",
+        "extract_text",
+        "generate_embeddings",
+        "store_embeddings",
+        "task_a",
+        "task_b",
+        "task_c",
+    ];
+    for id in expected_ids {
+        assert!(
+            task_namespaces.iter().any(|ns| ns.ends_with(id)),
+            "TaskEntry for {} should be present in inventory; saw {:?}",
+            id,
+            task_namespaces
+        );
+    }
+}
+
+#[test]
 fn test_workflow_execution_levels() {
     let _ = tracing_subscriber::fmt::try_init();
 


### PR DESCRIPTION
## Summary

**CLOACI-I-0096** — Runtime Registry Unification. Replaces the `#[ctor]`-based global registries with `inventory`-based lazy collection so `Runtime::new()` produces a complete, reliable snapshot of every macro-registered item (tasks, workflows, triggers, computation graphs, stream backends). Fixes the macOS `#[ctor]` ordering bug that sank I-0095.

Bundles three of the five planned tasks; the full cleanup (T-0508) is split off as a follow-up because it pulls in broader test rewrites. T-0504 already landed separately as #69.

## Tasks in this PR

### T-0505 — macros emit `inventory::submit!` alongside `#[ctor]`
- Workspace + cloacina depend on `inventory = 0.3`. Re-exported as `cloacina::inventory`.
- Five entry types: `TaskEntry`, `WorkflowEntry`, `TriggerEntry`, `ComputationGraphEntry`, `StreamBackendEntry`, each with `inventory::collect!`.
- `#[workflow]` emits `WorkflowEntry` + one `TaskEntry` per task. `#[trigger]` emits `TriggerEntry` for both cron and poll. `#[computation_graph]` emits `ComputationGraphEntry` in both internal and external codegen paths.
- Smoke test confirms `inventory::iter` returns the expected workflows and tasks.

### T-0506 — `Runtime::new()` seeds from inventory; add `Runtime::empty()`
- `Runtime::new()` = `Runtime::empty()` + `seed_from_inventory()` + `seed_from_globals()`. Inventory gives full-fidelity tasks (trigger-rule rewrite, dep-namespace resolution, `TaskWithNamespacedTriggers` wrapper — all mirrored in the macro codegen). Globals seeding stays as a transitional bridge for code that dynamically calls `register_*_constructor` (Python bindings, test fixtures).
- `Runtime::empty()` is the new \`truly blank\` constructor for isolation-sensitive tests.
- `DefaultRunner` and the execution planner drop their manual `seed_from_globals()` calls — `Runtime::new()` does it now.

### T-0507 — reconciler wired into Runtime for package load/unload
- `RegistryReconciler` takes an optional `Arc<Runtime>` via `.with_runtime(...)`. `DefaultRunner` hands its runtime to the reconciler at startup.
- After `load_package`, the reconciler calls `seed_from_globals()` so newly-registered items are visible through the runtime.
- On `unload_package`, the reconciler calls `runtime.unregister_task` / `unregister_workflow` / `unregister_trigger` / `unregister_computation_graph` for each package-declared item.

## Deferred — T-0508 cleanup

Full removal of `#[ctor]` emission, the `ctor` dep, and the global static registries was attempted but reverted: a nontrivial number of existing integration tests read the globals directly (`global_workflow_registry().read().contains_key(...)`, `is_trigger_registered(...)`, etc.). Rewriting them to read via Runtime is straightforward but broader in scope than this initiative should hold. The ordering-bug fix is already delivered by T-0505/6/7 — the remaining cleanup is pure polish and can land separately. I'll file a follow-up task.

## Test plan

- [x] `angreal cloacina unit` — 831 passing
- [x] `angreal cloacina integration` — 295 passing, 0 failed
- [ ] CI

## Merge

Squash merge.