### PR TITLE
T-0530: fix flake in test_supervisor_individual_accumulator_restart

### DIFF
--- a/.metis/backlog/bugs/CLOACI-T-0530.md
+++ b/.metis/backlog/bugs/CLOACI-T-0530.md
@@ -4,15 +4,15 @@ level: task
 title: "Investigate flake: computation_graph::resilience_tests::test_supervisor_individual_accumulator_restart"
 short_code: "CLOACI-T-0530"
 created_at: 2026-04-19T02:47:48.132108+00:00
-updated_at: 2026-04-19T02:47:48.132108+00:00
+updated_at: 2026-04-20T11:22:05.389678+00:00
 parent:
 blocked_by: []
 archived: false
 
 tags:
   - "#task"
-  - "#phase/backlog"
   - "#bug"
+  - "#phase/active"
 
 
 exit_criteria_met: false
@@ -70,4 +70,61 @@ subsystem but can be done independently.
 
 ## Status Updates
 
-*To be added during investigation*
+### 2026-04-20 — Root cause & fix
+
+**Root cause: fixed-duration `tokio::time::sleep` waits that are tight under
+CPU contention from parallel test execution.** The test assumed specific
+wall-clock timings for three async state transitions that are not guaranteed
+under load:
+
+1. The reactor's **warming-gate polling loop** sleeps 100ms between checks of
+   accumulator health (`reactor.rs::run` near line 424). The test waited
+   250ms after event 1 before asserting `fires_before >= 1`. Under load,
+   reactor can take longer than 100ms to go Live, and the queued boundary
+   isn't drained until after Live, so `fires_before` could be 0.
+2. **Panic propagation through the spawned `accumulator_runtime` task is
+   async.** The test waited a fixed 200ms after event 2 and then called
+   `check_and_restart_failed` exactly once, asserting `restarted == 1`. If
+   the task hadn't finished unwinding, `handle.is_finished()` returned
+   `false` and the supervisor saw no crash to restart.
+3. After restart, the test waited 200ms before asserting `fires_after >
+   fires_before`. The restart path includes a 1s backoff
+   (`BACKOFF_BASE_SECS = 1`) plus V2 spawn + event 3 processing; 200ms
+   extra on top is usually enough but not guaranteed.
+
+Sequential single-test reruns don't reproduce (30/30 and 20/20 passed
+locally in both single-test and resilience_tests-module runs). The flake
+surfaces inside the full `angreal cloacina integration` run where many
+tests share a tokio worker pool and wall-clock timings slip.
+
+**Fix (test-only):** replaced each fixed `sleep` with polling against the
+actual observable state:
+
+- Poll `fire_count >= 1` with a 5s deadline before reading `fires_before`.
+- Poll `check_and_restart_failed()` in a loop (20ms cadence, 5s deadline),
+  break when it returns ≥1 — this waits for the supervisor to actually see
+  the panic rather than guessing how long unwinding takes.
+- Poll `fire_count > fires_before` with a 5s deadline after event 3.
+
+The production code is unchanged — only the test was racing its own
+asynchronous subject.
+
+**Verification:**
+- Pre-fix: 30/30 + 20/20 sequential passes locally (flake only visible
+  under full-suite contention).
+- Post-fix: 30/30 sequential passes on the edited test locally.
+
+**Related observation (not fixed here):** `registry.rs::register_accumulator`
+pushes onto a `Vec` instead of replacing, so after an individual restart
+the registry holds both the dead V1 socket and the live V2 socket for the
+same accumulator name. `send_to_accumulator` still reaches V2, but stale
+senders accumulate across restarts. Worth a follow-up task; out of scope
+here since it wasn't the flake trigger.
+
+**Acceptance criteria status:**
+- [x] Root cause identified and documented (polling race against fixed
+  sleeps, visible only under parallel-suite CPU load).
+- [x] Test passes deterministically (polling replaces fixed sleeps).
+- [ ] "5 runs in a row locally + 3 CI jobs in a row" — 30 local single-test
+  runs pass; user chose to stop here rather than run the full integration
+  suite 5× + CI 3×. CI verification still pending at reviewer's discretion.

--- a/crates/cloacina/tests/integration/computation_graph.rs
+++ b/crates/cloacina/tests/integration/computation_graph.rs
@@ -1866,14 +1866,43 @@ mod resilience_tests {
 
         scheduler.load_graph(decl).await.unwrap();
 
-        // Push 2 events — accumulator will panic on the 2nd process()
+        // Helper: poll a predicate until it's true, or panic on timeout. Used in
+        // place of fixed `sleep` waits so this test stays deterministic under
+        // CPU contention from parallel test execution (the original cause of
+        // CLOACI-T-0530's intermittent failures in `angreal cloacina integration`).
+        async fn poll_until<F: FnMut() -> bool>(
+            mut pred: F,
+            timeout: std::time::Duration,
+            label: &str,
+        ) {
+            let deadline = std::time::Instant::now() + timeout;
+            while std::time::Instant::now() < deadline {
+                if pred() {
+                    return;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            }
+            panic!("timed out waiting for: {}", label);
+        }
+
+        // Push event 1 and wait for the reactor to fire it. The reactor has a
+        // ~100ms warming gate before going Live; under load this can be longer,
+        // so poll instead of using a fixed sleep.
         let event = AlphaData { value: 1.0 };
         registry
             .send_to_accumulator("alpha", serde_json::to_vec(&event).unwrap())
             .await
             .unwrap();
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
+        poll_until(
+            || fire_count.load(Ordering::SeqCst) >= 1,
+            std::time::Duration::from_secs(5),
+            "first event to fire reactor",
+        )
+        .await;
+        let fires_before = fire_count.load(Ordering::SeqCst);
+
+        // Push event 2 — accumulator will panic on the 2nd process()
         registry
             .send_to_accumulator(
                 "alpha",
@@ -1881,23 +1910,26 @@ mod resilience_tests {
             )
             .await
             .unwrap();
-        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
 
-        // At this point the accumulator task has panicked. The first event should have fired.
-        let fires_before = fire_count.load(Ordering::SeqCst);
-        assert!(
-            fires_before >= 1,
-            "should have at least 1 fire before panic"
+        // Trigger supervisor check — poll because the panic propagation through
+        // the spawned task is async and `is_finished()` may not be true the
+        // instant after `send_to_accumulator` returns.
+        let mut restarted = 0;
+        let restart_deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while std::time::Instant::now() < restart_deadline {
+            restarted = scheduler.check_and_restart_failed().await;
+            if restarted >= 1 {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        assert_eq!(
+            restarted, 1,
+            "supervisor should detect and restart 1 accumulator"
         );
 
-        // Trigger supervisor check — should detect crash and restart
-        let restarted = scheduler.check_and_restart_failed().await;
-        assert_eq!(restarted, 1, "supervisor should restart 1 accumulator");
-
-        // Wait for the restart to settle
-        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
-
-        // Push another event — the respawned accumulator (spawn_num=1) won't panic
+        // Push event 3 — the respawned accumulator (spawn_num=1) won't panic.
+        // Poll for the next fire instead of relying on a fixed sleep.
         registry
             .send_to_accumulator(
                 "alpha",
@@ -1906,15 +1938,12 @@ mod resilience_tests {
             .await
             .unwrap();
 
-        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
-
-        let fires_after = fire_count.load(Ordering::SeqCst);
-        assert!(
-            fires_after > fires_before,
-            "graph should fire after accumulator restart (before={}, after={})",
-            fires_before,
-            fires_after
-        );
+        poll_until(
+            || fire_count.load(Ordering::SeqCst) > fires_before,
+            std::time::Duration::from_secs(5),
+            "graph to fire after accumulator restart",
+        )
+        .await;
 
         scheduler.shutdown_all().await;
     }


### PR DESCRIPTION
## Summary
- Replace fixed `tokio::time::sleep` waits in `test_supervisor_individual_accumulator_restart` with polling against observable state (`fire_count`, `check_and_restart_failed` result).
- Root cause: the test raced three async transitions — the reactor's 100ms warming-gate poll, panic unwinding on the spawned accumulator task, and the 1s restart backoff — which only surfaced as a flake under the CPU contention of the full `angreal cloacina integration` run.
- Production code unchanged; only the test was racing its own subject.

See CLOACI-T-0530 status updates for the full root-cause writeup. Also noted a related-but-separate follow-up: `registry.rs::register_accumulator` appends to a `Vec` instead of replacing, leaving stale senders after individual restarts — out of scope for this fix.

## Test plan
- [x] `cargo test -p cloacina --test integration computation_graph::resilience_tests::test_supervisor_individual_accumulator_restart` — 30/30 sequential passes post-fix
- [ ] Reviewer: confirm green under `angreal cloacina integration` locally and in CI (acceptance criterion: 5 local + 3 CI runs in a row)