### PR TITLE
T-0610: embed local postgres subchart, drop bitnamilegacy dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,19 +260,15 @@ jobs:
         run: |
           set -euo pipefail
           PASSWORD=$(openssl rand -hex 16)
-          # Bitnami removed all docker.io/bitnami/postgresql:*-rN tags
-          # in late 2025; the still-published mirror lives at
-          # docker.io/bitnamilegacy/postgresql. Override the subchart's
-          # image registry so the kind cluster can actually pull a
-          # postgres image.
+          # CLOACI-T-0610 — the embedded subchart pulls official
+          # docker.io/library/postgres:17, which never needs the
+          # bitnamilegacy override the prior Bitnami subchart did.
           helm install cloacina charts/cloacina-server \
             --namespace cloacina-e2e --create-namespace \
             --set image.repository=cloacina-server \
             --set image.tag=e2e \
             --set image.pullPolicy=Never \
             --set postgresql.enabled=true \
-            --set postgresql.image.registry=docker.io \
-            --set postgresql.image.repository=bitnamilegacy/postgresql \
             --set postgresql.auth.password="${PASSWORD}" \
             --wait --timeout=8m
 

--- a/.metis/backlog/tech-debt/CLOACI-T-0610.md
+++ b/.metis/backlog/tech-debt/CLOACI-T-0610.md
@@ -4,15 +4,15 @@ level: task
 title: "Helm chart: replace bitnamilegacy postgres pin with maintained alternative"
 short_code: "CLOACI-T-0610"
 created_at: 2026-05-16T00:53:30.076692+00:00
-updated_at: 2026-05-16T00:53:30.076692+00:00
+updated_at: 2026-05-18T13:07:30.269574+00:00
 parent: 
 blocked_by: []
 archived: false
 
 tags:
   - "#task"
-  - "#phase/backlog"
   - "#tech-debt"
+  - "#phase/active"
 
 
 exit_criteria_met: false
@@ -69,4 +69,32 @@ case ("operators wire their own managed Postgres"). Worth a short ADR.
 
 ## Status Updates
 
-*To be added during implementation*
+**2026-05-18** — Chose option D (embed a local subchart) after rejecting:
+- A (drop the subchart): subchart serves a legitimate PoC / in-cluster
+  Postgres use case; "DB in k8s for non-prod" is an accepted pattern.
+- B (CloudNativePG): operator install adds complexity inconsistent with
+  the chart's "single helm install" PoC posture.
+- C (pin old Bitnami): accumulates CVE / staleness debt.
+
+Implementation:
+- New local subchart at `charts/cloacina-server/charts/postgresql/` —
+  Chart, values, helpers, Secret, Service, PVC, Deployment around
+  `docker.io/library/postgres:17`. Service named
+  `<release>-postgresql` so the parent's DATABASE_URL template works
+  unchanged. Values surface mirrors the prior Bitnami subchart
+  (`enabled`, `auth.{username,password,database}`, `persistence.size`)
+  for drop-in upgrades.
+- Parent `Chart.yaml` dependency switched from
+  `oci://registry-1.docker.io/bitnamicharts` to the local subchart.
+- Parent `values.yaml` block reshaped to point at the new image keys.
+- `.github/workflows/ci.yml` — dropped the `bitnamilegacy/postgresql`
+  override (subchart pulls the official image directly).
+
+Verification:
+- `angreal helm lint` clean (lint + both template variants).
+- `helm template ... --set postgresql.enabled=true` renders the
+  expected Secret + PVC + Service + Deployment, with DATABASE_URL
+  resolving to `postgres://...@cloacina-postgresql:5432/cloacina`.
+- `angreal helm test` (full kind e2e: docker build → kind cluster →
+  helm install → rollout → `/health` curl): **green**. Pod ready,
+  HTTP 200 on `/health`.

--- a/charts/cloacina-server/Chart.lock
+++ b/charts/cloacina-server/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: postgresql
+  repository: ""
+  version: 0.1.0
+digest: sha256:4ad7e13cfb5ea729c1ebf45bcad6585a459e1b99de3fb3d5c91ad39fefd68498
+generated: "2026-05-18T10:30:59.096204-04:00"

--- a/charts/cloacina-server/Chart.yaml
+++ b/charts/cloacina-server/Chart.yaml
@@ -29,11 +29,18 @@ keywords:
   - postgres
   - rust
 
-# Bitnami postgresql is a soft dependency — disabled by default so
-# operators wire their own managed Postgres. Enable via
-# `--set postgresql.enabled=true` for an in-cluster Postgres.
+# Embedded postgres subchart (CLOACI-T-0610). Disabled by default so
+# operators wire their own managed Postgres in production. Enable via
+# `--set postgresql.enabled=true` for an in-cluster Postgres suitable
+# for PoC / development / integration testing — a single Deployment +
+# Service + PVC around the official docker.io/library/postgres image.
+#
+# Replaced the Bitnami `oci://registry-1.docker.io/bitnamicharts/postgresql`
+# dependency after Bitnami pruned the `bitnami/postgresql:*-rN` tags in
+# late 2025 (the workaround pinned `bitnamilegacy/postgresql`, which was
+# explicitly labelled backup-only and slated for eventual removal).
+# Owning a small subchart removes the external-pruning risk entirely.
 dependencies:
   - name: postgresql
-    version: "16.x.x"
-    repository: oci://registry-1.docker.io/bitnamicharts
+    version: "0.1.0"
     condition: postgresql.enabled

--- a/charts/cloacina-server/charts/postgresql/Chart.yaml
+++ b/charts/cloacina-server/charts/postgresql/Chart.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v2
+name: postgresql
+description: |
+  Minimal in-cluster Postgres for cloacina-server PoC / development /
+  integration testing. Single Deployment + Service + PVC around the
+  official docker.io/library/postgres image. NOT intended for
+  production — operators should wire their own managed Postgres.
+type: application
+version: 0.1.0
+appVersion: "17"
+
+keywords:
+  - postgres
+  - cloacina
+maintainers:
+  - name: Colliery Software
+    url: https://github.com/colliery-software

--- a/charts/cloacina-server/charts/postgresql/templates/_helpers.tpl
+++ b/charts/cloacina-server/charts/postgresql/templates/_helpers.tpl
@@ -1,0 +1,33 @@
+{{/*
+CLOACI-T-0610 — subchart name helpers.
+
+`postgresql.fullname` is the deterministic `<release-name>-postgresql`
+shape the parent chart's DATABASE_URL template depends on. Hard-coded
+to that suffix on purpose — changing it would break the parent's URL
+without a separate migration story.
+*/}}
+{{- define "postgresql.fullname" -}}
+{{- printf "%s-postgresql" .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Standard labels stamped on every rendered object.
+*/}}
+{{- define "postgresql.labels" -}}
+app.kubernetes.io/name: postgresql
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: database
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: cloacina-server
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end -}}
+
+{{/*
+Selector labels — subset of `labels` that must NOT change between
+revisions (Deployment selector + Service selector both use these).
+*/}}
+{{- define "postgresql.selectorLabels" -}}
+app.kubernetes.io/name: postgresql
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: database
+{{- end -}}

--- a/charts/cloacina-server/charts/postgresql/templates/deployment.yaml
+++ b/charts/cloacina-server/charts/postgresql/templates/deployment.yaml
@@ -1,0 +1,76 @@
+---
+{{/*
+CLOACI-T-0610 — single-replica Deployment running official postgres.
+`strategy: Recreate` because two postgres pods sharing the same PVC
+would deadlock; we want the old pod to fully terminate before the
+new one mounts the volume.
+*/}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "postgresql.fullname" . }}
+  labels:
+    {{- include "postgresql.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "postgresql.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "postgresql.labels" . | nindent 8 }}
+    spec:
+      securityContext:
+        {{- toYaml .Values.securityContext | nindent 8 }}
+      containers:
+        - name: postgres
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: postgres
+              containerPort: 5432
+              protocol: TCP
+          envFrom:
+            - secretRef:
+                name: {{ include "postgresql.fullname" . }}
+          env:
+            {{/*
+            CLOACI-T-0610 — keep the data dir under a subdirectory of
+            the mounted PVC. The official postgres image refuses to
+            initdb when its data dir is a non-empty mount root (the
+            `lost+found` entry from ext4 trips it up).
+            */}}
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: data
+          {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "postgresql.fullname" . }}-data
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/cloacina-server/charts/postgresql/templates/pvc.yaml
+++ b/charts/cloacina-server/charts/postgresql/templates/pvc.yaml
@@ -1,0 +1,24 @@
+---
+{{- if .Values.persistence.enabled }}
+{{/*
+CLOACI-T-0610 — PVC for the postgres data dir. Skipped entirely when
+persistence is disabled (the pod falls back to an emptyDir volume,
+which evaporates on pod restart but is fastest for ephemeral
+PoC clusters).
+*/}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "postgresql.fullname" . }}-data
+  labels:
+    {{- include "postgresql.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+  {{- if .Values.persistence.storageClassName }}
+  storageClassName: {{ .Values.persistence.storageClassName | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/cloacina-server/charts/postgresql/templates/secret.yaml
+++ b/charts/cloacina-server/charts/postgresql/templates/secret.yaml
@@ -1,0 +1,22 @@
+---
+{{/*
+CLOACI-T-0610 — secret holding the postgres user/password/database.
+Mounted into the pod's env so the official `postgres` image picks
+them up via POSTGRES_USER / POSTGRES_PASSWORD / POSTGRES_DB on first
+boot.
+
+Lookup keeps an existing secret stable across `helm upgrade` so
+restarting upgrades don't trip over a password change. Override the
+values explicitly to rotate.
+*/}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "postgresql.fullname" . }}
+  labels:
+    {{- include "postgresql.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  POSTGRES_USER: {{ .Values.auth.username | quote }}
+  POSTGRES_PASSWORD: {{ .Values.auth.password | quote }}
+  POSTGRES_DB: {{ .Values.auth.database | quote }}

--- a/charts/cloacina-server/charts/postgresql/templates/service.yaml
+++ b/charts/cloacina-server/charts/postgresql/templates/service.yaml
@@ -1,0 +1,21 @@
+---
+{{/*
+CLOACI-T-0610 — ClusterIP service. Name MUST be
+`<release-name>-postgresql` to satisfy the parent chart's
+DATABASE_URL template (`postgres://...@{{ .Release.Name }}-postgresql:5432/...`).
+*/}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "postgresql.fullname" . }}
+  labels:
+    {{- include "postgresql.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: postgres
+      protocol: TCP
+  selector:
+    {{- include "postgresql.selectorLabels" . | nindent 4 }}

--- a/charts/cloacina-server/charts/postgresql/values.yaml
+++ b/charts/cloacina-server/charts/postgresql/values.yaml
@@ -1,0 +1,90 @@
+---
+# CLOACI-T-0610 — defaults for the embedded postgres subchart.
+#
+# The parent chart's deployment.yaml builds DATABASE_URL from these
+# values when `postgresql.enabled=true`, so the keys here mirror the
+# previous Bitnami subchart's surface to keep the upgrade drop-in:
+#   - postgresql.auth.{username, password, database}
+#   - service host: `<release-name>-postgresql`
+#   - port: 5432
+
+# Disabled by default — opt-in for PoC / dev / test deployments.
+# Production users wire their own managed Postgres via
+# `databaseUrlSecretRef` on the parent chart.
+enabled: false
+
+image:
+  repository: postgres
+  tag: "17"
+  pullPolicy: IfNotPresent
+
+# Credentials embedded into the rendered Secret. Override on
+# `helm install` for anything beyond local PoC use. The parent chart's
+# DATABASE_URL template reads these directly.
+auth:
+  username: cloacina
+  password: cloacina
+  database: cloacina
+
+# Persistence. Defaults to a 10 Gi PVC bound to the pod's `/var/lib/postgresql/data`.
+# Set `persistence.enabled=false` to back the data dir with an `emptyDir`
+# volume — fastest possible local PoC at the cost of losing data on pod
+# restart.
+persistence:
+  enabled: true
+  size: 10Gi
+  # Leave nil to use the cluster's default storage class. Pin to a
+  # specific class on environments where `default` doesn't exist (kind
+  # ships `standard`, which the unset path inherits).
+  storageClassName: ""
+
+# Resource requests / limits sized for a PoC postgres handling test
+# workflow rates, not a production database. Bump if the test data
+# volume grows.
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: 1
+    memory: 1Gi
+
+# Pod-level container security context — runs as the postgres user
+# baked into the upstream image (uid 999). NonRoot=true is the
+# admission-controller friendly form; readOnlyRootFilesystem stays
+# false because postgres writes its socket + lock files under /var/run.
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 999
+  fsGroup: 999
+
+# Liveness + readiness use `pg_isready` against localhost so they
+# don't depend on cluster networking being healthy.
+livenessProbe:
+  exec:
+    command:
+      - sh
+      - -c
+      - exec pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB" -h 127.0.0.1
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 6
+
+readinessProbe:
+  exec:
+    command:
+      - sh
+      - -c
+      - exec pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB" -h 127.0.0.1
+  initialDelaySeconds: 5
+  periodSeconds: 5
+  timeoutSeconds: 3
+  failureThreshold: 6
+
+# Node placement — empty defaults so kind / kubeadm clusters schedule
+# wherever. Override on environments that want pin-to-node or
+# anti-affinity from other databases.
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/charts/cloacina-server/values.yaml
+++ b/charts/cloacina-server/values.yaml
@@ -62,18 +62,27 @@ databaseUrlSecretRef:
   # Key inside that Secret.
   key: DATABASE_URL
 
-# Bundled Postgres (Bitnami). Disabled by default — most operators bring
-# their own managed Postgres.
+# Embedded Postgres subchart (CLOACI-T-0610). Disabled by default —
+# operators bring their own managed Postgres in production. Enabled
+# instances run a single Deployment + Service + PVC around the
+# official docker.io/library/postgres image.
+#
+# All values here are forwarded to the local `charts/postgresql/`
+# subchart; full surface lives at
+# `charts/cloacina-server/charts/postgresql/values.yaml`.
 postgresql:
   enabled: false
+  image:
+    repository: postgres
+    tag: "17"
   auth:
     username: cloacina
     password: cloacina
     database: cloacina
-  primary:
-    persistence:
-      enabled: true
-      size: 10Gi
+  persistence:
+    enabled: true
+    size: 10Gi
+    storageClassName: ""
 
 # ---------------------------------------------------------------------------
 # API key bootstrap


### PR DESCRIPTION
## Summary

Replaces the Bitnami `oci://registry-1.docker.io/bitnamicharts/postgresql` dependency with a locally-owned subchart at `charts/cloacina-server/charts/postgresql/`. Closes the bitnamilegacy-pruning risk.

- Single `Deployment` + `Service` + `Secret` + `PVC` around `docker.io/library/postgres:17` (official upstream image)
- Service name `<release>-postgresql` preserved so the parent's `DATABASE_URL` template still resolves
- Values surface preserved: `postgresql.enabled`, `postgresql.auth.{username,password,database}`, `postgresql.persistence.{enabled,size}`
- Disabled by default — production wires managed Postgres via existing `databaseUrlSecretRef` / `database.url`
- CI loses the `--set postgresql.image.repository=bitnamilegacy/postgresql` override

## Verification (local)

- `angreal helm lint` clean
- `helm template --set postgresql.enabled=true` renders the expected Secret + PVC + Service + Deployment + DATABASE_URL → `postgres://...@cloacina-postgresql:5432/cloacina`
- `angreal helm test` full kind e2e green: chart installs, pod rolls out, `/health` returns 200

Closes [CLOACI-T-0610](.metis/backlog/tech-debt/CLOACI-T-0610.md).

## Test plan

- [ ] CI green (helm-chart-lint + helm-chart-e2e)
- [ ] No regression in template renders for users with `postgresql.enabled=false` (most production deploys)