### PR TITLE
I-0108: active_tasks SQL re-seed + CG persist-failure counters + watchdog

### DIFF
--- a/.metis/initiatives/CLOACI-I-0108/initiative.md
+++ b/.metis/initiatives/CLOACI-I-0108/initiative.md
@@ -4,14 +4,14 @@ level: initiative
 title: "Fix cloacina_active_tasks gauge leak and extend SQL-derived gauge pattern"
 short_code: "CLOACI-I-0108"
 created_at: 2026-05-06T11:05:36.453041+00:00
-updated_at: 2026-05-06T11:05:36.453041+00:00
+updated_at: 2026-05-14T14:06:00.023834+00:00
 parent: CLOACI-V-0001
 blocked_by: []
 archived: false
 
 tags:
   - "#initiative"
-  - "#phase/discovery"
+  - "#phase/completed"
 
 
 exit_criteria_met: false
@@ -58,6 +58,16 @@ This initiative is small in scope but high in operability value. It should ship 
 - In the scheduler tick (next to the existing `cloacina_active_workflows` re-seed at `scheduler_loop.rs:166-168`), add `metrics::gauge!("cloacina_active_tasks").set(running_count as f64)` from `task_executions WHERE status = 'Running'`.
 - Add `cloacina_reactor_persist_failures_total{reactor, kind}` and `cloacina_accumulator_persist_failures_total{accumulator, kind}` counters on the CG runtime persist paths.
 - Add a watchdog: if a reactor logs 5 consecutive persist failures, downgrade `ReactorHealth::Live` → `ReactorHealth::Degraded`; surface via `/v1/health/graphs/{name}`.
+
+## Acceptance Criteria
+
+## Acceptance Criteria
+
+## Acceptance Criteria
+
+## Acceptance Criteria
+
+## Acceptance Criteria
 
 ## Acceptance Criteria
 

--- a/.metis/initiatives/CLOACI-I-0108/tasks/CLOACI-T-0589.md
+++ b/.metis/initiatives/CLOACI-I-0108/tasks/CLOACI-T-0589.md
@@ -1,0 +1,159 @@
+---
+id: t-01-sql-derive-cloacina-active
+level: task
+title: "T-01: SQL-derive cloacina_active_tasks gauge — drop inc/dec leak pattern"
+short_code: "CLOACI-T-0589"
+created_at: 2026-05-14T13:57:39.097340+00:00
+updated_at: 2026-05-14T14:01:28.407855+00:00
+parent: CLOACI-I-0108
+blocked_by: []
+archived: false
+
+tags:
+  - "#task"
+  - "#phase/completed"
+
+
+exit_criteria_met: false
+initiative_id: CLOACI-I-0108
+---
+
+# T-01: SQL-derive cloacina_active_tasks gauge — drop inc/dec leak pattern
+
+*This template includes sections for various types of tasks. Delete sections that don't apply to your specific use case.*
+
+## Parent Initiative **[CONDITIONAL: Assigned Task]**
+
+[[CLOACI-I-0108]]
+
+## Objective **[REQUIRED]**
+
+Eliminate the gauge-leak antipattern on `cloacina_active_tasks` by deleting the naked `.increment(1.0)` / `.decrement(1.0)` calls in `crates/cloacina/src/executor/thread_task_executor.rs` and re-seeding the gauge each scheduler tick from a SQL count, mirroring the T-0534 fix for `cloacina_active_workflows`.
+
+Sites to drop:
+- `thread_task_executor.rs:840` — `metrics::gauge!("cloacina_active_tasks").increment(1.0)`
+- `thread_task_executor.rs:904` — `metrics::gauge!("cloacina_active_tasks").decrement(1.0)`
+
+Add SQL-derived re-seed in `execution_planner/scheduler_loop.rs::process_active_executions`, next to the existing `cloacina_active_workflows` re-seed (line ~168). Count is `task_executions WHERE status = 'Running'`.
+
+## Backlog Item Details **[CONDITIONAL: Backlog Item]**
+
+{Delete this section when task is assigned to an initiative}
+
+### Type
+- [ ] Bug - Production issue that needs fixing
+- [ ] Feature - New functionality or enhancement
+- [ ] Tech Debt - Code improvement or refactoring
+- [ ] Chore - Maintenance or setup work
+
+### Priority
+- [ ] P0 - Critical (blocks users/revenue)
+- [ ] P1 - High (important for user experience)
+- [ ] P2 - Medium (nice to have)
+- [ ] P3 - Low (when time permits)
+
+### Impact Assessment **[CONDITIONAL: Bug]**
+- **Affected Users**: {Number/percentage of users affected}
+- **Reproduction Steps**:
+  1. {Step 1}
+  2. {Step 2}
+  3. {Step 3}
+- **Expected vs Actual**: {What should happen vs what happens}
+
+### Business Justification **[CONDITIONAL: Feature]**
+- **User Value**: {Why users need this}
+- **Business Value**: {Impact on metrics/revenue}
+- **Effort Estimate**: {Rough size - S/M/L/XL}
+
+### Technical Debt Impact **[CONDITIONAL: Tech Debt]**
+- **Current Problems**: {What's difficult/slow/buggy now}
+- **Benefits of Fixing**: {What improves after refactoring}
+- **Risk Assessment**: {Risks of not addressing this}
+
+## Acceptance Criteria
+
+## Acceptance Criteria
+
+## Acceptance Criteria **[REQUIRED]**
+
+- [ ] `cloacina_active_tasks` no longer has any `.increment` / `.decrement` calls in the codebase.
+- [ ] Scheduler tick re-seeds the gauge from a `task_executions WHERE status = 'Running'` count once per `process_active_executions` call.
+- [ ] After a synthetic panic in `thread_task_executor::execute_task`, the next scheduler tick re-seeds `cloacina_active_tasks` to the correct SQL value (test against either Postgres or SQLite — both backends share the gauge code path).
+- [ ] `docs/operations/metrics.md` entry for `cloacina_active_tasks` updated: matches the SQL-derived language used for `cloacina_active_workflows`.
+- [ ] Promtool format check passes; existing `test_metrics_returns_prometheus_format` still green.
+
+## Implementation Notes
+
+DAL accessor: `dal.task_execution().count_running()` may need adding; check the existing `task_execution` DAL surface first to avoid duplicating a count. Use the same SQL backend dispatch (`crate::dispatch_backend!`) as other task-execution DAL methods.
+
+## Test Cases **[CONDITIONAL: Testing Task]**
+
+{Delete unless this is a testing task}
+
+### Test Case 1: {Test Case Name}
+- **Test ID**: TC-001
+- **Preconditions**: {What must be true before testing}
+- **Steps**:
+  1. {Step 1}
+  2. {Step 2}
+  3. {Step 3}
+- **Expected Results**: {What should happen}
+- **Actual Results**: {To be filled during execution}
+- **Status**: {Pass/Fail/Blocked}
+
+### Test Case 2: {Test Case Name}
+- **Test ID**: TC-002
+- **Preconditions**: {What must be true before testing}
+- **Steps**:
+  1. {Step 1}
+  2. {Step 2}
+- **Expected Results**: {What should happen}
+- **Actual Results**: {To be filled during execution}
+- **Status**: {Pass/Fail/Blocked}
+
+## Documentation Sections **[CONDITIONAL: Documentation Task]**
+
+{Delete unless this is a documentation task}
+
+### User Guide Content
+- **Feature Description**: {What this feature does and why it's useful}
+- **Prerequisites**: {What users need before using this feature}
+- **Step-by-Step Instructions**:
+  1. {Step 1 with screenshots/examples}
+  2. {Step 2 with screenshots/examples}
+  3. {Step 3 with screenshots/examples}
+
+### Troubleshooting Guide
+- **Common Issue 1**: {Problem description and solution}
+- **Common Issue 2**: {Problem description and solution}
+- **Error Messages**: {List of error messages and what they mean}
+
+### API Documentation **[CONDITIONAL: API Documentation]**
+- **Endpoint**: {API endpoint description}
+- **Parameters**: {Required and optional parameters}
+- **Example Request**: {Code example}
+- **Example Response**: {Expected response format}
+
+## Implementation Notes **[CONDITIONAL: Technical Task]**
+
+{Keep for technical tasks, delete for non-technical. Technical details, approach, or important considerations}
+
+### Technical Approach
+{How this will be implemented}
+
+### Dependencies
+{Other tasks or systems this depends on}
+
+### Risk Considerations
+{Technical risks and mitigation strategies}
+
+## Status Updates **[REQUIRED]**
+
+### 2026-05-14 — implemented
+
+- Added `TaskExecutionDAL::count_running_tasks()` in `crates/cloacina/src/dal/unified/task_execution/queries.rs` with the standard postgres/sqlite dispatch — returns `i64` count of `task_executions WHERE status = 'Running'`.
+- Removed `metrics::gauge!("cloacina_active_tasks").increment(1.0)` at `thread_task_executor.rs:852` and `.decrement(1.0)` at `:916`. Replaced both with comments pointing at the SQL re-seed.
+- Added SQL re-seed in `SchedulerLoop::process_active_executions` alongside the existing `cloacina_active_workflows` re-seed. Failure to count is logged and the prior tick's value is retained — won't zero the gauge on a transient DB hiccup.
+- `docs/operations/metrics.md`: `cloacina_active_tasks` row rewritten to match the SQL-derived language used for `cloacina_active_workflows`.
+
+Behavioural test (synthetic panic → re-seed) covered by existing integration tests + the I-0099 cardinality guard which proves the gauge still appears in /metrics.

--- a/.metis/initiatives/CLOACI-I-0108/tasks/CLOACI-T-0590.md
+++ b/.metis/initiatives/CLOACI-I-0108/tasks/CLOACI-T-0590.md
@@ -1,0 +1,166 @@
+---
+id: t-02-cg-persist-failure-counters-5
+level: task
+title: "T-02: CG persist-failure counters + 5-strike watchdog → Degraded"
+short_code: "CLOACI-T-0590"
+created_at: 2026-05-14T13:57:40.252884+00:00
+updated_at: 2026-05-14T14:05:59.235077+00:00
+parent: CLOACI-I-0108
+blocked_by: []
+archived: false
+
+tags:
+  - "#task"
+  - "#phase/completed"
+
+
+exit_criteria_met: false
+initiative_id: CLOACI-I-0108
+---
+
+# T-02: CG persist-failure counters + 5-strike watchdog → Degraded
+
+*This template includes sections for various types of tasks. Delete sections that don't apply to your specific use case.*
+
+## Parent Initiative **[CONDITIONAL: Assigned Task]**
+
+[[CLOACI-I-0108]]
+
+## Objective **[REQUIRED]**
+
+Surface silent persist failures in the CG runtime as Prometheus counters, then degrade reactor health after a sustained failure streak so operators see the problem on the health endpoint without tailing logs.
+
+Two metrics + one health watchdog:
+- `cloacina_reactor_persist_failures_total{graph,reactor,kind}` — counter. `kind` ∈ `cache`, `dirty`, `seq_queue` (corresponding to the three branches of `persist_reactor_state`).
+- `cloacina_accumulator_persist_failures_total{graph,accumulator,kind}` — counter. `kind` ∈ `checkpoint`, `boundary`, `batch_buffer` (corresponding to `CheckpointHandle::save`, `persist_boundary`, `persist_batch_buffer`).
+- Watchdog: 5 consecutive persist failures on a reactor downgrade `ReactorHealth::Live` (or `Warming`) to `ReactorHealth::Degraded`. Surfaces via `/v1/health/graphs/{name}` (no readiness-probe propagation — that would be too aggressive for a transient DB blip).
+
+Replaces the `let _ = persist_*` patterns flagged as OPS-15 in the May 2026 review.
+
+## Backlog Item Details **[CONDITIONAL: Backlog Item]**
+
+{Delete this section when task is assigned to an initiative}
+
+### Type
+- [ ] Bug - Production issue that needs fixing
+- [ ] Feature - New functionality or enhancement
+- [ ] Tech Debt - Code improvement or refactoring
+- [ ] Chore - Maintenance or setup work
+
+### Priority
+- [ ] P0 - Critical (blocks users/revenue)
+- [ ] P1 - High (important for user experience)
+- [ ] P2 - Medium (nice to have)
+- [ ] P3 - Low (when time permits)
+
+### Impact Assessment **[CONDITIONAL: Bug]**
+- **Affected Users**: {Number/percentage of users affected}
+- **Reproduction Steps**:
+  1. {Step 1}
+  2. {Step 2}
+  3. {Step 3}
+- **Expected vs Actual**: {What should happen vs what happens}
+
+### Business Justification **[CONDITIONAL: Feature]**
+- **User Value**: {Why users need this}
+- **Business Value**: {Impact on metrics/revenue}
+- **Effort Estimate**: {Rough size - S/M/L/XL}
+
+### Technical Debt Impact **[CONDITIONAL: Tech Debt]**
+- **Current Problems**: {What's difficult/slow/buggy now}
+- **Benefits of Fixing**: {What improves after refactoring}
+- **Risk Assessment**: {Risks of not addressing this}
+
+## Acceptance Criteria
+
+## Acceptance Criteria
+
+## Acceptance Criteria **[REQUIRED]**
+
+- [ ] `cloacina_reactor_persist_failures_total` increments on every failed `persist_reactor_state` branch (cache / dirty / seq_queue).
+- [ ] `cloacina_accumulator_persist_failures_total` increments on every failed `CheckpointHandle::save`, `persist_boundary`, `persist_batch_buffer`.
+- [ ] A reactor whose persist fails 5 times in a row transitions to `ReactorHealth::Degraded` and reports that state via `/v1/health/graphs/{name}`.
+- [ ] On the next successful persist, the failure streak resets to 0 and the reactor can transition back to `Live` via the existing health state machine.
+- [ ] Both metrics registered with `describe_counter!` in `crates/cloacina-server/src/lib.rs`.
+- [ ] `docs/operations/metrics.md` updated with both rows and a PromQL example for "graphs in degraded state".
+- [ ] Promtool format check passes; new unit test asserts each `kind` label round-trips through /metrics.
+
+## Implementation Notes
+
+- Failure streak is reactor-level (one counter per reactor), not per-kind — operators want to know "is this reactor stuck?" not "is its cache branch stuck specifically?".
+- The streak counter lives on `RunningGraph` alongside the existing `failure_counts: HashMap<String, u32>`. Reuse that map with a new key like `format!("{}::persist", graph_name)`.
+- `ReactorHealth::Degraded { disconnected: Vec<String> }` already carries a payload — reuse it with `disconnected = vec!["persist".to_string()]` so the health surface explains *why* degraded.
+- Reset on success: every `persist_*` success path resets the streak counter to 0.
+
+## Test Cases **[CONDITIONAL: Testing Task]**
+
+{Delete unless this is a testing task}
+
+### Test Case 1: {Test Case Name}
+- **Test ID**: TC-001
+- **Preconditions**: {What must be true before testing}
+- **Steps**:
+  1. {Step 1}
+  2. {Step 2}
+  3. {Step 3}
+- **Expected Results**: {What should happen}
+- **Actual Results**: {To be filled during execution}
+- **Status**: {Pass/Fail/Blocked}
+
+### Test Case 2: {Test Case Name}
+- **Test ID**: TC-002
+- **Preconditions**: {What must be true before testing}
+- **Steps**:
+  1. {Step 1}
+  2. {Step 2}
+- **Expected Results**: {What should happen}
+- **Actual Results**: {To be filled during execution}
+- **Status**: {Pass/Fail/Blocked}
+
+## Documentation Sections **[CONDITIONAL: Documentation Task]**
+
+{Delete unless this is a documentation task}
+
+### User Guide Content
+- **Feature Description**: {What this feature does and why it's useful}
+- **Prerequisites**: {What users need before using this feature}
+- **Step-by-Step Instructions**:
+  1. {Step 1 with screenshots/examples}
+  2. {Step 2 with screenshots/examples}
+  3. {Step 3 with screenshots/examples}
+
+### Troubleshooting Guide
+- **Common Issue 1**: {Problem description and solution}
+- **Common Issue 2**: {Problem description and solution}
+- **Error Messages**: {List of error messages and what they mean}
+
+### API Documentation **[CONDITIONAL: API Documentation]**
+- **Endpoint**: {API endpoint description}
+- **Parameters**: {Required and optional parameters}
+- **Example Request**: {Code example}
+- **Example Response**: {Expected response format}
+
+## Implementation Notes **[CONDITIONAL: Technical Task]**
+
+{Keep for technical tasks, delete for non-technical. Technical details, approach, or important considerations}
+
+### Technical Approach
+{How this will be implemented}
+
+### Dependencies
+{Other tasks or systems this depends on}
+
+### Risk Considerations
+{Technical risks and mitigation strategies}
+
+## Status Updates **[REQUIRED]**
+
+### 2026-05-14 — implemented
+
+- `cloacina_reactor_persist_failures_total{graph,reactor,kind}` emitted at every failure branch in `persist_reactor_state`. **Note on kind values**: the spec listed `cache | dirty | seq_queue` but `save_reactor_state` is a single atomic DAL call bundling all three — so the bounded `kind` actually shipped is `cache_serialize | dirty_serialize | seq_serialize | save`. Each kind attributes the failure to which step blew up; documented in metrics.md.
+- `cloacina_accumulator_persist_failures_total{graph,accumulator,kind}` emitted at the three accumulator persist paths: `checkpoint` (polling-runtime `handle.save`), `boundary` (`persist_boundary` — serialize + DAL save), `batch_buffer` (`persist_batch_buffer`).
+- **Watchdog**: `persist_streak: Arc<AtomicU32>` captured by the reactor executor. On any persist failure the streak increments; reaching `PERSIST_FAILURE_DEGRADE_THRESHOLD=5` sends `ReactorHealth::Degraded { disconnected: vec!["persist"] }` via the existing health channel — surfaces on `/v1/health/graphs/{name}` because the response already projects ReactorHealth. Next successful persist resets the streak and sends `Live`. (Diverged from the AC note about `RunningGraph::failure_counts` — that map is owned by the supervisor on a separate task, so an atomic captured inside the reactor task itself is the simpler lock-free path.)
+- Both metrics registered with `describe_counter!` in `crates/cloacina-server/src/lib.rs`.
+- Unit test `test_persist_failure_metrics_emit` covers all four reactor kinds + all three accumulator kinds via direct emit + /metrics scrape.
+- Cardinality guard (`test_i0099_cardinality_within_ceiling`) extended to emit + verify both new metrics — they're held to the same ≤ 64 ceiling as the rest of the I-0099 surface.
+- `docs/operations/metrics.md`: rows added for both metrics + a PromQL example "Graphs currently in Degraded state" that uses the existing `cloacina_component_health` gauge to surface stuck reactors.

--- a/crates/cloacina-server/src/lib.rs
+++ b/crates/cloacina-server/src/lib.rs
@@ -407,6 +407,21 @@ pub async fn run(
          `ticket_expired`, `invalid_signature`, `tenant_mismatch`, \
          `not_authorized`."
     );
+    metrics::describe_counter!(
+        "cloacina_reactor_persist_failures_total",
+        "Total `persist_reactor_state` failures, broken down by branch. \
+         `kind` ∈ `cache_serialize`, `dirty_serialize`, `seq_serialize`, \
+         `save`. The reactor downgrades to `ReactorHealth::Degraded` after \
+         5 consecutive failures (any kind) and recovers on the next success. \
+         See CLOACI-I-0108 / T-0590."
+    );
+    metrics::describe_counter!(
+        "cloacina_accumulator_persist_failures_total",
+        "Total accumulator persist failures, broken down by call site. \
+         `kind` ∈ `checkpoint` (polling-accumulator save), `boundary` \
+         (persist_boundary), `batch_buffer` (batch accumulator buffer save). \
+         Replaces the silent `let _ = persist_*` patterns flagged as OPS-15."
+    );
 
     // Connect to Postgres with DB-backed registry (so uploaded packages get compiled + loaded)
     let mut runner_builder = DefaultRunnerConfig::builder();
@@ -1534,6 +1549,80 @@ mod tests {
         }
     }
 
+    #[tokio::test]
+    #[serial]
+    async fn test_persist_failure_metrics_emit() {
+        let state = test_state().await;
+
+        for kind in [
+            "cache_serialize",
+            "dirty_serialize",
+            "seq_serialize",
+            "save",
+        ] {
+            metrics::counter!(
+                "cloacina_reactor_persist_failures_total",
+                "graph" => "test_graph",
+                "reactor" => "test_reactor",
+                "kind" => kind,
+            )
+            .increment(1);
+        }
+        for kind in ["checkpoint", "boundary", "batch_buffer"] {
+            metrics::counter!(
+                "cloacina_accumulator_persist_failures_total",
+                "graph" => "test_graph",
+                "accumulator" => "acc0",
+                "kind" => kind,
+            )
+            .increment(1);
+        }
+
+        let app = build_router(state);
+        let response = app
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/metrics")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .expect("request failed");
+        assert_eq!(response.status(), StatusCode::OK);
+        let body_bytes = response
+            .into_body()
+            .collect()
+            .await
+            .expect("failed to read body")
+            .to_bytes();
+        let text = String::from_utf8_lossy(&body_bytes);
+
+        for kind in [
+            "cache_serialize",
+            "dirty_serialize",
+            "seq_serialize",
+            "save",
+        ] {
+            assert!(
+                text.contains(&format!(
+                    "cloacina_reactor_persist_failures_total{{graph=\"test_graph\",kind=\"{}\"",
+                    kind
+                )) || text.contains(&format!("kind=\"{}\"", kind)),
+                "Missing kind={} in reactor_persist_failures_total. Got:\n{}",
+                kind,
+                text
+            );
+        }
+        for kind in ["checkpoint", "boundary", "batch_buffer"] {
+            assert!(
+                text.contains(&format!("kind=\"{}\"", kind)),
+                "Missing kind={} in accumulator_persist_failures_total. Got:\n{}",
+                kind,
+                text
+            );
+        }
+    }
+
     /// I-0099 cardinality guard — assert that every `cloacina_*` metric
     /// introduced by the initiative stays under a fixed series ceiling.
     ///
@@ -1667,6 +1756,32 @@ mod tests {
             .increment(1);
         }
 
+        // I-0108 persist-failure counters — included so the cardinality
+        // guard covers them as well.
+        for kind in [
+            "cache_serialize",
+            "dirty_serialize",
+            "seq_serialize",
+            "save",
+        ] {
+            metrics::counter!(
+                "cloacina_reactor_persist_failures_total",
+                "graph" => "g0",
+                "reactor" => "r0",
+                "kind" => kind,
+            )
+            .increment(1);
+        }
+        for kind in ["checkpoint", "boundary", "batch_buffer"] {
+            metrics::counter!(
+                "cloacina_accumulator_persist_failures_total",
+                "graph" => "g0",
+                "accumulator" => "acc0",
+                "kind" => kind,
+            )
+            .increment(1);
+        }
+
         // Scrape and parse
         let app = build_router(state);
         let response = app
@@ -1767,6 +1882,8 @@ mod tests {
             "cloacina_ws_connections_active",
             "cloacina_ws_messages_total",
             "cloacina_ws_auth_failures_total",
+            "cloacina_reactor_persist_failures_total",
+            "cloacina_accumulator_persist_failures_total",
         ] {
             assert!(
                 series_count.contains_key(expected),

--- a/crates/cloacina/src/computation_graph/accumulator.rs
+++ b/crates/cloacina/src/computation_graph/accumulator.rs
@@ -563,6 +563,7 @@ pub async fn polling_accumulator_runtime<P: PollingAccumulator>(
                         if let Some(ref handle) = ctx.checkpoint {
                             if let Err(e) = handle.save(&output).await {
                                 tracing::warn!(name = %ctx.name, "polling checkpoint save failed: {}", e);
+                                record_accumulator_persist_failure(&ctx, "checkpoint");
                             }
                         }
                     }
@@ -725,6 +726,7 @@ async fn persist_batch_buffer(ctx: &AccumulatorContext, buffer: &[Vec<u8>]) {
     if let Some(ref handle) = ctx.checkpoint {
         if let Err(e) = handle.save(&buffer.to_vec()).await {
             tracing::warn!(name = %ctx.name, "batch buffer checkpoint failed: {}", e);
+            record_accumulator_persist_failure(ctx, "batch_buffer");
         }
     }
 }
@@ -764,6 +766,20 @@ fn set_health(ctx: &AccumulatorContext, health: AccumulatorHealth) {
     if let Some(ref sender) = ctx.health {
         let _ = sender.send(health);
     }
+}
+
+/// Increment `cloacina_accumulator_persist_failures_total{graph,accumulator,kind}`
+/// with a bounded `kind ∈ {checkpoint, boundary, batch_buffer}` label.
+/// Replaces the silent `let _ = persist_*` failure paths flagged as OPS-15
+/// (CLOACI-I-0108 / T-0590).
+fn record_accumulator_persist_failure(ctx: &AccumulatorContext, kind: &'static str) {
+    metrics::counter!(
+        "cloacina_accumulator_persist_failures_total",
+        "graph" => graph_label(ctx),
+        "accumulator" => ctx.name.clone(),
+        "kind" => kind,
+    )
+    .increment(1);
 }
 
 /// Derive the bounded `graph` metric label for an accumulator. When the
@@ -821,6 +837,7 @@ async fn persist_boundary<T: Serialize>(ctx: &AccumulatorContext, boundary: &T) 
             Ok(b) => b,
             Err(e) => {
                 tracing::warn!(name = %ctx.name, "boundary persistence serialization failed: {}", e);
+                record_accumulator_persist_failure(ctx, "boundary");
                 return;
             }
         };
@@ -841,6 +858,7 @@ async fn persist_boundary<T: Serialize>(ctx: &AccumulatorContext, boundary: &T) 
             }
             Err(e) => {
                 tracing::warn!(name = %ctx.name, "boundary persistence failed: {}", e);
+                record_accumulator_persist_failure(ctx, "boundary");
             }
         }
     }

--- a/crates/cloacina/src/computation_graph/reactor.rs
+++ b/crates/cloacina/src/computation_graph/reactor.rs
@@ -622,6 +622,10 @@ impl Reactor {
         let graph_name_exec = self.graph_name.clone();
         let batch_flush = self.batch_flush_senders.clone();
         let fire_counter = Arc::new(std::sync::atomic::AtomicU64::new(0));
+        // Consecutive persist failures — drives the I-0108 / T-0590
+        // watchdog that flips the reactor to `Degraded` after 5 in a row.
+        let persist_streak = Arc::new(std::sync::atomic::AtomicU32::new(0));
+        let health_exec = self.health.clone();
 
         loop {
             tokio::select! {
@@ -663,6 +667,7 @@ impl Reactor {
                                         tracing::info!(graph = %graph_name_exec, fires, "graph execution completed");
                                         persist_reactor_state(
                                             &dal_exec, &graph_name_exec, &cache_exec, &dirty_exec, None,
+                                            &persist_streak, &health_exec,
                                         ).await;
                                         for sender in &batch_flush {
                                             let _ = sender.try_send(());
@@ -682,6 +687,7 @@ impl Reactor {
                             persist_reactor_state(
                                 &dal_exec, &graph_name_exec, &cache_exec, &dirty_exec,
                                 Some(&seq_queue_exec),
+                                &persist_streak, &health_exec,
                             ).await;
                             // Drain the queue — one execution per queued boundary
                             loop {
@@ -712,6 +718,7 @@ impl Reactor {
                                                 persist_reactor_state(
                                                     &dal_exec, &graph_name_exec, &cache_exec,
                                                     &dirty_exec, Some(&seq_queue_exec),
+                                                    &persist_streak, &health_exec,
                                                 ).await;
                                                 // Signal batch accumulators to flush
                                                 for sender in &batch_flush {
@@ -735,6 +742,7 @@ impl Reactor {
                     persist_reactor_state(
                         &dal_exec, &graph_name_exec, &cache_exec, &dirty_exec,
                         Some(&seq_queue_exec),
+                        &persist_streak, &health_exec,
                     ).await;
                     break;
                 }
@@ -746,13 +754,27 @@ impl Reactor {
     }
 }
 
+/// Threshold for the persist-failure watchdog: a reactor whose persist
+/// fails this many times in a row is downgraded to
+/// `ReactorHealth::Degraded`. See CLOACI-I-0108 / T-0590.
+const PERSIST_FAILURE_DEGRADE_THRESHOLD: u32 = 5;
+
 /// Persist reactor state to DAL (best-effort, logs on failure).
+///
+/// Tracks consecutive failures via `persist_streak` and downgrades the
+/// reactor to `ReactorHealth::Degraded` after
+/// `PERSIST_FAILURE_DEGRADE_THRESHOLD` consecutive failures. On the next
+/// successful persist after the threshold has been crossed, the streak is
+/// reset and the reactor reports `Live` again — operators see persist
+/// trouble on `/v1/health/graphs/{name}` without tailing logs.
 async fn persist_reactor_state(
     dal: &Option<crate::dal::unified::DAL>,
     graph_name: &str,
     cache: &Arc<RwLock<InputCache>>,
     dirty: &Arc<RwLock<DirtyFlags>>,
     seq_queue: Option<&SeqQueue>,
+    persist_streak: &Arc<std::sync::atomic::AtomicU32>,
+    health: &Option<watch::Sender<ReactorHealth>>,
 ) {
     let dal = match dal {
         Some(d) if !graph_name.is_empty() => d,
@@ -767,6 +789,7 @@ async fn persist_reactor_state(
         Ok(b) => b,
         Err(e) => {
             tracing::warn!(graph = %graph_name, "cache serialization failed: {}", e);
+            record_reactor_persist_failure(graph_name, "cache_serialize", persist_streak, health);
             return;
         }
     };
@@ -775,6 +798,7 @@ async fn persist_reactor_state(
         Ok(b) => b,
         Err(e) => {
             tracing::warn!(graph = %graph_name, "dirty flags serialization failed: {}", e);
+            record_reactor_persist_failure(graph_name, "dirty_serialize", persist_streak, health);
             return;
         }
     };
@@ -788,6 +812,12 @@ async fn persist_reactor_state(
                 Ok(b) => Some(b),
                 Err(e) => {
                     tracing::warn!(graph = %graph_name, "sequential queue serialization failed: {}", e);
+                    record_reactor_persist_failure(
+                        graph_name,
+                        "seq_serialize",
+                        persist_streak,
+                        health,
+                    );
                     None
                 }
             }
@@ -802,6 +832,52 @@ async fn persist_reactor_state(
         .await
     {
         tracing::warn!(graph = %graph_name, "reactor state persistence failed: {}", e);
+        record_reactor_persist_failure(graph_name, "save", persist_streak, health);
+        return;
+    }
+
+    // Success path — reset streak and recover health if we'd previously
+    // degraded due to persist trouble.
+    let prev = persist_streak.swap(0, std::sync::atomic::Ordering::Relaxed);
+    if prev >= PERSIST_FAILURE_DEGRADE_THRESHOLD {
+        if let Some(ref tx) = health {
+            tracing::info!(graph = %graph_name, "persist recovered after {} failures", prev);
+            let _ = tx.send(ReactorHealth::Live);
+        }
+    }
+}
+
+/// Increment the bounded persist-failures counter for a reactor, bump the
+/// reactor-level streak, and push the reactor to `Degraded` once the
+/// streak crosses [`PERSIST_FAILURE_DEGRADE_THRESHOLD`]. The
+/// `kind ∈ {cache_serialize, dirty_serialize, seq_serialize, save}` label
+/// surface attributes the failure to a specific branch of
+/// [`persist_reactor_state`].
+fn record_reactor_persist_failure(
+    graph_name: &str,
+    kind: &'static str,
+    persist_streak: &Arc<std::sync::atomic::AtomicU32>,
+    health: &Option<watch::Sender<ReactorHealth>>,
+) {
+    metrics::counter!(
+        "cloacina_reactor_persist_failures_total",
+        "graph" => graph_name.to_string(),
+        "reactor" => graph_name.to_string(),
+        "kind" => kind,
+    )
+    .increment(1);
+    let streak = persist_streak.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
+    if streak == PERSIST_FAILURE_DEGRADE_THRESHOLD {
+        if let Some(ref tx) = health {
+            tracing::warn!(
+                graph = %graph_name,
+                streak,
+                "persist failure streak hit threshold — downgrading reactor to Degraded"
+            );
+            let _ = tx.send(ReactorHealth::Degraded {
+                disconnected: vec!["persist".to_string()],
+            });
+        }
     }
 }
 

--- a/crates/cloacina/src/dal/unified/task_execution/queries.rs
+++ b/crates/cloacina/src/dal/unified/task_execution/queries.rs
@@ -159,6 +159,62 @@ impl<'a> TaskExecutionDAL<'a> {
         Ok(tasks.into_iter().map(Into::into).collect())
     }
 
+    /// Count task executions currently in the `Running` state across all
+    /// workflows. Used by the scheduler tick to re-seed
+    /// `cloacina_active_tasks` from SQL, replacing the gauge-leak prone
+    /// increment/decrement pattern (CLOACI-T-0589, mirrors T-0534).
+    pub async fn count_running_tasks(&self) -> Result<i64, ValidationError> {
+        crate::dispatch_backend!(
+            self.dal.backend(),
+            self.count_running_tasks_postgres().await,
+            self.count_running_tasks_sqlite().await
+        )
+    }
+
+    #[cfg(feature = "postgres")]
+    async fn count_running_tasks_postgres(&self) -> Result<i64, ValidationError> {
+        let conn = self
+            .dal
+            .database
+            .get_postgres_connection()
+            .await
+            .map_err(|e| ValidationError::ConnectionPool(e.to_string()))?;
+
+        let n: i64 = conn
+            .interact(move |conn| {
+                task_executions::table
+                    .filter(task_executions::status.eq("Running"))
+                    .count()
+                    .get_result(conn)
+            })
+            .await
+            .map_err(|e| ValidationError::ConnectionPool(e.to_string()))??;
+
+        Ok(n)
+    }
+
+    #[cfg(feature = "sqlite")]
+    async fn count_running_tasks_sqlite(&self) -> Result<i64, ValidationError> {
+        let conn = self
+            .dal
+            .database
+            .get_sqlite_connection()
+            .await
+            .map_err(|e| ValidationError::ConnectionPool(e.to_string()))?;
+
+        let n: i64 = conn
+            .interact(move |conn| {
+                task_executions::table
+                    .filter(task_executions::status.eq("Running"))
+                    .count()
+                    .get_result(conn)
+            })
+            .await
+            .map_err(|e| ValidationError::ConnectionPool(e.to_string()))??;
+
+        Ok(n)
+    }
+
     /// Checks if all tasks in a workflow execution have reached a terminal state.
     pub async fn check_workflow_completion(
         &self,

--- a/crates/cloacina/src/execution_planner/scheduler_loop.rs
+++ b/crates/cloacina/src/execution_planner/scheduler_loop.rs
@@ -163,9 +163,21 @@ impl<'a> SchedulerLoop<'a> {
             .get_active_executions()
             .await?;
 
-        // SQL-derived gauge — re-seeded every tick so it cannot drift on crash,
-        // claim loss, or any path that skips finalize_workflow_execution.
+        // SQL-derived gauges — re-seeded every tick so they cannot drift on
+        // crash, claim loss, or any path that skips
+        // finalize_workflow_execution (workflows) /
+        // `ThreadTaskExecutor::execute_task` (tasks). See T-0534 + T-0589.
         metrics::gauge!("cloacina_active_workflows").set(active_executions.len() as f64);
+        match self.dal.task_execution().count_running_tasks().await {
+            Ok(n) => {
+                metrics::gauge!("cloacina_active_tasks").set(n as f64);
+            }
+            Err(e) => {
+                // Best-effort — leave the previous tick's value rather than
+                // zeroing the gauge on a transient DB hiccup.
+                warn!("failed to count running tasks for gauge re-seed: {}", e);
+            }
+        }
 
         if active_executions.is_empty() {
             // Even with no active workflow executions, dispatch any Ready tasks (e.g., retries)

--- a/crates/cloacina/src/executor/thread_task_executor.rs
+++ b/crates/cloacina/src/executor/thread_task_executor.rs
@@ -849,7 +849,10 @@ impl TaskExecutor for ThreadTaskExecutor {
             }
         };
 
-        metrics::gauge!("cloacina_active_tasks").increment(1.0);
+        // `cloacina_active_tasks` is SQL-derived in the scheduler tick
+        // (see `SchedulerLoop::process_active_executions`); no
+        // increment/decrement here because a panic between the two would
+        // leak the gauge permanently. CLOACI-T-0589 / mirrors T-0534.
 
         // Execute the task — if it requires a handle, wrap execution with
         // task-local storage so the macro-generated code can access it.
@@ -913,7 +916,8 @@ impl TaskExecutor for ThreadTaskExecutor {
         drop(cancel_tx);
         let duration = start.elapsed();
         metrics::histogram!("cloacina_task_duration_seconds").record(duration.as_secs_f64());
-        metrics::gauge!("cloacina_active_tasks").decrement(1.0);
+        // No `cloacina_active_tasks.decrement()` — SQL-derived in the
+        // scheduler tick. See CLOACI-T-0589.
 
         // Stop heartbeat and release claim after execution (success or failure)
         if let Some(handle) = heartbeat_handle {

--- a/docs/operations/metrics.md
+++ b/docs/operations/metrics.md
@@ -33,6 +33,8 @@ used as labels. Adding a new metric should preserve this invariant; see
 | `cloacina_reactor_deduped_events_total` | `graph`, `reactor`, `source` | Boundary events the reactor rejected as duplicates of an already-seen emission sequence. **Reserved** — the reactor-side dedup path lands as a follow-up to T-0413; the metric is registered today so dashboards and alert rules can be authored against the eventual name. |
 | `cloacina_ws_messages_total` | `endpoint`, `direction` | WebSocket framed messages by `endpoint` (`accumulator` | `reactor`) and `direction` (`in` | `out`). Ping/pong handled by axum are excluded. |
 | `cloacina_ws_auth_failures_total` | `reason` | Rejected WebSocket upgrade requests. `reason` ∈ `ticket_expired`, `invalid_signature`, `tenant_mismatch`, `not_authorized`. |
+| `cloacina_reactor_persist_failures_total` | `graph`, `reactor`, `kind` | Reactor state-persistence failures. `kind` ∈ `cache_serialize`, `dirty_serialize`, `seq_serialize`, `save`. The reactor downgrades to `Degraded` after 5 consecutive failures and recovers on the next success. |
+| `cloacina_accumulator_persist_failures_total` | `graph`, `accumulator`, `kind` | Accumulator persist failures. `kind` ∈ `checkpoint` (polling save), `boundary` (persist_boundary), `batch_buffer` (batch buffer save). |
 
 ### Histograms
 
@@ -49,7 +51,7 @@ used as labels. Adding a new metric should preserve this invariant; see
 | Name | Labels | Description |
 |------|--------|-------------|
 | `cloacina_active_workflows` | — | Workflow executions in `Pending` or `Running` state. SQL-derived — re-seeded every scheduler tick from `workflow_executions` row count, so the value is correct by construction across crashes, claim loss, and finalize-path errors. Lags real DB state by at most one scheduler `poll_interval`. |
-| `cloacina_active_tasks` | — | Tasks currently inside the executor's run body. Incremented at the top of `ThreadTaskExecutor::execute_task`, decremented at the bottom; a panic between the two leaks one. |
+| `cloacina_active_tasks` | — | Task executions in the `Running` state. SQL-derived — re-seeded every scheduler tick from a `task_executions WHERE status = 'Running'` count, so the value is correct by construction across crashes, claim loss, and panic-between-inc-and-dec paths. Lags real DB state by at most one scheduler `poll_interval`. |
 | `cloacina_component_health` | `graph`, `component`, `state` | One-of indicator for a computation-graph component's current health. For each `(graph, component)` tuple the gauge is `1` on the current state and `0` on every other state. `state` is bounded: `healthy`, `degraded`, `starting`, `stopped`, `crashed`. Re-emitted every supervisor tick. |
 | `cloacina_accumulator_buffer_depth` | `graph`, `accumulator` | Current internal buffer size for buffered accumulators. Meaningful for `batch` and stateful `stream` kinds; `passthrough` and `polling` emit `0` from runtime startup so dashboards see a stable series per (graph, accumulator). |
 | `cloacina_reactor_cache_age_seconds` | `graph`, `reactor`, `source` | Age in seconds of the most-recent emission per source held in the reactor's input cache. Refreshed on every boundary arrival (all known sources re-emitted, so silent sources show increasing staleness). |
@@ -124,6 +126,18 @@ window.
 
 ```promql
 rate(cloacina_scheduler_stale_claims_swept_total[5m])
+```
+
+### Graphs currently in Degraded state
+
+The supervisor downgrades a reactor to `Degraded` after 5 consecutive
+persist failures (see I-0108 / T-0590) and recovers on the next
+success. This query lists every graph currently reporting Degraded
+health — operators triage by checking the matching `*_persist_failures_total`
+counters by `kind`.
+
+```promql
+cloacina_component_health{component="reactor",state="degraded"} == 1
 ```
 
 ## Current gaps


### PR DESCRIPTION
**Stacked on #97 (I-0099).** Targets `cg-observability-i0099` so the diff shows only the I-0108 delta. Will retarget to `main` automatically once #97 merges.

## Summary

Closes [CLOACI-I-0108](.metis/initiatives/CLOACI-I-0108/initiative.md). Two complementary observability fixes flagged by the May 2026 review:

- **OPS-01 fix**: `cloacina_active_tasks` no longer leaks on panic — gauge is re-seeded from SQL every scheduler tick (mirrors T-0534's fix for `cloacina_active_workflows`).
- **OPS-15 fix**: silent CG persist failures now surface as Prometheus counters, and a reactor whose persist fails 5 times in a row downgrades to `ReactorHealth::Degraded`.

Two tasks bundled per the "one PR per initiative" convention.

## T-0589 — Gauge leak fix

**The bug**: `thread_task_executor::execute_task` ran `cloacina_active_tasks.increment(1.0)` at the top and `.decrement(1.0)` at the bottom. A panic between the two leaked the gauge permanently. The COR-04 cdylib panic vector is one reachable path; production deployments observing the gauge would see slow upward drift.

**The fix**:
- Delete the increment/decrement calls.
- New \`TaskExecutionDAL::count_running_tasks() -> Result<i64>\` doing a simple `SELECT COUNT(*) WHERE status = 'Running'` with the standard postgres/sqlite dispatch.
- `SchedulerLoop::process_active_executions` re-seeds the gauge from that count on every tick, right next to the existing `cloacina_active_workflows` re-seed.
- Failure to count logs a warning and **retains the prior tick's value** rather than zeroing the gauge on a transient DB hiccup.

## T-0590 — CG persist failures + watchdog

### Metrics

| Metric | Labels | Emit sites |
|--------|--------|------------|
| \`cloacina_reactor_persist_failures_total\` | \`graph\`, \`reactor\`, \`kind\` | Every failure branch in `persist_reactor_state` |
| \`cloacina_accumulator_persist_failures_total\` | \`graph\`, \`accumulator\`, \`kind\` | `persist_boundary`, `persist_batch_buffer`, polling-runtime `handle.save` |

**Note on reactor `kind` values**: the original spec listed `cache | dirty | seq_queue`, but `save_reactor_state` is a single atomic DAL call bundling all three. The actually-bounded `kind` shipped here is `cache_serialize | dirty_serialize | seq_serialize | save` — each value attributes the failure to the specific step that blew up rather than implying three independent DAL calls. Documented in metrics.md.

### Watchdog

\`persist_streak: Arc<AtomicU32>\` captured by the reactor executor. On any persist failure the streak increments; reaching the threshold (5, configurable as \`PERSIST_FAILURE_DEGRADE_THRESHOLD\`) sends \`ReactorHealth::Degraded { disconnected: vec!["persist"] }\` via the existing health watch channel.

The next successful persist resets the streak and sends \`Live\` — operators see persist trouble on \`/v1/health/graphs/{name}\` without tailing logs, and recovery is automatic.

**Design divergence from the AC**: the initiative doc suggested using \`RunningGraph::failure_counts\` (the supervisor-owned map) for the streak. That map lives on the supervisor task; the reactor task would need cross-task coordination to read/write it. An atomic captured inside the reactor executor itself is a simpler, lock-free path with identical observable behaviour.

## Test coverage

New \`test_persist_failure_metrics_emit\` in \`crates/cloacina-server/src/lib.rs\` covers all four reactor \`kind\` values + all three accumulator \`kind\` values via direct emit + /metrics scrape.

The I-0099 cardinality guard (\`test_i0099_cardinality_within_ceiling\`) is **extended** to include both new metrics — the same ≤ 64 series ceiling now guards persist-failure counters against future label bloat.

## Files touched

\`\`\`
crates/cloacina/src/dal/unified/task_execution/queries.rs   (count_running_tasks)
crates/cloacina/src/execution_planner/scheduler_loop.rs     (SQL re-seed)
crates/cloacina/src/executor/thread_task_executor.rs        (drop inc/dec)
crates/cloacina/src/computation_graph/reactor.rs            (persist_streak + record_reactor_persist_failure + watchdog)
crates/cloacina/src/computation_graph/accumulator.rs        (record_accumulator_persist_failure at 3 sites)
crates/cloacina-server/src/lib.rs                           (2 describes + unit test + cardinality additions)
docs/operations/metrics.md                                  (rewritten active_tasks row + 2 new rows + 1 new PromQL)
.metis/initiatives/CLOACI-I-0108/                           (initiative + 2 task files, all completed)
\`\`\`

## Test plan

- [ ] \`angreal check crate cloacina\` + \`angreal check crate cloacina-server\`
- [ ] \`angreal test unit\` — new test + extended cardinality guard pass
- [ ] \`angreal test metrics-format\` — promtool format check still clean
- [ ] \`angreal lint all\`

## Follow-ups (not in this PR)

- Threshold tuning (5 was the doc default; revisit after baseline failure-rate data from a soak run).
- Per-kind streak observability (e.g. \`cloacina_reactor_persist_streak\` gauge) if operators want to dashboard the streak directly.