### PR TITLE
I-0101: decompose into T-0538..T-0542 and activate

### DIFF
--- a/.metis/initiatives/CLOACI-I-0101/initiative.md
+++ b/.metis/initiatives/CLOACI-I-0101/initiative.md
@@ -4,14 +4,14 @@ level: initiative
 title: "Decouple computation graph from reactor; enable embedded CG workflow tasks"
 short_code: "CLOACI-I-0101"
 created_at: 2026-04-23T23:44:55.541551+00:00
-updated_at: 2026-04-23T23:44:55.541551+00:00
+updated_at: 2026-04-24T15:13:17.470059+00:00
 parent: CLOACI-V-0001
 blocked_by: []
 archived: false
 
 tags:
   - "#initiative"
-  - "#phase/discovery"
+  - "#phase/active"
 
 
 exit_criteria_met: false

--- a/.metis/initiatives/CLOACI-I-0101/tasks/CLOACI-T-0538.md
+++ b/.metis/initiatives/CLOACI-I-0101/tasks/CLOACI-T-0538.md
@@ -1,0 +1,75 @@
+---
+id: t-01a-cg-macro-split-internals-new
+level: task
+title: "T-01a: CG macro split internals (new declaration + type binding + tests)"
+short_code: "CLOACI-T-0538"
+created_at: 2026-04-24T15:08:02.717131+00:00
+updated_at: 2026-04-24T15:08:02.717131+00:00
+parent: CLOACI-I-0101
+blocked_by: []
+archived: false
+
+tags:
+  - "#task"
+  - "#phase/todo"
+
+
+exit_criteria_met: false
+initiative_id: CLOACI-I-0101
+---
+
+# T-01a: CG macro split internals (new declaration + type binding + tests)
+
+## Parent Initiative
+
+[[CLOACI-I-0101]]
+
+## Objective
+
+Land the `#[computation_graph]` macro changes that enable the split declaration model from CLOACI-S-0011 and I-0101, without touching any in-tree caller yet. The bundled form keeps working through this task so CI stays green; the new form is validated end-to-end against the existing runtime via added tests. No external behavior changes; no migration; no removal of the old path.
+
+## Acceptance Criteria
+
+- [ ] `#[computation_graph]` accepts a new `trigger = reactor("name")` clause and emits a declaration that references the reactor by name.
+- [ ] `#[computation_graph]` accepts no trigger clause at all (trigger-less declaration compiles and is registered).
+- [ ] Compile-time type binding: when `trigger = reactor("name")` is present, macro expansion produces a type assertion that the reactor's firing output matches the graph's `entry_type`. Mismatch is a compile error with a readable message.
+- [ ] The bundled form (`#[computation_graph]` with reactor + accumulators inside) continues to compile and run — it should emit the same runtime artifacts it does today. Migration of in-tree callers happens in T-01b.
+- [ ] Unit tests: macro expansion for each of the three forms (bundled — existing; split with trigger — new; trigger-less — new).
+- [ ] Integration tests: standalone CG using the new `trigger = reactor(...)` form fires via reactor end-to-end; trigger-less CG compiles and is present in the graph registry (even if nothing invokes it yet).
+- [ ] `cargo check --workspace --all-features` green.
+- [ ] `angreal cloacina unit` green.
+- [ ] `angreal cloacina integration --backend sqlite` green end-to-end (full suite, not just new tests).
+
+## Implementation Notes
+
+### Technical Approach
+
+1. Extend the `#[computation_graph]` macro parser in `crates/cloacina-macros` to accept:
+   - `trigger = reactor("name")` as an optional top-level clause.
+   - A form with no reactor/accumulators/criteria clauses at all (trigger-less).
+2. Update the macro's internal IR (`computation_graph::graph_ir`) to carry `Option<TriggerBinding>`. When the bundled form is used, the bundled inline reactor translates to a synthesized `trigger` binding + a separately emitted reactor declaration. This is the narrow "temporary compat path" mentioned in the initiative — it keeps the old form working by desugaring it into the new form, not by shipping two code paths.
+3. Emit the type-binding assertion with `const _: () = { ... assert_type_eq!(...) };` at expansion so mismatches surface as compile errors.
+4. Extend the runtime graph registry to accept a trigger-less graph: the graph's compiled function is still registered by name, but it is not bound to any reactor subscription — that binding happens later when a subscriber (a reactor or workflow task) references it.
+5. Keep `ComputationGraphScheduler::load_graph` compatible with both old-style and new-style declarations (both desugar to the same internal representation by this point).
+
+### Key Files
+
+- `crates/cloacina-macros/src/computation_graph/parser.rs` — add new clauses.
+- `crates/cloacina-macros/src/computation_graph/graph_ir.rs` — IR updates.
+- `crates/cloacina-macros/src/computation_graph/codegen.rs` — emission changes.
+- `crates/cloacina/src/computation_graph/scheduler.rs` — registry additions for trigger-less graphs.
+- `crates/cloacina-macros/tests/` + `crates/cloacina/tests/integration/computation_graph.rs` — new unit + integration tests.
+
+### Dependencies
+
+- None. This is the foundation task on the I-0101 branch.
+
+### Risk Considerations
+
+- Macro IR changes ripple through downstream codegen. Keep the IR evolution minimal — additive fields with `Option<>`, no renames of existing ones. Removing old fields happens in T-01b.
+- Type binding via `assert_type_eq!` requires the reactor's firing-output type to be visible at the graph's macro-expansion point. If users put the reactor and graph in different modules without a shared import, the assertion may fail to compile even when types are correct. Document the import pattern in the error message.
+- Keep the bundled-form desugar surgical — it should produce byte-identical runtime artifacts to today's bundled emission. Snapshot-test the macro output if practical.
+
+## Status Updates
+
+*To be added during implementation.*

--- a/.metis/initiatives/CLOACI-I-0101/tasks/CLOACI-T-0539.md
+++ b/.metis/initiatives/CLOACI-I-0101/tasks/CLOACI-T-0539.md
@@ -1,0 +1,75 @@
+---
+id: t-01b-migrate-rust-callers-remove
+level: task
+title: "T-01b: Migrate Rust callers + remove bundled CG form"
+short_code: "CLOACI-T-0539"
+created_at: 2026-04-24T15:08:10.182883+00:00
+updated_at: 2026-04-24T15:08:10.182883+00:00
+parent: CLOACI-I-0101
+blocked_by: []
+archived: false
+
+tags:
+  - "#task"
+  - "#phase/todo"
+
+
+exit_criteria_met: false
+initiative_id: CLOACI-I-0101
+---
+
+# T-01b: Migrate Rust callers + remove bundled CG form
+
+## Parent Initiative
+
+[[CLOACI-I-0101]]
+
+## Objective
+
+Migrate every in-tree Rust user of the bundled `#[computation_graph]` form to the new split form (`#[reactor]` declaration + `#[computation_graph(trigger = reactor("name"))]`). Then remove the bundled-form desugar from the macro, leaving only the split form on main. After this task lands, the bundled form is unreachable in the tree and in the public macro surface.
+
+## Acceptance Criteria
+
+- [ ] Every in-tree Rust CG declaration uses the split form: a separate `#[reactor]` declaration for each reactor, plus `#[computation_graph(trigger = reactor("name"))]` for each CG that subscribes to one.
+- [ ] Files touched by the migration (non-exhaustive; verified during the task):
+  - `examples/**` — any Rust example declaring a CG
+  - `crates/cloacina/tests/integration/computation_graph.rs`
+  - `crates/cloacina/src/computation_graph/**` — internal examples/tests
+  - Any CG declarations in `crates/cloacina-server/tests/**`
+  - `crates/cloacina-computation-graph` if it carries sample declarations
+- [ ] The bundled-form desugar added in T-01a is removed from `cloacina-macros`. Attempting to use the old form now produces a compile error pointing at the migration docs.
+- [ ] `cargo check --workspace --all-features` green.
+- [ ] `angreal cloacina unit` green (both backends).
+- [ ] `angreal cloacina integration --backend postgres` and `--backend sqlite` green end-to-end.
+- [ ] `angreal cloacina macros` green.
+- [ ] `angreal cloacina soak` quick run green (optional; include if soak isn't already exercised in integration).
+- [ ] No cargo warnings introduced by the migration (unused imports, dead code, etc.).
+
+## Implementation Notes
+
+### Technical Approach
+
+1. Grep for every macro invocation that uses the bundled form (`#[computation_graph(...)]` with inline reactor/accumulator clauses) and rewrite each into two declarations: `#[reactor]` for the reactor + its accumulators + its criteria, and `#[computation_graph(trigger = reactor("name"))]` for the graph topology.
+2. Migrate the corresponding tests so they reference the new declaration surface.
+3. Delete the bundled-form parse path in the macro parser, the IR shape that supports it, and the code-gen desugar that T-01a added.
+4. Add a compile-error diagnostic at the macro level: if a user tries the old syntax, the error message says "the bundled `#[computation_graph]` form has been removed; declare `#[reactor]` and `#[computation_graph(trigger = reactor(\"name\"))]` separately — see initiative CLOACI-I-0101."
+
+### Key Files (expected)
+
+- `crates/cloacina-macros/src/computation_graph/parser.rs`
+- `crates/cloacina-macros/src/computation_graph/graph_ir.rs`
+- `crates/cloacina-macros/src/computation_graph/codegen.rs`
+- All in-tree CG declarations (see Acceptance Criteria for paths).
+
+### Dependencies
+
+- T-01a must have landed first. The split form must exist before we migrate to it.
+
+### Risk Considerations
+
+- Migration churn is mechanical but wide — touching many files. Single atomic PR; no half-migrated states.
+- The macro's diagnostic quality matters here: the compile-error message is the user's first signal of the breaking change. Write it well.
+
+## Status Updates
+
+*To be added during implementation.*

--- a/.metis/initiatives/CLOACI-I-0101/tasks/CLOACI-T-0540.md
+++ b/.metis/initiatives/CLOACI-I-0101/tasks/CLOACI-T-0540.md
@@ -1,0 +1,78 @@
+---
+id: t-02-workflow-task-cg-invocation
+level: task
+title: "T-02: Workflow-task CG invocation (`invokes = computation_graph(...)`)"
+short_code: "CLOACI-T-0540"
+created_at: 2026-04-24T15:08:15.391806+00:00
+updated_at: 2026-04-24T15:08:15.391806+00:00
+parent: CLOACI-I-0101
+blocked_by: []
+archived: false
+
+tags:
+  - "#task"
+  - "#phase/todo"
+
+
+exit_criteria_met: false
+initiative_id: CLOACI-I-0101
+---
+
+# T-02: Workflow-task CG invocation
+
+## Parent Initiative
+
+[[CLOACI-I-0101]]
+
+## Objective
+
+Add the capability for a workflow task to wrap a computation graph and execute it on demand. Implements the `invokes = computation_graph("name")` clause on `#[task]`, the matching executor path that resolves a graph by name and runs it to completion, and the context ↔ graph-types adapter. This is the embedded-CG-in-workflow payoff from S-0011 — one shot per task execution, no reactor in scope, no streams, graph runs as a deterministic function.
+
+## Acceptance Criteria
+
+- [ ] `#[task]` accepts an `invokes = computation_graph("name")` clause and emits a task whose body is a CG invocation. If the user supplies a function body, it runs before/after the invocation; if omitted, the task is a pure invocation.
+- [ ] New task-invocation kind in the dispatcher / `ThreadTaskExecutor`. When a task with `invokes = ...` is dispatched, the executor:
+  - Resolves the graph by name via the graph registry.
+  - Translates the task's input context into the graph's `entry_type`.
+  - Invokes the compiled graph function.
+  - Translates terminal-node outputs back into the task's output context.
+  - Records completion via the existing task lifecycle (heartbeat, complete).
+- [ ] Task retry/timeout apply as for any other task. A graph panic becomes a task error; a graph that exceeds the task's timeout is cancelled per the existing T-0487 cancellation path.
+- [ ] Compile-time binding: `invokes = computation_graph("name")` must reference a graph that exists in the build — macro expansion errors at compile time if the name is unresolvable at link time.
+- [ ] Integration tests, postgres + sqlite:
+  - Trigger-less CG invoked by a workflow task; terminal outputs land in the downstream task's context.
+  - Fan-out: two computation graphs both declare `trigger = reactor("R")`; one firing of R invokes both graphs. Unrelated to `invokes`, but this initiative owns proving fan-out works.
+  - Graph error → task failure → workflow retry engages.
+  - Graph timeout → task cancellation via the claim-loss / timeout path.
+
+## Implementation Notes
+
+### Technical Approach
+
+1. Extend the `#[task]` macro to parse `invokes = computation_graph("name")`. Emit a task whose `execute()` body resolves the graph and runs it. The user's function body, if provided, is inserted around the invocation (pre-work, invocation, post-work).
+2. Extend the task dispatcher (see `thread_task_executor.rs`) to recognize the new invocation kind. The graph lookup uses the registry already exposed by T-01a.
+3. Build the context adapter: `Context<Value>` → `entry_type` on the way in (serde deserialize from the context's serialized form into the typed entry), `terminal_outputs` → `Context<Value>` on the way out (serde serialize each terminal into the task's output context under the terminal's node name).
+4. Hook graph panics into `TaskError`. The existing executor already catches panics from task bodies; extend the same treatment to graph invocations.
+
+### Key Files
+
+- `crates/cloacina-macros/src/task/parser.rs` — add the `invokes` clause.
+- `crates/cloacina-macros/src/task/codegen.rs` — emit the CG-invocation body.
+- `crates/cloacina/src/executor/thread_task_executor.rs` — handle the new invocation kind.
+- `crates/cloacina/src/computation_graph/scheduler.rs` — expose the compiled-function lookup if T-01a didn't already.
+- New integration tests under `crates/cloacina/tests/integration/executor/` or alongside the existing CG tests.
+
+### Dependencies
+
+- **T-01a** (graph registry understands trigger-less CGs; `#[computation_graph]` split exists).
+- Does *not* depend on T-01b — this task can land while the bundled form still works in T-01a's branch state.
+
+### Risk Considerations
+
+- Context ↔ graph-types adapter is the highest-risk piece. `Context<Value>` is serde-flexible; the graph's `entry_type` may have required fields the context can't satisfy. Return a specific task error on adapter failure, not a generic panic.
+- Terminal node naming: if a graph has multiple terminal nodes, each terminal's output is serialized under a distinct context key. Document the convention in the task doc comment.
+- Fan-out test requires two CGs declaring the same `trigger = reactor("R")` — confirm with T-01a that multiple subscribers on one reactor are supported at the runtime level before writing the test.
+
+## Status Updates
+
+*To be added during implementation.*

--- a/.metis/initiatives/CLOACI-I-0101/tasks/CLOACI-T-0541.md
+++ b/.metis/initiatives/CLOACI-I-0101/tasks/CLOACI-T-0541.md
@@ -1,0 +1,74 @@
+---
+id: t-03-python-decorator-parity-for
+level: task
+title: "T-03: Python decorator parity for split CG + CG-invoking task"
+short_code: "CLOACI-T-0541"
+created_at: 2026-04-24T15:08:19.954995+00:00
+updated_at: 2026-04-24T15:08:19.954995+00:00
+parent: CLOACI-I-0101
+blocked_by: []
+archived: false
+
+tags:
+  - "#task"
+  - "#phase/todo"
+
+
+exit_criteria_met: false
+initiative_id: CLOACI-I-0101
+---
+
+# T-03: Python decorator parity for split CG + CG-invoking task
+
+## Parent Initiative
+
+[[CLOACI-I-0101]]
+
+## Objective
+
+Mirror the Rust declaration surface from T-01a and T-02 in the Python bindings. `@cloaca.computation_graph` accepts the `trigger = reactor("name")` kwarg; `@cloaca.task` accepts `invokes = computation_graph("name")`. Python is dynamic, so validation is runtime, not compile-time, but the authoring experience must match what Rust users see.
+
+## Acceptance Criteria
+
+- [ ] `@cloaca.computation_graph(trigger=cloaca.reactor("name"), ...)` compiles and registers a CG bound to the named reactor.
+- [ ] `@cloaca.computation_graph(...)` without a `trigger` kwarg registers a trigger-less CG that can be invoked by a workflow task.
+- [ ] `@cloaca.task(invokes=cloaca.computation_graph("name"), ...)` registers a workflow task whose body is a CG invocation. If the user supplies a function body, pre/post semantics match the Rust task.
+- [ ] Runtime validation: at registration time, a CG with `trigger=reactor("name")` where the named reactor does not exist raises a `ValueError` with a clear message. Same for a task whose `invokes=computation_graph("name")` target is not registered.
+- [ ] Runtime type-compatibility check (best-effort): when a CG's entry data class and a reactor's firing payload can be compared (both are `@dataclass` or both are `TypedDict`), a mismatch raises at registration. If the types cannot be statically introspected, skip with a debug log — Python dynamism.
+- [ ] Python scenario tests match the Rust integration coverage:
+  - CG with reactor trigger fires end-to-end.
+  - Trigger-less CG invoked by a workflow task; outputs propagate to downstream tasks.
+  - Fan-out: two CGs, same reactor trigger.
+  - Adapter failure raises a clean error, not an opaque PyO3 crash.
+- [ ] `angreal cloaca test` (or its successor under the cloacina namespace) green.
+- [ ] `angreal demos python-tutorial-09` (or the CG-equivalent tutorial) green after its migration in T-04.
+
+## Implementation Notes
+
+### Technical Approach
+
+1. Extend the Python decorators in `crates/cloacina-python/src/workflow.rs` (for `@task`) and `crates/cloacina-python/src/computation_graph.rs` (for `@computation_graph`). Add `trigger` and `invokes` kwargs to each.
+2. On registration, resolve the referenced reactor / graph name against the scoped runtime. If missing, raise `PyValueError` with a migration-friendly message.
+3. Context adaptation: Python context is the same `PyContext` wrapper as today. Marshal context → graph entry type at invocation time. For trigger-firings originating on the Rust side with a typed payload, the Python bridge already exists (from the existing reactor wiring); extend it to surface terminal outputs back to the calling task's context.
+4. Python scenario tests go under `tests/python/test_scenario_*.py`. Expect to add two or three new scenarios; verify they run under both backends in CI.
+
+### Key Files
+
+- `crates/cloacina-python/src/workflow.rs` — task decorator extensions.
+- `crates/cloacina-python/src/computation_graph.rs` — CG decorator extensions + reactor helper.
+- `crates/cloacina-python/src/task.rs` — task registration hook.
+- `tests/python/test_scenario_*.py` — new scenarios for split-CG-with-reactor, trigger-less CG invoked by task, fan-out.
+
+### Dependencies
+
+- **T-02** (the Rust workflow-task CG invocation must exist — Python is a thin wrapper over the Rust executor).
+- Indirectly T-01a (the CG declaration surface this decorator targets).
+
+### Risk Considerations
+
+- Python's dynamic nature means some type validations the Rust macro catches at compile time become runtime checks here. Err on the side of explicit, readable error messages at registration (not at first firing).
+- Keep the decorator kwargs symmetric with Rust's: `trigger=cloaca.reactor("name")` mirrors `trigger = reactor("name")`. Don't let ergonomic drift between the languages creep in.
+
+## Status Updates
+
+*To be added during implementation.*

--- a/.metis/initiatives/CLOACI-I-0101/tasks/CLOACI-T-0542.md
+++ b/.metis/initiatives/CLOACI-I-0101/tasks/CLOACI-T-0542.md
@@ -1,0 +1,72 @@
+---
+id: t-04-tutorials-how-to-and-breaking
+level: task
+title: "T-04: Tutorials, how-to, and breaking-change release notes for CG split"
+short_code: "CLOACI-T-0542"
+created_at: 2026-04-24T15:08:24.727807+00:00
+updated_at: 2026-04-24T15:08:24.727807+00:00
+parent: CLOACI-I-0101
+blocked_by: []
+archived: false
+
+tags:
+  - "#task"
+  - "#phase/todo"
+
+
+exit_criteria_met: false
+initiative_id: CLOACI-I-0101
+---
+
+# T-04: Tutorials, how-to, and breaking-change release notes for CG split
+
+## Parent Initiative
+
+[[CLOACI-I-0101]]
+
+## Objective
+
+Bring the user-facing docs, tutorials, and release notes in line with the post-I-0101 declaration surface. All tutorials that touch computation graphs use the split form; a new how-to guide covers "wrap a computation graph as a workflow task node"; release notes call out the breaking change with a clear before/after migration example. No user-facing reference to the bundled form survives.
+
+## Acceptance Criteria
+
+- [ ] All Rust computation-graph tutorials under `docs/content/computation-graphs/tutorials/` use the split declaration (`#[reactor]` + `#[computation_graph(trigger = reactor("name"))]` for standalone CGs).
+- [ ] All Python computation-graph tutorials under `docs/content/python/tutorials/computation-graphs/` use the split decorator form (`@cloaca.computation_graph(trigger=cloaca.reactor("name"))`).
+- [ ] New how-to guide: `docs/content/platform/how-to-guides/computation-graph-in-workflow.md` (or equivalent location), covering the `invokes = computation_graph("name")` / `@task(invokes=...)` pattern, the context ↔ graph-type adapter, and when to prefer embedded-CG vs. standalone-CG.
+- [ ] Any reference doc (`docs/content/api-reference/**`, tutorials' `_index.md`, glossary) that mentioned the bundled form is rewritten.
+- [ ] Release notes entry (wherever the project tracks them — `CHANGELOG.md` or an entry under `.github/release_notes/` or the docs' release section) that:
+  - Announces the breaking change.
+  - Shows a before-and-after migration snippet for Rust.
+  - Shows the same for Python.
+  - Links to CLOACI-I-0101 and CLOACI-S-0011.
+- [ ] `docs/content/_index.md` and any entry-point material reflects the new mental model (reactor as standalone trigger; CG optionally declares its trigger upstream).
+- [ ] Full-text grep across `docs/content/` for the old bundled form turns up nothing (or only release-notes historical references).
+- [ ] `angreal docs build` green.
+
+## Implementation Notes
+
+### Technical Approach
+
+1. Audit `docs/content/computation-graphs/**` for any code examples that use the bundled macro form. Rewrite each using the split form. Verify that the narrative still flows — if the existing tutorial's pedagogy assumed "declare reactor + accumulators + graph all in one block," it may need a small reordering so the reactor and graph are introduced as distinct steps.
+2. Same pass on `docs/content/python/tutorials/computation-graphs/**`.
+3. Write the new how-to guide. Recommended structure:
+   - Problem statement ("I have a multi-step workflow and one step is a computation graph").
+   - Declaration shape (trigger-less CG + task with `invokes`).
+   - Context adapter notes (what gets serialized, what terminal outputs look like in the downstream task's context).
+   - When to use this vs. standalone-CG-with-reactor (the two quantum models from S-0011).
+4. Draft the release notes entry. Before/after snippets should be copy-pasteable. Add a one-liner pointing at the how-to for the embedded-CG case.
+5. Grep + cleanup pass for stray references to the old form.
+
+### Dependencies
+
+- **T-01b** (bundled form removed — docs should show the final state).
+- **T-03** (Python parity exists — tutorials and how-to cover both languages).
+
+### Risk Considerations
+
+- Docs are often written in a way that conflates "the reactor" and "the graph." With the split, every existing sentence that said "the reactor" or "the computation graph" needs to be read carefully to make sure it still names the right primitive per CLOACI-S-0011 R1–R3.
+- Release-notes tone: the breaking change needs to be clearly marked and easy to migrate from. A short, direct entry beats a comprehensive one here.
+
+## Status Updates
+
+*To be added during implementation.*


### PR DESCRIPTION
## Summary

Planning-only. No code. Decomposes CLOACI-I-0101 into five child tasks and transitions the initiative to \`active\`.

- **T-0538** T-01a CG macro split internals — new declaration surface + type binding + tests; bundled form keeps working through this task.
- **T-0539** T-01b Migrate Rust callers + remove bundled CG form. Depends on T-0538.
- **T-0540** T-02 Workflow-task CG invocation (\`invokes = computation_graph(...)\`). Depends on T-0538.
- **T-0541** T-03 Python decorator parity. Depends on T-0540.
- **T-0542** T-04 Tutorials, how-to, and breaking-change release notes. Depends on T-0539 + T-0541.

Dependency graph allows some parallelism (T-0539 and T-0540 after T-0538) but the initiative executes linearly on a single branch.

## Test plan

- [x] No code changes; \`.metis/**\` is in \`paths-ignore\` so no CI runs.