### PR TITLE
T-0608: substitute sqlite :memory: for tempfile + re-enable tutorials 03/04 on postgres

### DIFF
--- a/.github/workflows/examples-docs.yml
+++ b/.github/workflows/examples-docs.yml
@@ -219,17 +219,14 @@ jobs:
           - tutorial: "02"
             backend: postgres
           # Tutorials 03 + 04 hardcode `sqlite://:memory:` regardless of
-          # the --backend flag, so the postgres lane was running the same
-          # in-memory sqlite path twice. After I-0100 added reactor-poll
-          # ticks to the unified scheduler, that path also started racing
-          # with migrations under sqlite's pool-of-1 (`no such table:
-          # workflow_executions`). Sqlite lane covers them; postgres lane
-          # is redundant and flaky. Re-enable once the tutorials honor the
-          # backend flag (or move to a configurable URL).
-          # - tutorial: "03"
-          #   backend: postgres
-          # - tutorial: "04"
-          #   backend: postgres
+          # the --backend flag. After CLOACI-T-0608 fixed the sqlite
+          # `:memory:` → tempfile substitution, the postgres lane works
+          # again (it still exercises the in-memory sqlite path, but the
+          # tempfile-backed shared DB no longer races with migrations).
+          - tutorial: "03"
+            backend: postgres
+          - tutorial: "04"
+            backend: postgres
           - tutorial: "05"
             backend: postgres
           - tutorial: "06"

--- a/.metis/backlog/bugs/CLOACI-T-0608.md
+++ b/.metis/backlog/bugs/CLOACI-T-0608.md
@@ -4,15 +4,15 @@ level: task
 title: "Fix sqlite :memory: + I-0100 reactor poll race; re-enable tutorials 03/04 on postgres lane"
 short_code: "CLOACI-T-0608"
 created_at: 2026-05-16T00:53:30.076692+00:00
-updated_at: 2026-05-16T00:53:30.076692+00:00
+updated_at: 2026-05-16T03:47:49.299900+00:00
 parent: 
 blocked_by: []
 archived: false
 
 tags:
   - "#task"
-  - "#phase/backlog"
   - "#bug"
+  - "#phase/active"
 
 
 exit_criteria_met: false
@@ -72,4 +72,24 @@ Tutorials 03 and 04 are excluded from the postgres lane in
 
 ## Status Updates
 
-*To be added during implementation*
+**2026-05-16** — Root-caused: with diesel's sqlite open path (no
+`SQLITE_OPEN_URI`), every `:memory:` connection gets its own private
+database. `max_size = 1` kept it latent; I-0100's new reactor poll
+loop made concurrent connection-use detectable.
+
+Fix landed: substitute `:memory:` requests for a per-Database
+`NamedTempFile` on disk, wrapped in `Arc` so every Database clone
+keeps the file alive and the last drop deletes it. Pool connections
+all open the same real file → real sharing, no URI gotchas.
+
+`file::memory:?cache=shared` was considered but rejected: it requires
+`SQLITE_OPEN_URI` which diesel doesn't set, so it silently creates a
+file literally named `:memory:` in CWD without any shared cache.
+
+Postgres lane re-enabled for tutorials 03 + 04 in same PR.
+
+Unit tests added:
+- `test_sqlite_connection_strings_passthrough` (file paths + sqlite://
+  prefix stripping)
+- `test_sqlite_memory_substitutes_tempfile` (substitution + cleanup on
+  owner drop, both `:memory:` and `sqlite://:memory:` inputs)

--- a/.metis/backlog/tech-debt/CLOACI-T-0609.md
+++ b/.metis/backlog/tech-debt/CLOACI-T-0609.md
@@ -1,10 +1,10 @@
 ---
-id: move-cloacina-kafka-out-of-default
+id: add-rdkafka-build-deps-to-cloacina
 level: task
 title: "Add rdkafka build deps to cloacina-server Dockerfile (keep kafka as a default capability)"
 short_code: "CLOACI-T-0609"
 created_at: 2026-05-16T00:53:30.076692+00:00
-updated_at: 2026-05-16T03:17:44.987742+00:00
+updated_at: 2026-05-16T03:47:05.859453+00:00
 parent: 
 blocked_by: []
 archived: false
@@ -12,7 +12,7 @@ archived: false
 tags:
   - "#task"
   - "#tech-debt"
-  - "#phase/active"
+  - "#phase/completed"
 
 
 exit_criteria_met: false

--- a/crates/cloacina/src/database/connection/mod.rs
+++ b/crates/cloacina/src/database/connection/mod.rs
@@ -64,6 +64,10 @@ pub use backend::{DbConnection, DbConnectionManager, DbPool};
 #[cfg(all(feature = "sqlite", not(feature = "postgres")))]
 pub use backend::{DbConnection, DbPool};
 
+#[cfg(feature = "sqlite")]
+use std::sync::Arc;
+#[cfg(feature = "sqlite")]
+use tempfile::NamedTempFile;
 use thiserror::Error;
 use tracing::info;
 use url::Url;
@@ -176,6 +180,13 @@ pub struct Database {
     backend: BackendType,
     /// The PostgreSQL schema name for multi-tenant isolation (ignored for SQLite)
     schema: Option<String>,
+    /// Backing tempfile when the user requested `:memory:` (or
+    /// `sqlite://:memory:`). Held via Arc so every Database clone keeps the
+    /// file alive; when the last clone drops, NamedTempFile::Drop deletes
+    /// the file. See `materialize_sqlite_connection` for why we substitute
+    /// a real tempfile for in-memory requests.
+    #[cfg(feature = "sqlite")]
+    _memory_tempfile: Option<Arc<NamedTempFile>>,
 }
 
 impl std::fmt::Debug for Database {
@@ -287,10 +298,13 @@ impl Database {
                     pool: AnyPool::Postgres(pool),
                     backend,
                     schema: validated_schema,
+                    #[cfg(feature = "sqlite")]
+                    _memory_tempfile: None,
                 })
             }
             BackendType::Sqlite => {
-                let connection_url = Self::build_sqlite_url(connection_string);
+                let (connection_url, memory_tempfile) =
+                    Self::materialize_sqlite_connection(connection_string)?;
                 let manager = SqliteManager::new(connection_url, SqliteRuntime::Tokio1);
                 let sqlite_pool_size = 1;
                 let pool = SqlitePool::builder(manager)
@@ -310,6 +324,7 @@ impl Database {
                     pool: AnyPool::Sqlite(pool),
                     backend,
                     schema: validated_schema,
+                    _memory_tempfile: memory_tempfile,
                 })
             }
         }
@@ -338,13 +353,16 @@ impl Database {
                 pool,
                 backend: BackendType::Postgres,
                 schema: validated_schema,
+                #[cfg(feature = "sqlite")]
+                _memory_tempfile: None,
             });
         }
 
         #[cfg(all(feature = "sqlite", not(feature = "postgres")))]
         {
             let _ = backend; // suppress unused warning
-            let connection_url = Self::build_sqlite_url(connection_string);
+            let (connection_url, memory_tempfile) =
+                Self::materialize_sqlite_connection(connection_string)?;
             let manager = SqliteManager::new(connection_url, SqliteRuntime::Tokio1);
             let sqlite_pool_size = 1;
             let pool = SqlitePool::builder(manager)
@@ -364,6 +382,7 @@ impl Database {
                 pool,
                 backend: BackendType::Sqlite,
                 schema: validated_schema,
+                _memory_tempfile: memory_tempfile,
             });
         }
     }
@@ -414,14 +433,58 @@ impl Database {
         Ok(url.to_string())
     }
 
-    /// Builds a SQLite connection URL.
-    fn build_sqlite_url(connection_string: &str) -> String {
-        // Strip sqlite:// prefix if present
-        if let Some(path) = connection_string.strip_prefix("sqlite://") {
-            path.to_string()
-        } else {
-            connection_string.to_string()
+    /// Resolve a SQLite connection string into (url, optional tempfile owner).
+    ///
+    /// `:memory:` (with or without the `sqlite://` prefix) is substituted
+    /// for a per-Database tempfile on disk. This is the only reliable way
+    /// to get multi-connection sharing under diesel — the standard
+    /// `file::memory:?cache=shared` form requires `SQLITE_OPEN_URI`, which
+    /// diesel's open path doesn't set. Without that flag, sqlite silently
+    /// creates a file literally named `:memory:` in CWD and the supposed
+    /// "shared cache" never happens.
+    ///
+    /// The returned `NamedTempFile` must be held for the lifetime of the
+    /// Database (we wrap it in `Arc` and stash it on `Self` so Clone'd
+    /// Databases share ownership and the file is deleted only when the
+    /// last clone drops).
+    ///
+    /// Returns `(url, Some(handle))` for `:memory:` requests; otherwise
+    /// `(url, None)` and the file path passes through unchanged.
+    #[cfg(feature = "sqlite")]
+    fn materialize_sqlite_connection(
+        connection_string: &str,
+    ) -> Result<(String, Option<Arc<NamedTempFile>>), DatabaseError> {
+        let stripped = connection_string
+            .strip_prefix("sqlite://")
+            .unwrap_or(connection_string);
+        if stripped != ":memory:" {
+            return Ok((stripped.to_string(), None));
         }
+
+        // Build a tempfile in the system temp dir. We use NamedTempFile so
+        // the path is stable across pool connection opens. The file gets
+        // unlinked on Drop.
+        let tempfile =
+            NamedTempFile::new().map_err(|e| DatabaseError::PoolCreation {
+                backend: "SQLite",
+                source: Box::new(e),
+            })?;
+        let path = tempfile
+            .path()
+            .to_str()
+            .ok_or_else(|| DatabaseError::PoolCreation {
+                backend: "SQLite",
+                source: Box::new(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "tempfile path is not valid UTF-8",
+                )),
+            })?
+            .to_string();
+        info!(
+            "SQLite `:memory:` substituted with tempfile path '{}' (per-Database, cleaned on drop)",
+            path
+        );
+        Ok((path, Some(Arc::new(tempfile))))
     }
 
     /// Runs pending database migrations for the appropriate backend.
@@ -841,23 +904,53 @@ mod tests {
         assert!(Url::parse("not-a-url").is_err());
     }
 
+    #[cfg(feature = "sqlite")]
     #[test]
-    fn test_sqlite_connection_strings() {
-        // Test file path
-        let url = Database::build_sqlite_url("/path/to/database.db");
+    fn test_sqlite_connection_strings_passthrough() {
+        // Plain file paths pass through unchanged + no tempfile owner.
+        let (url, owner) =
+            Database::materialize_sqlite_connection("/path/to/database.db").unwrap();
         assert_eq!(url, "/path/to/database.db");
+        assert!(owner.is_none());
 
-        // Test in-memory database
-        let url = Database::build_sqlite_url(":memory:");
-        assert_eq!(url, ":memory:");
-
-        // Test relative path
-        let url = Database::build_sqlite_url("./database.db");
+        let (url, owner) =
+            Database::materialize_sqlite_connection("./database.db").unwrap();
         assert_eq!(url, "./database.db");
+        assert!(owner.is_none());
 
-        // Test sqlite:// prefix stripping
-        let url = Database::build_sqlite_url("sqlite:///path/to/db.sqlite");
+        // sqlite:// prefix is stripped.
+        let (url, owner) =
+            Database::materialize_sqlite_connection("sqlite:///path/to/db.sqlite").unwrap();
         assert_eq!(url, "/path/to/db.sqlite");
+        assert!(owner.is_none());
+    }
+
+    #[cfg(feature = "sqlite")]
+    #[test]
+    fn test_sqlite_memory_substitutes_tempfile() {
+        // `:memory:` (with or without prefix) becomes a real tempfile path,
+        // and the NamedTempFile owner is returned so the caller can keep
+        // the file alive for the Database's lifetime.
+        for input in [":memory:", "sqlite://:memory:"] {
+            let (url, owner) = Database::materialize_sqlite_connection(input).unwrap();
+            assert_ne!(url, ":memory:", "input '{}' was not substituted", input);
+            let owner = owner
+                .unwrap_or_else(|| panic!("input '{}' returned no tempfile owner", input));
+            assert!(
+                std::path::Path::new(&url).exists(),
+                "substituted path '{}' for input '{}' does not exist on disk",
+                url,
+                input
+            );
+            // Drop the owner — file should disappear.
+            drop(owner);
+            assert!(
+                !std::path::Path::new(&url).exists(),
+                "tempfile '{}' for input '{}' was not cleaned on owner drop",
+                url,
+                input
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Diesel's sqlite open path doesn't set `SQLITE_OPEN_URI`, so every `:memory:` connection gets its own private in-memory DB. Pool `max_size = 1` kept this latent; I-0100's new reactor-poll loop made the connection-vs-migration race detectable.
- Fix: substitute `:memory:` requests for a per-Database `NamedTempFile` on disk. Arc'd onto the Database struct so every clone keeps the file alive; last drop deletes it. Pool connections all open the same real path → real sharing, no URI gotchas.
- `file::memory:?cache=shared` was considered but rejected — diesel doesn't pass `SQLITE_OPEN_URI`, so it silently creates a file literally named `:memory:` in CWD with no shared cache.

## Verification

- Unit tests: `test_sqlite_connection_strings_passthrough` + `test_sqlite_memory_substitutes_tempfile`
- CI: re-enables tutorials 03 + 04 on the postgres matrix (skipped in `e7f40a7f`); this PR's CI is the integration test

Closes [CLOACI-T-0608](.metis/backlog/bugs/CLOACI-T-0608.md).

## Test plan

- [ ] CI green (cloacina-tests, examples-docs including 03 + 04 postgres)
- [ ] No regression in the existing sqlite lane