### PR TITLE
T-0602: CEL predicate filtering for reactor-triggered workflows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,6 +124,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "antlr4rust"
+version = "0.3.0-rc2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d240d49ee89063f90fa0cb18aead41a5893cd544a1785983dc3bf5c3d5faa58b"
+dependencies = [
+ "better_any",
+ "bit-set",
+ "byteorder",
+ "lazy_static",
+ "murmur3",
+ "once_cell",
+ "parking_lot",
+ "typed-arena",
+ "uuid",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -235,6 +252,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "better_any"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4372b9543397a4b86050cc5e7ee36953edf4bac9518e8a774c2da694977fb6e4"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -242,6 +265,21 @@ checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -328,6 +366,31 @@ checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "shlex",
+]
+
+[[package]]
+name = "cel-interpreter"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a76c07820046cc8239526fceec6df147a979ae48644dbad274fc3ce38ab0973b"
+dependencies = [
+ "cel-parser",
+ "chrono",
+ "nom",
+ "paste",
+ "regex",
+ "serde",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "cel-parser"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "546fb134998490c5c47fc7a29c7535e725d2e403f172040e8f263d0b318bff5f"
+dependencies = [
+ "antlr4rust",
+ "lazy_static",
 ]
 
 [[package]]
@@ -447,6 +510,7 @@ dependencies = [
  "base64",
  "bincode",
  "bzip2 0.4.4",
+ "cel-interpreter",
  "chrono",
  "chrono-tz",
  "cloacina-computation-graph",
@@ -2162,6 +2226,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2188,6 +2258,25 @@ dependencies = [
  "mime",
  "spin",
  "version_check",
+]
+
+[[package]]
+name = "murmur3"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a198f9589efc03f544388dfc4a19fe8af4323662b62f598b8dcfdac62c14771c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -2413,6 +2502,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pem"
@@ -4144,6 +4239,12 @@ dependencies = [
  "sha1",
  "thiserror 2.0.18",
 ]
+
+[[package]]
+name = "typed-arena"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
 name = "typenum"

--- a/crates/cloacina-python/src/bindings/runner.rs
+++ b/crates/cloacina-python/src/bindings/runner.rs
@@ -155,10 +155,12 @@ enum RuntimeMessage {
         >,
     },
     // CLOACI-I-0100 / T-0600 — reactor subscription registration API.
+    // CLOACI-T-0602 added the optional CEL `predicate` field.
     SubscribeWorkflowToReactor {
         reactor: String,
         workflow: String,
         tenant: Option<String>,
+        predicate: Option<String>,
         response_tx: oneshot::Sender<Result<String, cloacina::executor::WorkflowExecutionError>>,
     },
     UnsubscribeWorkflowFromReactor {
@@ -672,12 +674,18 @@ async fn run_event_loop(
                 reactor,
                 workflow,
                 tenant,
+                predicate,
                 response_tx,
             } => {
                 let runner = runner.clone();
                 tokio::spawn(async move {
                     let result = runner
-                        .subscribe_workflow_to_reactor(&reactor, &workflow, tenant.as_deref())
+                        .subscribe_workflow_to_reactor(
+                            &reactor,
+                            &workflow,
+                            tenant.as_deref(),
+                            predicate.as_deref(),
+                        )
                         .await
                         .map(|uuid| uuid.to_string());
                     let _ = response_tx.send(result);
@@ -1212,18 +1220,40 @@ impl PyDefaultRunner {
     /// from the firing.
     ///
     /// Idempotent — calling twice with the same `(reactor, workflow,
-    /// tenant)` returns the existing subscription id.
+    /// tenant)` upserts; a later call's `when` predicate replaces the
+    /// earlier one's.
     ///
     /// # Arguments
     /// * `reactor` - The reactor name.
     /// * `workflow` - The workflow to dispatch on each firing.
     /// * `tenant` - Tenant scope. Defaults to `"public"` if omitted.
-    #[pyo3(signature = (reactor, workflow, tenant=None))]
+    /// * `when` - Optional CEL filter expression (CLOACI-T-0602). When
+    ///   provided, the scheduler evaluates it against the firing payload
+    ///   and only dispatches when it evaluates to true. The watermark
+    ///   still advances when it evaluates to false. Variables available:
+    ///   `payload` (dict, keys are boundary source names), `reactor`
+    ///   (str), `tenant` (str). Invalid CEL is rejected immediately with
+    ///   a ValueError — no row written.
+    ///
+    /// # Examples
+    /// ```python
+    /// # Unfiltered — fires on every firing.
+    /// runner.subscribe_workflow_to_reactor("pricing", "alert")
+    ///
+    /// # Filtered — fires only when the boundary's `quote` source
+    /// # carries a price above $100 in us-east.
+    /// runner.subscribe_workflow_to_reactor(
+    ///     "pricing", "alert",
+    ///     when="payload.quote.price > 100 && payload.quote.region == 'us-east'",
+    /// )
+    /// ```
+    #[pyo3(signature = (reactor, workflow, tenant=None, *, when=None))]
     pub fn subscribe_workflow_to_reactor(
         &self,
         reactor: String,
         workflow: String,
         tenant: Option<String>,
+        when: Option<String>,
         py: Python,
     ) -> PyResult<String> {
         let (response_tx, response_rx) = oneshot::channel();
@@ -1231,6 +1261,7 @@ impl PyDefaultRunner {
             reactor,
             workflow,
             tenant,
+            predicate: when,
             response_tx,
         };
         self.send_and_recv(

--- a/crates/cloacina/Cargo.toml
+++ b/crates/cloacina/Cargo.toml
@@ -81,6 +81,7 @@ pem = { version = "3.0" }
 toml = { version = "0.8" }
 anyhow = { version = "1.0" }
 bincode = { workspace = true }
+cel-interpreter = "0.10"
 
 [dev-dependencies]
 tracing-test = "0.2"

--- a/crates/cloacina/src/cron_trigger_scheduler.rs
+++ b/crates/cloacina/src/cron_trigger_scheduler.rs
@@ -147,7 +147,18 @@ pub struct Scheduler {
     /// Tracks when the `reactor_firings` TTL prune last ran
     /// (CLOACI-I-0100 / T-0601).
     last_reactor_prune: Option<Instant>,
+    /// Per-subscription compiled CEL predicate cache (CLOACI-T-0602).
+    /// Key is the subscription id; value is `(expression_string, program)`
+    /// so we can invalidate on expression-text change without restart.
+    /// Arc<Mutex> for shared interior mutability across Scheduler clones
+    /// (the active poller is single-threaded, but Clone is on the type).
+    predicate_cache: PredicateCache,
 }
+
+/// CLOACI-T-0602 — alias to satisfy clippy::type_complexity on the
+/// Scheduler's predicate cache field.
+type PredicateCache =
+    Arc<parking_lot::Mutex<HashMap<UniversalUuid, (String, Arc<cel_interpreter::Program>)>>>;
 
 impl Scheduler {
     /// Creates a new unified scheduler.
@@ -174,6 +185,7 @@ impl Scheduler {
             last_cron_check: None,
             last_reactor_poll: None,
             last_reactor_prune: None,
+            predicate_cache: Arc::new(parking_lot::Mutex::new(HashMap::new())),
         }
     }
 
@@ -911,6 +923,10 @@ impl Scheduler {
                 ),
             })?;
 
+        // CLOACI-T-0602 — borrow the CEL predicate string (if any) so we
+        // can evaluate it inside the per-firing loop below.
+        let predicate_expr = sub.predicate_expression.as_deref();
+
         for firing in firings {
             // Build the workflow's input context from the firing payload.
             let mut context = Context::<serde_json::Value>::new();
@@ -952,6 +968,64 @@ impl Scheduler {
                 "reactor_fired_at",
                 serde_json::json!(firing.fired_at.0.to_rfc3339()),
             );
+
+            // CLOACI-T-0602 — predicate evaluation. If the subscription
+            // carries a CEL filter, evaluate it now. Skip dispatch when
+            // it's false; advance the watermark either way (the firing
+            // was *seen* even if we decided not to fire). Eval errors are
+            // logged warn and treated as skip — fail-closed semantics
+            // mirror the spec: a broken filter shouldn't fire workflows.
+            if let Some(expr) = predicate_expr {
+                match self.evaluate_predicate(sub.id, expr, &context) {
+                    Ok(true) => {} // proceed to dispatch
+                    Ok(false) => {
+                        debug!(
+                            subscription = %sub.id.0,
+                            firing = %firing.id.0,
+                            "predicate evaluated false; skipping dispatch + advancing watermark",
+                        );
+                        if let Err(e) = self
+                            .dal
+                            .reactor_subscriptions()
+                            .advance_watermark(sub.id.0, firing.fired_at)
+                            .await
+                        {
+                            warn!(
+                                subscription = %sub.id.0,
+                                firing = %firing.id.0,
+                                "watermark advance failed for filtered firing; \
+                                 it may re-evaluate next tick: {}",
+                                e
+                            );
+                            return Ok(());
+                        }
+                        continue;
+                    }
+                    Err(e) => {
+                        warn!(
+                            subscription = %sub.id.0,
+                            firing = %firing.id.0,
+                            "predicate eval error (treating as skip): {}",
+                            e
+                        );
+                        if let Err(e) = self
+                            .dal
+                            .reactor_subscriptions()
+                            .advance_watermark(sub.id.0, firing.fired_at)
+                            .await
+                        {
+                            warn!(
+                                subscription = %sub.id.0,
+                                firing = %firing.id.0,
+                                "watermark advance failed after predicate error: {}",
+                                e
+                            );
+                            return Ok(());
+                        }
+                        continue;
+                    }
+                }
+            }
 
             // Dispatch — fire-and-forget. The poller hands off the
             // workflow and moves on; failures are surfaced via the
@@ -1002,6 +1076,51 @@ impl Scheduler {
         }
 
         Ok(())
+    }
+
+    /// Evaluate a CEL predicate for a subscription firing
+    /// (CLOACI-T-0602).
+    ///
+    /// Compiles `expr` on first sight per subscription id and caches
+    /// the `Program` for future firings. If the expression text changes
+    /// (subscriber re-subscribes with a different `when=`), the cache
+    /// entry is invalidated by comparing the stored expression string.
+    ///
+    /// Returns:
+    /// - `Ok(true)`  — predicate fired, dispatch should proceed.
+    /// - `Ok(false)` — predicate did not fire, skip + advance watermark.
+    /// - `Err(_)`    — compile error or runtime evaluation error.
+    ///   Caller treats as skip per the fail-closed contract.
+    ///
+    /// Variables exposed to the CEL expression:
+    /// - `payload`  — a map keyed by boundary source name, values are
+    ///   the JSON-decoded payloads (or hex strings for non-JSON bytes).
+    /// - `reactor`  — the reactor name (string).
+    /// - `tenant`   — the tenant id (string).
+    fn evaluate_predicate(
+        &self,
+        sub_id: UniversalUuid,
+        expr: &str,
+        context: &Context<serde_json::Value>,
+    ) -> Result<bool, String> {
+        // Cache lookup. Re-compile only when the stored expression
+        // string doesn't match — handles "subscriber upserted with a
+        // new `when=`" without an explicit invalidation API.
+        let program = {
+            let mut cache = self.predicate_cache.lock();
+            match cache.get(&sub_id) {
+                Some((cached_expr, prog)) if cached_expr == expr => prog.clone(),
+                _ => {
+                    let prog = Arc::new(
+                        cel_interpreter::Program::compile(expr)
+                            .map_err(|e| format!("compile error: {}", e))?,
+                    );
+                    cache.insert(sub_id, (expr.to_string(), prog.clone()));
+                    prog
+                }
+            }
+        };
+        eval_cel_predicate_program(&program, context)
     }
 
     /// TTL prune of `reactor_firings` (CLOACI-I-0100 / T-0601).
@@ -1091,6 +1210,43 @@ impl Scheduler {
             info!("Enabled trigger '{}'", trigger_name);
         }
         Ok(())
+    }
+}
+
+/// Evaluate a compiled CEL `Program` against a workflow context, returning
+/// the boolean result. CLOACI-T-0602 helper, factored so the cache + pure
+/// evaluation logic can be tested independently.
+fn eval_cel_predicate_program(
+    program: &cel_interpreter::Program,
+    context: &Context<serde_json::Value>,
+) -> Result<bool, String> {
+    use cel_interpreter::{Context as CelContext, Value as CelValue};
+
+    let mut cel_ctx = CelContext::default();
+    let mut payload = serde_json::Map::new();
+    for (k, v) in context.data().iter() {
+        if k == "reactor_name" || k == "reactor_firing_id" || k == "reactor_fired_at" {
+            continue;
+        }
+        payload.insert(k.clone(), v.clone());
+    }
+    cel_ctx
+        .add_variable("payload", serde_json::Value::Object(payload))
+        .map_err(|e| format!("cel add_variable(payload): {}", e))?;
+    cel_ctx
+        .add_variable(
+            "reactor",
+            context.get("reactor_name").cloned().unwrap_or_default(),
+        )
+        .map_err(|e| format!("cel add_variable(reactor): {}", e))?;
+    cel_ctx
+        .add_variable("tenant", serde_json::Value::String(String::new()))
+        .map_err(|e| format!("cel add_variable(tenant): {}", e))?;
+
+    match program.execute(&cel_ctx) {
+        Ok(CelValue::Bool(b)) => Ok(b),
+        Ok(other) => Err(format!("predicate must evaluate to bool, got {:?}", other)),
+        Err(e) => Err(format!("eval error: {}", e)),
     }
 }
 
@@ -1406,5 +1562,72 @@ mod tests {
         let mut schedule = create_test_trigger_schedule("queue_trigger");
         schedule.allow_concurrent = None;
         assert!(!schedule.allows_concurrent());
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // CLOACI-T-0602 — CEL predicate evaluation
+    // ─────────────────────────────────────────────────────────────────
+
+    fn ctx_with_payload(items: &[(&str, serde_json::Value)]) -> Context<serde_json::Value> {
+        let mut c = Context::<serde_json::Value>::new();
+        for (k, v) in items {
+            c.insert(*k, v.clone()).unwrap();
+        }
+        c
+    }
+
+    #[test]
+    fn cel_predicate_true_when_payload_matches() {
+        let prog = cel_interpreter::Program::compile(
+            "payload.quote.price > 100 && payload.quote.region == 'us-east'",
+        )
+        .unwrap();
+        let ctx = ctx_with_payload(&[(
+            "quote",
+            serde_json::json!({"price": 150, "region": "us-east"}),
+        )]);
+        assert!(eval_cel_predicate_program(&prog, &ctx).unwrap());
+    }
+
+    #[test]
+    fn cel_predicate_false_when_payload_does_not_match() {
+        let prog = cel_interpreter::Program::compile("payload.quote.price > 100").unwrap();
+        let ctx = ctx_with_payload(&[("quote", serde_json::json!({"price": 50}))]);
+        assert!(!eval_cel_predicate_program(&prog, &ctx).unwrap());
+    }
+
+    #[test]
+    fn cel_predicate_skips_bookkeeping_keys_from_payload() {
+        // reactor_name / reactor_firing_id / reactor_fired_at are
+        // exposed at the top level (`reactor`, no payload access), NOT
+        // under `payload.*`. Predicate using `payload.reactor_name`
+        // should not see anything.
+        let prog = cel_interpreter::Program::compile("has(payload.reactor_name)").unwrap();
+        let mut ctx = ctx_with_payload(&[("quote", serde_json::json!({"price": 50}))]);
+        ctx.insert("reactor_name", serde_json::json!("pricing"))
+            .unwrap();
+        // With the bookkeeping keys stripped, payload.reactor_name
+        // doesn't exist → has() returns false.
+        assert!(!eval_cel_predicate_program(&prog, &ctx).unwrap());
+    }
+
+    #[test]
+    fn cel_predicate_non_bool_result_is_error() {
+        let prog = cel_interpreter::Program::compile("payload.quote.price").unwrap();
+        let ctx = ctx_with_payload(&[("quote", serde_json::json!({"price": 50}))]);
+        let err = eval_cel_predicate_program(&prog, &ctx).unwrap_err();
+        assert!(
+            err.contains("must evaluate to bool"),
+            "expected bool-type error, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn cel_compile_rejects_malformed_expressions() {
+        // Smoke that the upstream compile fails on garbage — this is
+        // what `ReactorSubscriptionsDAL::subscribe` relies on to reject
+        // bad predicates before the row is written.
+        assert!(cel_interpreter::Program::compile("this is &&& not valid").is_err());
     }
 }

--- a/crates/cloacina/src/dal/unified/reactor_subscriptions.rs
+++ b/crates/cloacina/src/dal/unified/reactor_subscriptions.rs
@@ -63,6 +63,11 @@ pub struct ReactorSubscription {
     pub last_seen_fired_at: Option<UniversalTimestamp>,
     pub created_at: UniversalTimestamp,
     pub updated_at: UniversalTimestamp,
+    /// CLOACI-T-0602 — optional CEL filter expression. When `Some`, the
+    /// scheduler evaluates it against the firing payload before dispatch;
+    /// `Some(_) && false` means "skip + advance watermark". `None`
+    /// preserves the original unfiltered behavior (fire on every firing).
+    pub predicate_expression: Option<String>,
 }
 
 /// Data access layer for reactor subscriptions + firings.
@@ -318,18 +323,35 @@ impl<'a> ReactorSubscriptionsDAL<'a> {
     // ─────────────────────────────────────────────────────────────────
 
     /// Create a subscription. Idempotent: calling twice with the same
-    /// `(reactor, workflow, tenant)` returns the existing row's id
-    /// without error.
+    /// `(reactor, workflow, tenant)` upserts; the second call's
+    /// `predicate` (if any) replaces the first one's.
+    ///
+    /// `predicate` is an optional CEL expression (CLOACI-T-0602). When
+    /// `Some(_)`, the expression is compiled at subscribe time and any
+    /// syntax error is returned as a `ValidationError` before the row is
+    /// written, so a bad expression never lands in the DB. The scheduler
+    /// re-compiles + caches at dispatch time.
     pub async fn subscribe(
         &self,
         reactor: &str,
         workflow: &str,
         tenant: &str,
+        predicate: Option<&str>,
     ) -> Result<Uuid, ValidationError> {
+        if let Some(expr) = predicate {
+            // Compile-time validation: reject malformed expressions before
+            // they reach the DB. Cheap (single parse), centralizes the
+            // error message at the API boundary.
+            cel_interpreter::Program::compile(expr)
+                .map_err(|e| ValidationError::InvalidPredicate(e.to_string()))?;
+        }
+        let predicate = predicate.map(str::to_string);
         crate::dispatch_backend!(
             self.dal.backend(),
-            self.subscribe_postgres(reactor, workflow, tenant).await,
-            self.subscribe_sqlite(reactor, workflow, tenant).await
+            self.subscribe_postgres(reactor, workflow, tenant, predicate.clone())
+                .await,
+            self.subscribe_sqlite(reactor, workflow, tenant, predicate)
+                .await
         )
     }
 
@@ -339,6 +361,7 @@ impl<'a> ReactorSubscriptionsDAL<'a> {
         reactor: &str,
         workflow: &str,
         tenant: &str,
+        predicate: Option<String>,
     ) -> Result<Uuid, ValidationError> {
         let conn = self
             .dal
@@ -351,6 +374,7 @@ impl<'a> ReactorSubscriptionsDAL<'a> {
         let reactor = reactor.to_string();
         let workflow = workflow.to_string();
         let tenant = tenant.to_string();
+        let predicate_for_update = predicate.clone();
         let row: ReactorSubscription = conn
             .interact(move |conn| {
                 diesel::insert_into(reactor_trigger_subscriptions::table)
@@ -362,6 +386,7 @@ impl<'a> ReactorSubscriptionsDAL<'a> {
                         reactor_trigger_subscriptions::enabled.eq(UniversalBool::from(true)),
                         reactor_trigger_subscriptions::created_at.eq(now),
                         reactor_trigger_subscriptions::updated_at.eq(now),
+                        reactor_trigger_subscriptions::predicate_expression.eq(&predicate),
                     ))
                     .on_conflict((
                         reactor_trigger_subscriptions::reactor_name,
@@ -369,7 +394,11 @@ impl<'a> ReactorSubscriptionsDAL<'a> {
                         reactor_trigger_subscriptions::tenant_id,
                     ))
                     .do_update()
-                    .set(reactor_trigger_subscriptions::updated_at.eq(now))
+                    .set((
+                        reactor_trigger_subscriptions::updated_at.eq(now),
+                        reactor_trigger_subscriptions::predicate_expression
+                            .eq(&predicate_for_update),
+                    ))
                     .get_result::<ReactorSubscription>(conn)
             })
             .await
@@ -383,6 +412,7 @@ impl<'a> ReactorSubscriptionsDAL<'a> {
         reactor: &str,
         workflow: &str,
         tenant: &str,
+        predicate: Option<String>,
     ) -> Result<Uuid, ValidationError> {
         let conn = self
             .dal
@@ -397,7 +427,8 @@ impl<'a> ReactorSubscriptionsDAL<'a> {
         let tenant = tenant.to_string();
         let row: ReactorSubscription = conn
             .interact(move |conn| {
-                // SQLite: try insert; on conflict, look up the existing row.
+                // SQLite: try insert; on conflict, update predicate +
+                // updated_at and re-read.
                 let insert_result = diesel::insert_into(reactor_trigger_subscriptions::table)
                     .values((
                         reactor_trigger_subscriptions::id.eq(new_id),
@@ -407,6 +438,7 @@ impl<'a> ReactorSubscriptionsDAL<'a> {
                         reactor_trigger_subscriptions::enabled.eq(UniversalBool::from(true)),
                         reactor_trigger_subscriptions::created_at.eq(now),
                         reactor_trigger_subscriptions::updated_at.eq(now),
+                        reactor_trigger_subscriptions::predicate_expression.eq(&predicate),
                     ))
                     .execute(conn);
                 match insert_result {
@@ -416,11 +448,26 @@ impl<'a> ReactorSubscriptionsDAL<'a> {
                     Err(diesel::result::Error::DatabaseError(
                         diesel::result::DatabaseErrorKind::UniqueViolation,
                         _,
-                    )) => reactor_trigger_subscriptions::table
-                        .filter(reactor_trigger_subscriptions::reactor_name.eq(&reactor))
-                        .filter(reactor_trigger_subscriptions::workflow_name.eq(&workflow))
-                        .filter(reactor_trigger_subscriptions::tenant_id.eq(&tenant))
-                        .first::<ReactorSubscription>(conn),
+                    )) => {
+                        // Existing row — overwrite predicate so the
+                        // upsert semantics match postgres.
+                        diesel::update(
+                            reactor_trigger_subscriptions::table
+                                .filter(reactor_trigger_subscriptions::reactor_name.eq(&reactor))
+                                .filter(reactor_trigger_subscriptions::workflow_name.eq(&workflow))
+                                .filter(reactor_trigger_subscriptions::tenant_id.eq(&tenant)),
+                        )
+                        .set((
+                            reactor_trigger_subscriptions::updated_at.eq(now),
+                            reactor_trigger_subscriptions::predicate_expression.eq(&predicate),
+                        ))
+                        .execute(conn)?;
+                        reactor_trigger_subscriptions::table
+                            .filter(reactor_trigger_subscriptions::reactor_name.eq(&reactor))
+                            .filter(reactor_trigger_subscriptions::workflow_name.eq(&workflow))
+                            .filter(reactor_trigger_subscriptions::tenant_id.eq(&tenant))
+                            .first::<ReactorSubscription>(conn)
+                    }
                     Err(e) => Err(e),
                 }
             })

--- a/crates/cloacina/src/database/migrations/postgres/026_reactor_subscription_predicate/down.sql
+++ b/crates/cloacina/src/database/migrations/postgres/026_reactor_subscription_predicate/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE reactor_trigger_subscriptions
+    DROP COLUMN predicate_expression;

--- a/crates/cloacina/src/database/migrations/postgres/026_reactor_subscription_predicate/up.sql
+++ b/crates/cloacina/src/database/migrations/postgres/026_reactor_subscription_predicate/up.sql
@@ -1,0 +1,7 @@
+-- CLOACI-T-0602 — add CEL predicate to reactor_trigger_subscriptions.
+-- NULL means "fire on every reactor firing" (existing unfiltered behavior).
+-- Non-NULL is a CEL expression evaluated against the firing payload; the
+-- scheduler only dispatches when it evaluates to true. Watermark advance
+-- happens whether or not the firing dispatches.
+ALTER TABLE reactor_trigger_subscriptions
+    ADD COLUMN predicate_expression TEXT NULL;

--- a/crates/cloacina/src/database/migrations/sqlite/023_reactor_subscription_predicate/down.sql
+++ b/crates/cloacina/src/database/migrations/sqlite/023_reactor_subscription_predicate/down.sql
@@ -1,0 +1,7 @@
+-- SQLite ALTER TABLE DROP COLUMN was added in 3.35 (2021) but our
+-- bundled libsqlite3-sys may pre-date that on some platforms. The
+-- "rebuild table without the column" dance is the portable form, but
+-- since this column is additive and NULL-tolerant, the safest down
+-- migration is a no-op that documents the situation rather than
+-- risking data on rollback.
+SELECT 'down migration is a no-op — predicate_expression column kept';

--- a/crates/cloacina/src/database/migrations/sqlite/023_reactor_subscription_predicate/up.sql
+++ b/crates/cloacina/src/database/migrations/sqlite/023_reactor_subscription_predicate/up.sql
@@ -1,0 +1,6 @@
+-- CLOACI-T-0602 — add CEL predicate to reactor_trigger_subscriptions.
+-- Mirror of postgres migration 026. ADD COLUMN is the right shape here:
+-- per project convention we avoid DROP+CREATE sqlite migrations, and the
+-- column is genuinely additive (NULL preserves existing behavior).
+ALTER TABLE reactor_trigger_subscriptions
+    ADD COLUMN predicate_expression TEXT NULL;

--- a/crates/cloacina/src/database/schema.rs
+++ b/crates/cloacina/src/database/schema.rs
@@ -408,6 +408,10 @@ mod unified_schema {
             last_seen_fired_at -> Nullable<DbTimestamp>,
             created_at -> DbTimestamp,
             updated_at -> DbTimestamp,
+            // CLOACI-T-0602 — optional CEL filter. NULL means "fire on
+            // every firing"; non-NULL is evaluated against the firing
+            // payload before dispatch.
+            predicate_expression -> Nullable<Text>,
         }
     }
 

--- a/crates/cloacina/src/error.rs
+++ b/crates/cloacina/src/error.rs
@@ -216,6 +216,11 @@ pub enum ValidationError {
     #[error("Invalid trigger rule format: {0}")]
     InvalidTriggerRule(String),
 
+    /// CLOACI-T-0602 — caller passed a CEL expression to
+    /// `subscribe_workflow_to_reactor` that fails to compile.
+    #[error("Invalid predicate expression: {0}")]
+    InvalidPredicate(String),
+
     #[error("Invalid task name format: {0}")]
     InvalidTaskName(String),
 

--- a/crates/cloacina/src/runner/default_runner/reactor_subscriptions_api.rs
+++ b/crates/cloacina/src/runner/default_runner/reactor_subscriptions_api.rs
@@ -43,23 +43,46 @@ impl DefaultRunner {
     /// cache from the firing as its input context.
     ///
     /// Idempotent: calling twice with the same `(reactor, workflow,
-    /// tenant)` returns the existing subscription id without error.
+    /// tenant)` upserts; the later call's predicate (if any) replaces
+    /// the earlier one's.
     ///
     /// # Arguments
     /// * `reactor` - The reactor name (matches `reactor_name` on
     ///   loaded CG declarations).
     /// * `workflow` - The workflow to dispatch.
     /// * `tenant` - Tenant scope. `None` ⇒ `"public"`.
+    /// * `predicate` - Optional CEL filter expression (CLOACI-T-0602).
+    ///   `None` keeps the original fire-on-every-firing behaviour. When
+    ///   `Some(_)`, the expression is compiled at subscribe time;
+    ///   invalid CEL is rejected with `ExecutionFailed` before any DB
+    ///   write. At dispatch time the scheduler evaluates it against the
+    ///   firing payload and skips dispatch when it returns false (the
+    ///   watermark still advances). Variables available in the
+    ///   expression: `payload` (the deserialised boundary cache, keys
+    ///   are source names), `reactor` (string), `tenant` (string).
+    ///
+    /// # Examples
+    /// ```ignore
+    /// // Fire on every firing — original behaviour.
+    /// runner.subscribe_workflow_to_reactor("pricing", "alert", None, None).await?;
+    ///
+    /// // Fire only when payload.price > 100 in the us-east region.
+    /// runner.subscribe_workflow_to_reactor(
+    ///     "pricing", "alert", None,
+    ///     Some("payload.price > 100 && payload.region == 'us-east'"),
+    /// ).await?;
+    /// ```
     pub async fn subscribe_workflow_to_reactor(
         &self,
         reactor: &str,
         workflow: &str,
         tenant: Option<&str>,
+        predicate: Option<&str>,
     ) -> Result<Uuid, WorkflowExecutionError> {
         let tenant = tenant.unwrap_or(DEFAULT_TENANT);
         let dal = DAL::new(self.database.clone());
         dal.reactor_subscriptions()
-            .subscribe(reactor, workflow, tenant)
+            .subscribe(reactor, workflow, tenant, predicate)
             .await
             .map_err(|e| WorkflowExecutionError::ExecutionFailed {
                 message: format!(

--- a/crates/cloacina/tests/integration/dal/reactor_subscriptions.rs
+++ b/crates/cloacina/tests/integration/dal/reactor_subscriptions.rs
@@ -47,7 +47,7 @@ async fn test_firing_round_trip_and_watermark_advance() {
 
     // Subscribe.
     let sub_id = api
-        .subscribe(&reactor, &workflow, &tenant)
+        .subscribe(&reactor, &workflow, &tenant, None)
         .await
         .expect("subscribe");
 
@@ -113,11 +113,11 @@ async fn test_fan_out_two_subscriptions_independent() {
     let reactor = "rt_fan_out".to_string();
 
     let sub_a = api
-        .subscribe(&reactor, "wf_a", &tenant)
+        .subscribe(&reactor, "wf_a", &tenant, None)
         .await
         .expect("subscribe a");
     let sub_b = api
-        .subscribe(&reactor, "wf_b", &tenant)
+        .subscribe(&reactor, "wf_b", &tenant, None)
         .await
         .expect("subscribe b");
     assert_ne!(
@@ -177,11 +177,11 @@ async fn test_tenant_isolation_on_poll() {
     let reactor = "rt_tenancy".to_string();
 
     let _sub_a = api
-        .subscribe(&reactor, "wf", &tenant_a)
+        .subscribe(&reactor, "wf", &tenant_a, None)
         .await
         .expect("subscribe a");
     let _sub_b = api
-        .subscribe(&reactor, "wf", &tenant_b)
+        .subscribe(&reactor, "wf", &tenant_b, None)
         .await
         .expect("subscribe b");
 
@@ -229,7 +229,7 @@ async fn test_at_least_once_on_crash_simulates_redelivery() {
     let tenant = format!("tenant-{}", uuid::Uuid::new_v4());
     let reactor = "rt_at_least_once".to_string();
     let _sub_id = api
-        .subscribe(&reactor, "wf", &tenant)
+        .subscribe(&reactor, "wf", &tenant, None)
         .await
         .expect("subscribe");
 
@@ -271,7 +271,7 @@ async fn test_ttl_prune_removes_old_firings_and_documents_gotcha() {
     let tenant = format!("tenant-{}", uuid::Uuid::new_v4());
     let reactor = "rt_ttl".to_string();
     let _sub_id = api
-        .subscribe(&reactor, "wf", &tenant)
+        .subscribe(&reactor, "wf", &tenant, None)
         .await
         .expect("subscribe");
 
@@ -326,11 +326,11 @@ async fn test_subscribe_is_idempotent() {
     let reactor = "rt_idempotent".to_string();
 
     let id1 = api
-        .subscribe(&reactor, "wf", &tenant)
+        .subscribe(&reactor, "wf", &tenant, None)
         .await
         .expect("first subscribe");
     let id2 = api
-        .subscribe(&reactor, "wf", &tenant)
+        .subscribe(&reactor, "wf", &tenant, None)
         .await
         .expect("second subscribe");
     assert_eq!(id1, id2, "duplicate subscribe must return the existing id");
@@ -341,4 +341,108 @@ async fn test_subscribe_is_idempotent() {
         .filter(|s| s.reactor_name == reactor && s.workflow_name == "wf")
         .collect();
     assert_eq!(matching.len(), 1, "exactly one row for the (r,w,t) triple");
+}
+
+// ─────────────────────────────────────────────────────────────────
+// CLOACI-T-0602 — predicate persistence + validation
+// ─────────────────────────────────────────────────────────────────
+
+/// Bad CEL is rejected at subscribe time, before any DB row is written.
+#[tokio::test]
+#[serial]
+async fn test_subscribe_rejects_invalid_cel_predicate() {
+    let fixture = get_or_init_fixture().await;
+    let fixture = fixture.lock().unwrap();
+    let dal = fixture.get_dal();
+    let api = dal.reactor_subscriptions();
+
+    let tenant = format!("tenant-{}", uuid::Uuid::new_v4());
+    let reactor = "rt_bad_cel".to_string();
+
+    let err = api
+        .subscribe(&reactor, "wf", &tenant, Some("this is &&& not valid"))
+        .await
+        .expect_err("compile-invalid CEL must reject subscribe");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("predicate") || msg.contains("Invalid"),
+        "error should mention predicate/invalid, got: {}",
+        msg
+    );
+
+    // No subscription was created.
+    let listed = api.list_subscriptions(&tenant).await.expect("list");
+    assert!(
+        listed.iter().all(|s| s.reactor_name != reactor),
+        "no row should have been written"
+    );
+}
+
+/// Valid CEL persists, and re-subscribe upserts the predicate so the
+/// row reflects the *latest* call's expression.
+#[tokio::test]
+#[serial]
+async fn test_subscribe_persists_predicate_and_upserts_on_re_subscribe() {
+    let fixture = get_or_init_fixture().await;
+    let fixture = fixture.lock().unwrap();
+    let dal = fixture.get_dal();
+    let api = dal.reactor_subscriptions();
+
+    let tenant = format!("tenant-{}", uuid::Uuid::new_v4());
+    let reactor = "rt_predicate_persist".to_string();
+
+    // First subscribe: simple predicate.
+    let id1 = api
+        .subscribe(&reactor, "wf", &tenant, Some("payload.x > 0"))
+        .await
+        .expect("first subscribe");
+
+    let listed = api.list_subscriptions(&tenant).await.expect("list");
+    let row = listed
+        .iter()
+        .find(|s| s.reactor_name == reactor && s.workflow_name == "wf")
+        .expect("row exists");
+    assert_eq!(
+        row.predicate_expression.as_deref(),
+        Some("payload.x > 0"),
+        "first predicate persists"
+    );
+
+    // Re-subscribe with a different predicate (same triple, upsert).
+    let id2 = api
+        .subscribe(
+            &reactor,
+            "wf",
+            &tenant,
+            Some("payload.x > 100 && payload.region == 'us-east'"),
+        )
+        .await
+        .expect("upsert subscribe");
+    assert_eq!(id1, id2, "upsert returns existing subscription id");
+
+    let listed = api.list_subscriptions(&tenant).await.expect("list");
+    let row = listed
+        .iter()
+        .find(|s| s.reactor_name == reactor && s.workflow_name == "wf")
+        .expect("row still exists");
+    assert_eq!(
+        row.predicate_expression.as_deref(),
+        Some("payload.x > 100 && payload.region == 'us-east'"),
+        "upsert replaces predicate text"
+    );
+
+    // Re-subscribe with None — clears the predicate back to unfiltered.
+    let _ = api
+        .subscribe(&reactor, "wf", &tenant, None)
+        .await
+        .expect("clear predicate");
+    let listed = api.list_subscriptions(&tenant).await.expect("list");
+    let row = listed
+        .iter()
+        .find(|s| s.reactor_name == reactor && s.workflow_name == "wf")
+        .expect("row still exists after None upsert");
+    assert_eq!(
+        row.predicate_expression, None,
+        "None argument clears the predicate"
+    );
 }

--- a/docs/content/computation-graphs/how-to-guides/reactor-triggered-workflows.md
+++ b/docs/content/computation-graphs/how-to-guides/reactor-triggered-workflows.md
@@ -86,7 +86,12 @@ use cloacina::DefaultRunner;
 let runner = DefaultRunner::new(&database_url).await?;
 
 let sub_id = runner
-    .subscribe_workflow_to_reactor("pricing_reactor", "incident_response", Some("acme"))
+    .subscribe_workflow_to_reactor(
+        "pricing_reactor",
+        "incident_response",
+        Some("acme"),
+        None,            // no predicate → fire on every firing
+    )
     .await?;
 
 let subs = runner
@@ -95,8 +100,57 @@ let subs = runner
 ```
 
 `subscribe_workflow_to_reactor` is **idempotent** on the
-`(reactor, workflow, tenant)` triple — calling it twice returns the same
-subscription id without duplicating the row.
+`(reactor, workflow, tenant)` triple — calling it twice upserts; the
+later call's predicate (if any) replaces the earlier one's.
+
+## Filtering firings with CEL (T-0602)
+
+Reactors typically fire much more often than you want to dispatch a
+workflow. Pass a [CEL](https://github.com/google/cel-spec) expression as
+the optional `when` / fourth argument; the scheduler evaluates it against
+the firing payload and only dispatches when it returns `true`. The
+watermark advances whether or not the firing dispatches, so a "rejected"
+firing won't be re-evaluated.
+
+Variables available in the expression:
+
+| Variable   | Meaning                                                      |
+|------------|--------------------------------------------------------------|
+| `payload`  | Map keyed by boundary source name; values are JSON-decoded   |
+| `reactor`  | The reactor name (string)                                    |
+| `tenant`   | The tenant id (string)                                       |
+
+```python
+# Fire only when the latest quote's price > 100 in us-east.
+runner.subscribe_workflow_to_reactor(
+    "pricing_reactor",
+    "incident_response",
+    tenant="acme",
+    when="payload.quote.price > 100 && payload.quote.region == 'us-east'",
+)
+```
+
+```rust
+runner
+    .subscribe_workflow_to_reactor(
+        "pricing_reactor",
+        "incident_response",
+        Some("acme"),
+        Some("payload.quote.price > 100 && payload.quote.region == 'us-east'"),
+    )
+    .await?;
+```
+
+The expression is compiled at subscribe time; malformed CEL is rejected
+immediately with `InvalidPredicate` / `ValueError` — no row is written.
+At dispatch time the scheduler caches the compiled program per
+subscription, so the only per-firing cost is evaluation (microseconds).
+
+**Filter exception semantics.** If the predicate evaluates to something
+other than `bool` or the runtime hits an error, the scheduler treats it
+as `false`: the firing is **not** dispatched and the watermark advances.
+Fail-closed by design — a broken filter doesn't fire workflows
+indefinitely.
 
 ## Input context for the dispatched workflow
 


### PR DESCRIPTION
## Summary

Adds optional CEL predicates to reactor subscriptions so high-throughput reactors can filter firings at the scheduler tick instead of dispatching a workflow per firing.

- DAL: `subscribe(reactor, workflow, tenant, predicate: Option<&str>)` — compile-validated at the API boundary, persisted via migration 026 (postgres) / 023 (sqlite) as an additive `predicate_expression TEXT NULL` column
- Scheduler: per-subscription compiled `Program` cache keyed by (subscription_id, expression). Evaluates against the firing payload; true → dispatch, false → skip + advance watermark, error → warn + skip (fail-closed)
- Runner + Python: optional `predicate` / keyword `when` parameter on `subscribe_workflow_to_reactor`
- Docs: extends the reactor how-to with the CEL section and variable table

## Why CEL (not a Python callback or workflow-as-filter)

- High firing rates: CEL stays in Rust, no GIL acquire on the scheduler tick, no workflow_execution row per filtered-out firing
- Restart-safe: the expression lives in the DB with the subscription
- Expressive enough for the common case (`payload.x > 100 && payload.region == 'us-east'`); a Python-callable escape hatch can be filed later if we hit a real ceiling

## Tests

- 5 unit tests covering the pure CEL eval helper (true/false/bookkeeping-keys/non-bool-error/compile-rejection)
- 2 new integration tests covering DAL contract (reject bad CEL pre-write; persist + upsert + clear-with-None)
- Existing 8 DAL integration tests adjusted for the new `subscribe(..., None)` signature

Closes [CLOACI-T-0602](.metis/archived/initiatives/CLOACI-I-0100/tasks/CLOACI-T-0602.md).

## Test plan

- [ ] CI green
- [ ] DAL integration tests pass on both backends
- [ ] Smoke: subscribe with valid CEL persists; bad CEL is rejected pre-write