### PR TITLE
T-0443: credential-logging CI guard

### DIFF
--- a/.angreal/task_check.py
+++ b/.angreal/task_check.py
@@ -277,6 +277,26 @@ def crate(path: str, no_warnings=False):
 
 @check()
 @angreal.command(
+    name="credential-logging",
+    about="scan Rust sources for unmasked credential references in log/print macros (OPS-03 / T-0443)",
+    when_to_use=["pre-commit", "CI validation", "after touching code that handles database URLs or tenant credentials"],
+    when_not_to_use=["normal development iteration where no credential-touching code changed"]
+)
+def credential_logging():
+    """Run the credential-logging guard script (scripts/check_credential_logging.py)."""
+    script = PROJECT_ROOT / "scripts" / "check_credential_logging.py"
+    if not script.exists():
+        print(f"❌ Guard script not found: {script}")
+        return 1
+    result = subprocess.run(
+        ["python3", str(script)],
+        cwd=PROJECT_ROOT,
+    )
+    return result.returncode
+
+
+@check()
+@angreal.command(
     name="all-crates",
     about="run cargo check and build on all crates (workspace and standalone)",
     when_to_use=["before commits", "CI validation", "comprehensive code quality checks", "finding compilation issues across codebase"],

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-check-
 
+      - name: Credential-logging guard (OPS-03 / T-0443)
+        run: python3 scripts/check_credential_logging.py
+
       - name: Check formatting
         run: cargo fmt --all -- --check
 

--- a/.metis/backlog/tech-debt/CLOACI-T-0443.md
+++ b/.metis/backlog/tech-debt/CLOACI-T-0443.md
@@ -4,15 +4,15 @@ level: task
 title: "Defensive practice — lint/CI guard against credential logging in log and print statements"
 short_code: "CLOACI-T-0443"
 created_at: 2026-04-08T13:43:25.906031+00:00
-updated_at: 2026-04-08T13:43:25.906031+00:00
+updated_at: 2026-04-20T11:21:27.802952+00:00
 parent:
 blocked_by: []
 archived: false
 
 tags:
   - "#task"
-  - "#phase/backlog"
   - "#tech-debt"
+  - "#phase/active"
 
 
 exit_criteria_met: false
@@ -42,6 +42,10 @@ Establish a defensive practice that prevents credential leakage from recurring i
 
 ## Acceptance Criteria
 
+## Acceptance Criteria
+
+## Acceptance Criteria
+
 - [ ] A `SensitiveString` or `MaskedUrl` newtype wraps database URLs, with `Display`/`Debug` impls that mask credentials automatically
 - [ ] All `info!()`/`debug!()` log calls that format a database URL go through the newtype — no raw URL strings in log output
 - [ ] OR: a clippy lint / CI grep check that flags `database_url` appearing in `info!()`, `debug!()`, `eprintln!()`, or `println!()` macro invocations
@@ -66,4 +70,12 @@ Write a clippy lint that flags tracing macro invocations containing variables na
 
 ## Status Updates
 
-*To be added during implementation*
+- **2026-04-20**: Implemented Option B (CI grep guard).
+  - Added `scripts/check_credential_logging.py`: scans git-tracked `*.rs` files, parses `info!/debug!/trace!/warn!/error!/eprintln!/println!/eprint!/print!` invocations (multi-line aware with string and char-literal skipping), and flags any invocation whose body references `database_url`, `db_url`, `connection_string`, or `password` **after** stripping (a) string literals, (b) any `mask_*(...)` helper call (e.g. `mask_db_url`, `mask_password`), and (c) lines preceded by `// allow(credential-logging): <reason>`.
+  - Wired into CI: new step in `.github/workflows/ci.yml` `quick-checks` job runs `python3 scripts/check_credential_logging.py` alongside fmt/clippy.
+  - Wired into angreal: new `check credential-logging` command in `.angreal/task_check.py` for local/pre-commit runs.
+  - Fixed existing violations the guard surfaced:
+    - `crates/cloacina/tests/fixtures.rs`: Postgres and SQLite `new_*` logged raw `db_url`; routed through `mask_db_url()`.
+    - `examples/features/workflows/per-tenant-credentials/src/main.rs:76` logged admin-provided password cleartext; wrapped in `mask_password()` like its siblings.
+  - Verified detection with 8 synthetic cases (raw/masked/qualified/literal-only/allow-comment variants) — all pass.
+  - Final state: guard is clean across 392 Rust files; `cargo check` remains clean for `crates/cloacina` (sqlite+tests) and the per-tenant-credentials example.

--- a/crates/cloacina/tests/fixtures.rs
+++ b/crates/cloacina/tests/fixtures.rs
@@ -30,6 +30,7 @@
 
 use cloacina::database::connection::Database;
 use cloacina::database::BackendType;
+use cloacina::logging::mask_db_url;
 use diesel::deserialize::QueryableByName;
 use diesel::prelude::*;
 use diesel::sql_types::Text;
@@ -237,7 +238,8 @@ impl TestFixture {
 
         info!(
             "Test fixture created (PostgreSQL) with URL: {}, schema: {}",
-            db_url, schema
+            mask_db_url(&db_url),
+            schema
         );
 
         TestFixture {
@@ -257,7 +259,10 @@ impl TestFixture {
             cloacina::init_logging(None);
         });
 
-        info!("Test fixture created (SQLite) with URL: {}", db_url);
+        info!(
+            "Test fixture created (SQLite) with URL: {}",
+            mask_db_url(&db_url)
+        );
 
         TestFixture {
             initialized: false,

--- a/examples/features/workflows/per-tenant-credentials/src/main.rs
+++ b/examples/features/workflows/per-tenant-credentials/src/main.rs
@@ -73,7 +73,10 @@ async fn demonstrate_admin_tenant_creation(
         Ok(tenant_a_creds) => {
             info!("✓ Tenant A created successfully!");
             info!("  Username: {}", tenant_a_creds.username);
-            info!("  Password: {} (admin-provided)", tenant_a_creds.password);
+            info!(
+                "  Password: {} (admin-provided)",
+                mask_password(&tenant_a_creds.password)
+            );
             info!("  Schema: {}", tenant_a_creds.schema_name);
             info!(
                 "  Connection: {}",

--- a/scripts/check_credential_logging.py
+++ b/scripts/check_credential_logging.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""
+Credential-logging guard (CI check, T-0443 / OPS-03).
+
+Scans Rust sources for log and print macro invocations that reference
+sensitive identifiers (database URLs, passwords, connection strings)
+without routing them through `mask_db_url()`.
+
+This is a defensive practice: raw `info!("url: {}", database_url)` style
+calls leak credentials in logs. Any such call must either mask the value
+(`mask_db_url(&url)`) or bypass this guard with an explicit
+`// allow(credential-logging): <reason>` comment on the preceding line.
+
+Exit 0 on clean, 1 if any violations are found.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+MACROS = (
+    "info", "debug", "trace", "warn", "error",
+    "eprintln", "println", "eprint", "print",
+)
+
+# Sensitive identifier names (whole-word). Keep the list tight — false
+# positives are noisy and push developers toward disabling the check.
+SENSITIVE = (
+    "database_url",
+    "db_url",
+    "connection_string",
+    "password",
+)
+
+MACRO_RE = re.compile(
+    r"\b(" + "|".join(MACROS) + r")!\s*\(",
+)
+SENSITIVE_RE = re.compile(r"\b(" + "|".join(SENSITIVE) + r")\b")
+ALLOW_RE = re.compile(r"//\s*allow\(credential-logging\)")
+
+# Files that define or test the guard itself, or that intentionally
+# reference these identifiers in non-logging contexts the regex cannot
+# distinguish. Matches against a path relative to the repo root.
+EXCLUDE_PATHS = (
+    "scripts/check_credential_logging.py",
+    "tests/check_credential_logging_test.py",
+)
+
+
+def repo_root() -> Path:
+    out = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return Path(out.stdout.strip())
+
+
+def list_rust_files(root: Path) -> list[Path]:
+    out = subprocess.run(
+        ["git", "ls-files", "*.rs"],
+        cwd=root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    files = []
+    for line in out.stdout.splitlines():
+        if not line:
+            continue
+        if line in EXCLUDE_PATHS:
+            continue
+        files.append(root / line)
+    return files
+
+
+def find_macro_invocation_end(text: str, open_paren_idx: int) -> int:
+    """Return index just past the closing `)` of a macro invocation
+    whose opening `(` is at `open_paren_idx`. Handles nested parens,
+    string literals (including raw strings), and char literals.
+    """
+    i = open_paren_idx
+    depth = 0
+    n = len(text)
+    while i < n:
+        c = text[i]
+        if c == '"':
+            # Skip string literal, honoring escapes.
+            i += 1
+            while i < n:
+                if text[i] == "\\":
+                    i += 2
+                    continue
+                if text[i] == '"':
+                    i += 1
+                    break
+                i += 1
+            continue
+        if c == "'":
+            # Char literal or lifetime — skip a single char/escape if it
+            # looks like a char literal, otherwise just advance.
+            if i + 1 < n and text[i + 1] == "\\":
+                # escape seq; find closing '
+                j = i + 2
+                while j < n and text[j] != "'":
+                    j += 1
+                i = j + 1
+                continue
+            if i + 2 < n and text[i + 2] == "'":
+                i += 3
+                continue
+            i += 1
+            continue
+        if c == "(":
+            depth += 1
+        elif c == ")":
+            depth -= 1
+            if depth == 0:
+                return i + 1
+        i += 1
+    return n
+
+
+def line_of(text: str, idx: int) -> int:
+    return text.count("\n", 0, idx) + 1
+
+
+def preceding_line(text: str, idx: int) -> str:
+    # The line containing `idx` is the macro-call line. The "preceding"
+    # line is the one before it.
+    line_start = text.rfind("\n", 0, idx) + 1
+    prev_end = line_start - 1
+    if prev_end <= 0:
+        return ""
+    prev_start = text.rfind("\n", 0, prev_end) + 1
+    return text[prev_start:prev_end]
+
+
+def scan_file(path: Path, root: Path) -> list[tuple[Path, int, str, str]]:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (UnicodeDecodeError, OSError):
+        return []
+
+    violations: list[tuple[Path, int, str, str]] = []
+    for m in MACRO_RE.finditer(text):
+        open_paren = m.end() - 1
+        end = find_macro_invocation_end(text, open_paren)
+        body = text[open_paren + 1 : end - 1]
+
+        # String literals (including the format string) are user-facing
+        # text — `"database_url: {}"` is not a leak on its own. Strip
+        # them before searching for sensitive identifiers so we only
+        # flag actual Rust bindings being interpolated.
+        stripped = re.sub(r'"(?:\\.|[^"\\])*"', "", body)
+        # Raw string literals: r"..." and r#"..."# — strip a few hash depths.
+        stripped = re.sub(r'r#*"[^"]*"#*', "", stripped)
+        # Sub-expressions already routed through a `mask_*(...)` helper
+        # (mask_db_url, mask_password, …) are safe by construction.
+        stripped = re.sub(r"\bmask_\w+\s*\([^()]*\)", "", stripped)
+
+        hit = SENSITIVE_RE.search(stripped)
+        if not hit:
+            continue
+
+        # Respect explicit allow comment on the preceding line.
+        if ALLOW_RE.search(preceding_line(text, m.start())):
+            continue
+
+        rel = path.relative_to(root)
+        line = line_of(text, m.start())
+        macro = m.group(1)
+        violations.append((rel, line, macro, hit.group(1)))
+    return violations
+
+
+def main() -> int:
+    root = repo_root()
+    files = list_rust_files(root)
+    all_violations: list[tuple[Path, int, str, str]] = []
+    for f in files:
+        all_violations.extend(scan_file(f, root))
+
+    if not all_violations:
+        print(
+            f"credential-logging guard: clean ({len(files)} Rust files scanned)"
+        )
+        return 0
+
+    print("credential-logging guard: VIOLATIONS FOUND")
+    print()
+    print(
+        "Log/print macros referenced sensitive identifiers "
+        "without mask_db_url(). Wrap the value with "
+        "`cloacina::logging::mask_db_url(&url)` before logging, or "
+        "suppress with `// allow(credential-logging): <reason>` on the "
+        "line above the macro call.\n"
+    )
+    for rel, line, macro, ident in all_violations:
+        print(f"  {rel}:{line}: {macro}!(...) references `{ident}`")
+    print()
+    print(f"Total: {len(all_violations)} violation(s) in {len(files)} file(s).")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- New `scripts/check_credential_logging.py` scanner flags `info!/debug!/trace!/warn!/error!/eprintln!/println!/eprint!/print!` invocations that reference `database_url`, `db_url`, `connection_string`, or `password` unless wrapped in a `mask_*(...)` helper or preceded by `// allow(credential-logging): <reason>`. Multi-line aware; strips string/char literals so format-string labels don't trip it.
- Wired into CI (`.github/workflows/ci.yml` quick-checks) and angreal (`angreal check credential-logging`).
- Fixed the violations the guard surfaced on first run:
  - `crates/cloacina/tests/fixtures.rs`: Postgres + SQLite fixtures now `mask_db_url()` the logged URL.
  - `examples/features/workflows/per-tenant-credentials/src/main.rs`: admin-provided password now masked via `mask_password()` like its siblings.

Closes T-0443 (follow-up to T-0442 / OPS-03).

## Test plan
- [x] Guard passes clean on current tree (392 Rust files scanned).
- [x] 8 synthetic cases exercised (raw/masked/qualified/literal-only/allow-comment variants) — all detect/ignore as expected.
- [x] `cargo check --features sqlite --tests` clean for `crates/cloacina`.
- [x] `cargo check` clean for `examples/features/workflows/per-tenant-credentials`.
- [ ] CI `quick-checks` job green.