### PR TITLE
docs(fleet): execution-agent fleet Diataxis docs + reference drift (T-0635)

### DIFF
--- a/.metis/initiatives/CLOACI-I-0114/tasks/CLOACI-T-0635.md
+++ b/.metis/initiatives/CLOACI-I-0114/tasks/CLOACI-T-0635.md
@@ -4,14 +4,14 @@ level: task
 title: "Hardening — fleet soak variant, Diataxis docs, optional Helm agent deployment"
 short_code: "CLOACI-T-0635"
 created_at: 2026-05-27T17:36:35.740756+00:00
-updated_at: 2026-05-27T17:36:35.740756+00:00
+updated_at: 2026-06-07T16:51:26.846634+00:00
 parent: CLOACI-I-0114
-blocked_by: ["CLOACI-T-0634"]
+blocked_by: [CLOACI-T-0634]
 archived: false
 
 tags:
   - "#task"
-  - "#phase/todo"
+  - "#phase/active"
 
 
 exit_criteria_met: false
@@ -28,13 +28,15 @@ initiative_id: CLOACI-I-0114
 
 Make the fleet operable and durable over time. Add a sustained-load soak that runs a multi-agent fleet, ship the Diataxis docs for deploying/operating it, and (optionally) add a Helm agent deployment. Soak is first-class here — the prior server soak surfaced executor-deadlock and routing gaps ([[project_soak_test_gaps]]), so we exercise the fleet under sustained load, not just in unit/integration tests.
 
+## Acceptance Criteria
+
 ## Acceptance Criteria **[REQUIRED]**
 
 - [ ] New `angreal test soak` fleet variant: server + N agents under sustained load, watching for roster leaks, stuck in-flight/outbox entries, and reconciliation drift over time.
 - [ ] Soak stable over the target duration with no leaked work, no roster drift, flat outbox depth.
-- [ ] Diataxis docs: how-to (deploy an agent, route a glob to the fleet, operate it), explanation (where the fleet sits in scaling), reference (agent config/flags, metrics).
+- [x] Diataxis docs: how-to (deploy an agent, route a glob to the fleet, operate it), explanation (where the fleet sits in scaling), reference (agent config/flags, metrics). **Done 2026-06-07.**
 - [ ] Optional: Helm chart agent deployment (server in DB trust zone; agents pointed at it with API key + tenant).
-- [ ] Metrics doc updated with fleet/agent + outbox signals; scrape validated.
+- [x] Metrics doc updated with fleet/agent + outbox signals; scrape validated. **Done 2026-06-07** (fleet counters + delivery_outbox gauge in metrics-catalog; Hugo build green).
 
 ## Implementation Notes **[CONDITIONAL: Technical Task]**
 
@@ -50,4 +52,25 @@ Extend the existing soak harness (`angreal test soak server`) to stand up agents
 
 ## Status Updates **[REQUIRED]**
 
-*To be added during implementation*
+### 2026-06-07 — Diataxis fleet docs DONE (soak + helm agent chart still open)
+
+Documented the fleet (I-0114) end to end — it had zero doc coverage. Hugo build
+green (446 pages, no ref errors; `angreal docs build`).
+
+New pages:
+- `explanation/execution-agent-fleet.md` — register → route → claim → deliver →
+  fetch+dlopen → execute → reconcile, dead-agent reclaim, tenant isolation, OQ-6
+  triple/profile match, when to use fleet vs single-DB multi-runner vs
+  in-process, observability.
+- `how-to-guides/deploy-an-execution-agent-fleet.md` — route a glob, run agents,
+  verify, tune liveness, operate.
+
+Reference drift fixed: `reference/cli.md` (server fleet/liveness flags + new
+`## agent` section), `reference/environment-variables.md` (fleet + agent vars +
+summary), `reference/metrics-catalog.md` (`cloacina_fleet_*` +
+`cloacina_delivery_outbox_open`), `explanation/horizontal-scaling.md`
+(See-Also cross-link). (`--context` was already documented; the CLI fix made the
+code match.)
+
+**Still open under T-0635:** fleet soak variant (`angreal test soak` fleet) and
+the optional `charts/cloacina-agent` Helm chart. Docs deliverable complete.

--- a/docs/content/platform/explanation/execution-agent-fleet.md
+++ b/docs/content/platform/explanation/execution-agent-fleet.md
@@ -1,0 +1,142 @@
+---
+title: "Execution-Agent Fleet"
+description: "How Cloacina offloads task execution to a pool of DB-less remote agents — registration, routing, delivery, execution, and dead-agent reclaim"
+weight: 45
+---
+
+## Introduction
+
+[Horizontal Scaling]({{< ref "horizontal-scaling" >}}) explains how multiple
+runner instances share one PostgreSQL database and avoid double-executing a task
+through atomic claiming. That model scales the *control plane*: every runner is a
+full Cloacina instance with a database connection.
+
+The **execution-agent fleet** scales the *data plane* a different way. It moves
+task execution onto a pool of **DB-less** worker processes (`cloacina-agent`)
+that hold no database connection at all. The server stays the single point of
+DB authority; agents are pure executors that fetch compiled workflow code, run a
+task, and report the result. This is the right tool when you want to:
+
+- run task code on machines you don't want to grant database access to,
+- scale execution capacity independently of the server, or
+- isolate heavy or untrusted task execution away from the control plane.
+
+Routing is opt-in and per-task: tasks whose names match a configured glob run on
+the fleet; everything else keeps running in-process on the server's `default`
+executor. You can adopt the fleet for one workflow without changing anything
+else.
+
+## The pieces
+
+| Component | Role |
+|---|---|
+| `cloacina-server` | DB authority. Routes matching tasks to the fleet, selects an agent, pushes work, reconciles results. |
+| `cloacina-agent` | DB-less worker. Registers, fetches the compiled cdylib, executes the task, reports the result. |
+| `cloacina-compiler` | Builds uploaded workflow packages into `.cloacina` cdylibs the agents load. (Unchanged by the fleet.) |
+| `delivery_outbox` | Durable, ack-tracked push queue (the substrate, CLOACI-I-0115) that carries work packets to agents over a WebSocket. |
+
+## How a task reaches an agent
+
+When a fleet-routed task becomes `Ready`, the server's `FleetExecutor` runs the
+following, end to end:
+
+1. **Claim.** The executor atomically claims the task (the same `claim_for_runner`
+   mechanism the in-process executor uses) so exactly one invocation owns it,
+   then marks the workflow execution `Running`. This is what keeps the
+   over-selecting scheduler from dispatching the same task twice.
+2. **Select an agent.** From the in-memory agent roster it picks a *live* agent
+   **in the task's tenant** with spare capacity, greedy on most-free-capacity so
+   load spreads. Tenant scope is load-bearing: an agent only ever receives work
+   for the tenant its API key is scoped to (REQ-008).
+3. **Resolve the artifact.** It looks up the active (built, non-superseded)
+   `.cloacina` cdylib digest for the task's package in that tenant.
+4. **Inline the context.** It builds the merged dependency context with the same
+   `TaskContextBuilder` the in-process path uses, so a fleet-run task sees
+   byte-for-byte the input context it would running locally.
+5. **Enqueue + register a rendezvous.** It registers a one-shot keyed by the
+   `task_execution_id`, then enqueues a **work packet** (task name, context,
+   artifact reference, timeout, tenant) into `delivery_outbox` addressed to the
+   chosen agent and wakes the delivery relay.
+6. **Push.** The relay pushes the work packet over the agent's delivery
+   WebSocket. (A LISTEN/NOTIFY wake keeps same-replica delivery prompt; a
+   safety-net sweeper re-pushes anything that slips through.)
+
+On the agent:
+
+7. **Triple check (fail-closed).** The agent refuses any packet whose artifact
+   was built for a different target triple than its own (OQ-6). The server only
+   selects agents whose triple matches, but the agent enforces it independently.
+8. **Fetch + cache.** It fetches the cdylib by digest over REST (skipped on a
+   cache hit) and `dlopen`s it via [fidius]({{< ref "ffi-system" >}}).
+9. **Execute + report.** It resolves the task in the loaded library, runs it
+   under the packet's timeout with the inlined context, and POSTs the outcome
+   (`Success` / `Failure` / `Refused`) back to the server.
+10. **Reconcile.** The server hands the outcome to the **shared**
+    `TaskResultHandler` — the same code the in-process executor uses — so state
+    writes, retries, and context persistence are identical by construction
+    whether a task ran on the fleet or on the server.
+
+The agent reporting wakes the rendezvous registered in step 5, so the original
+executor invocation resumes and finalizes the task.
+
+> **Wire format follows the build profile.** fidius serializes in JSON for debug
+> builds and bincode for release builds, so an agent must load a cdylib built
+> with the *same* profile it runs. Production images are release builds; build
+> your workflow packages release too.
+
+## Liveness and dead-agent reclaim
+
+Agents send a heartbeat on an interval the server advertises at registration
+(`--agent-heartbeat-interval-s`, default 15s). A background sweeper marks an
+agent **dead** after `--agent-liveness-misses` consecutive missed beats
+(default 3 → ~45s) and then **reclaims its in-flight work**: every non-acked
+`delivery_outbox` row addressed to the dead agent is re-targeted to a live agent
+in the same tenant and reset to `pending`, so the relay re-pushes it.
+
+Because the work keeps its original `task_execution_id`, the executor invocation
+still awaiting that rendezvous receives the new agent's result unchanged — the
+task completes on a survivor with no workflow-level failure. If no live agent is
+available, the rows stay put and the executor's own result-wait timeout drives a
+retry (degraded, not lost).
+
+Two things worth knowing about the recovery characteristics:
+
+- **It is failover, not checkpointing.** The survivor re-runs the task from the
+  start; there is no mid-task resume. Tasks routed to the fleet should be
+  idempotent, like any retryable task.
+- **Detection latency is tunable.** Total time to recover ≈ (dead-after
+  detection) + (re-run). The detection floor is `interval × misses`; lower both
+  for more aggressive failover at the cost of more heartbeat traffic.
+
+## When to use the fleet
+
+| Situation | Use |
+|---|---|
+| Single process, modest load | In-process `default` executor (no fleet). |
+| Scale the control plane; runners may hold DB access | [Multiple runners on one DB]({{< ref "horizontal-scaling" >}}). |
+| Scale execution on workers that must **not** touch the DB, or isolate heavy/untrusted task code | **Execution-agent fleet.** |
+
+The models compose: a server can run some tasks in-process and route others to
+the fleet via per-task globs, and you can run several servers against one DB
+while each fans matching work out to agents.
+
+## Observability
+
+The fleet surfaces itself through the server's `/metrics`:
+
+- `cloacina_fleet_agents_evicted_total` — agents the sweeper declared dead.
+  Sustained non-zero means agents are crashing or losing connectivity.
+- `cloacina_fleet_work_reassigned_total` — in-flight rows reclaimed from dead
+  agents onto survivors.
+- `cloacina_delivery_outbox_open` — depth of the push queue. Sustained growth
+  means delivery is wedged (e.g. no live agent for a recipient).
+
+Agents themselves expose no HTTP surface; observe them via their logs and the
+server-side metrics above. See the [Metrics Catalog]({{< ref "metrics-catalog" >}}).
+
+## See also
+
+- [Deploy an execution-agent fleet]({{< ref "/platform/how-to-guides/deploy-an-execution-agent-fleet" >}}) — the operational how-to.
+- [CLI Reference]({{< ref "/platform/reference/cli" >}}#agent) — `cloacina-agent` flags and the server's fleet/liveness flags.
+- [Horizontal Scaling]({{< ref "horizontal-scaling" >}}) — the single-DB multi-runner model the fleet complements.
+- [FFI System]({{< ref "ffi-system" >}}) — how compiled workflow cdylibs are loaded.

--- a/docs/content/platform/explanation/horizontal-scaling.md
+++ b/docs/content/platform/explanation/horizontal-scaling.md
@@ -422,3 +422,4 @@ All horizontal scaling configuration is set through `DefaultRunnerConfig::builde
 - [Task Execution]({{< relref "task-execution-sequence.md" >}}) -- Task lifecycle and state transitions
 - [Dispatcher Architecture]({{< relref "dispatcher-architecture.md" >}}) -- Routing configuration and pluggable executors
 - [Guaranteed Execution Architecture]({{< relref "guaranteed-execution-architecture.md" >}}) -- Reliability guarantees and recovery mechanisms
+- [Execution-Agent Fleet]({{< relref "execution-agent-fleet.md" >}}) -- Offloading task execution to a pool of DB-less remote agents (complements the single-DB multi-runner model above)

--- a/docs/content/platform/how-to-guides/deploy-an-execution-agent-fleet.md
+++ b/docs/content/platform/how-to-guides/deploy-an-execution-agent-fleet.md
@@ -1,0 +1,148 @@
+---
+title: "Deploy an Execution-Agent Fleet"
+description: "Route tasks to a pool of DB-less cloacina-agent workers: configure routing, run agents, verify, tune liveness, and operate the fleet"
+weight: 58
+---
+
+# Deploy an Execution-Agent Fleet
+
+This guide stands up an [execution-agent fleet]({{< ref "/platform/explanation/execution-agent-fleet" >}}):
+a pool of DB-less `cloacina-agent` workers that the server offloads task
+execution to. For *why* the fleet exists and how it works internally, read the
+explanation; this is the operational path.
+
+## Prerequisites
+
+- A running `cloacina-server` (see [Deploying the API Server]({{< ref "deploying-the-api-server" >}})).
+- A running `cloacina-compiler`, or another way packages get built, so the
+  server has `.cloacina` cdylibs for agents to fetch (see [Running the Compiler]({{< ref "running-the-compiler" >}})).
+- An API key for the tenant whose work the fleet will run. **The agent's API key
+  tenant scope decides which tenants' tasks it may receive** — scope it
+  deliberately.
+- Network reachability: agents must reach the server over HTTP/WebSocket.
+- On each agent host: the shared libraries the compiled workflow cdylibs link
+  (`libpq`, `libpython`, `libssl`, `libsasl2`, …). The published agent image
+  carries these; a hand-rolled host must install them or `dlopen` fails at load.
+
+## 1. Route tasks to the fleet
+
+Routing is opt-in per task, configured on the **`cloacina-server`** binary via
+`--route` / `CLOACINA_FLEET_ROUTES` (the `cloacinactl server start` wrapper does
+not forward it — set it on `cloacina-server` or via the environment):
+
+```bash
+# Route everything to the fleet:
+CLOACINA_FLEET_ROUTES='**=fleet' cloacina-server --bind 0.0.0.0:8080
+
+# Or route only one package's tasks, leaving the rest in-process:
+CLOACINA_FLEET_ROUTES='public::heavy-etl::**=fleet' cloacina-server ...
+```
+
+Rules are `glob=executor_key`, comma-separated or repeated. Task names are
+four segments — `tenant::package::workflow::task` — and the globs follow the
+dispatcher's matcher: `*` matches **within** one `::` segment, `**` matches
+**across** segments. So `**=fleet` matches every task, while `*=fleet` matches
+nothing (a single segment can't span the whole name). Anything that doesn't
+match a rule runs on the in-process `default` executor.
+
+## 2. Run the agents
+
+Each agent is a standalone `cloacina-agent` process. The minimum is a server URL
+and an API key:
+
+```bash
+cloacina-agent \
+  --server http://cloacina-server:8080 \
+  --api-key "$CLOACINA_API_KEY" \
+  --max-concurrency 4
+```
+
+Or with the published image / Kubernetes — run N replicas, all pointed at the
+server, with the key from a secret:
+
+```yaml
+env:
+  - name: CLOACINA_SERVER
+    value: "http://cloacina-server:8080"
+  - name: CLOACINA_API_KEY
+    valueFrom:
+      secretKeyRef: { name: cloacina-agent, key: api-key }
+args: ["--max-concurrency", "4"]
+```
+
+Scale by adding replicas; the server spreads work across live agents greedily by
+free capacity. Useful options (full list in the [CLI reference]({{< ref "/platform/reference/cli" >}}#agent)):
+
+- `--max-concurrency <N>` (default 4) — packets this agent runs at once; a
+  saturated agent refuses further work.
+- `--cache-dir <PATH>` / `CLOACINA_AGENT_CACHE_DIR` — persist the fetched-cdylib
+  cache across restarts to skip re-fetching artifacts.
+- `--capabilities a,b` — advertise free-form tags at registration.
+
+> **Build profile must match.** Agents `dlopen` the compiler's cdylibs, and the
+> fidius wire format depends on the build profile (debug = JSON, release =
+> bincode). Release agents need release-built packages. Production images are
+> release; build your workflow packages release too.
+
+## 3. Verify it's running on the fleet
+
+Upload and run a workflow whose task matches your route, then confirm it
+executed on an agent rather than in-process:
+
+```bash
+cloacinactl package upload my-workflow.cloacina
+cloacinactl workflow run my_workflow            # prints an execution id
+cloacinactl execution status <execution-id>     # -> Completed
+```
+
+Confirm the fleet path (not the `default` executor) handled it:
+
+- **Server log:** `fleet: agent reported; reconciling via shared TaskResultHandler`.
+- **Agent log:** the agent registering the package's cdylib as it loads it.
+- **Metrics:** `/metrics` exposes the `cloacina_fleet_*` and
+  `cloacina_delivery_outbox_open` series.
+
+If the task instead runs on `default`, the route didn't match — re-check the glob
+against the fully-qualified `tenant::package::workflow::task` name.
+
+## 4. Tune failover aggressiveness
+
+Dead-agent detection and in-flight reclaim are governed by two server flags
+(defaults reproduce the prior hard-coded 15s / 45s):
+
+| Flag / env | Default | Effect |
+|---|---|---|
+| `--agent-heartbeat-interval-s` / `CLOACINA_AGENT_HEARTBEAT_INTERVAL_S` | `15` | Heartbeat cadence advertised to agents + the sweep tick. |
+| `--agent-liveness-misses` / `CLOACINA_AGENT_LIVENESS_MISSES` | `3` | Missed beats before an agent is declared dead. |
+
+Effective dead-after = interval × misses. For faster failover (at the cost of
+more heartbeat traffic), e.g. ~10s detection:
+
+```bash
+CLOACINA_AGENT_HEARTBEAT_INTERVAL_S=5 CLOACINA_AGENT_LIVENESS_MISSES=2 cloacina-server ...
+```
+
+## 5. Operate
+
+- **Losing an agent is safe.** When an agent dies, the sweeper reclaims its
+  in-flight work onto a live agent in the same tenant and the task completes
+  there — no workflow-level failure. The work re-runs from the start, so
+  fleet-routed tasks should be idempotent.
+- **Watch these signals:**
+  - `cloacina_delivery_outbox_open` climbing → delivery is wedged (often no live
+    agent for a tenant's work, or agents can't connect).
+  - `cloacina_fleet_agents_evicted_total` rising → agents dying / flapping.
+  - `cloacina_fleet_work_reassigned_total` → how much work crashed agents are
+    shedding onto survivors.
+- **Capacity:** if `delivery_outbox_open` grows under steady load, add agents or
+  raise `--max-concurrency`.
+- **Draining:** to retire an agent gracefully, stop sending it new work by
+  scaling the pool and let it finish in-flight packets; a hard kill is recovered
+  by the reclaim path within the detection window.
+
+## See also
+
+- [Execution-Agent Fleet]({{< ref "/platform/explanation/execution-agent-fleet" >}}) — how it works.
+- [CLI Reference]({{< ref "/platform/reference/cli" >}}#agent) — `cloacina-agent` + server fleet flags.
+- [Environment Variables]({{< ref "/platform/reference/environment-variables" >}}#execution-agent) — agent + fleet env vars.
+- [Metrics Catalog]({{< ref "/platform/reference/metrics-catalog" >}}) — the `cloacina_fleet_*` series.

--- a/docs/content/platform/reference/cli.md
+++ b/docs/content/platform/reference/cli.md
@@ -199,6 +199,16 @@ the multi-tenant cache knobs are exposed via `cloacinactl server start`
 Other runtime-tuning knobs are not surfaced through the wrapper — if
 you need to tune them, invoke `cloacina-server` directly.
 
+### Fleet routing & agent liveness (`cloacina-server`)
+
+These flags configure the [execution-agent fleet]({{< ref "/platform/explanation/execution-agent-fleet" >}}). They live on the `cloacina-server` binary directly (and via the env vars below); the `cloacinactl server start` wrapper does **not** forward them, so set them on `cloacina-server` itself or through the environment.
+
+| Flag | Env Var | Default | Description |
+|---|---|---|---|
+| `--route <GLOB=KEY>` | `CLOACINA_FLEET_ROUTES` | (none) | Task-glob → executor routing rule. Repeatable or comma-separated. A task whose fully-qualified name matches `GLOB` dispatches to executor `KEY` (use `fleet` for the agent fleet); unmatched tasks run on the in-process `default` executor. `*` matches within one `::` segment, `**` across segments — task names are 4-segment (`tenant::package::workflow::task`), so `**=fleet` routes everything. CLOACI-I-0114. |
+| `--agent-heartbeat-interval-s <N>` | `CLOACINA_AGENT_HEARTBEAT_INTERVAL_S` | `15` | Heartbeat interval (seconds) advertised to agents and used as the liveness-sweep cadence. Lower = faster dead-agent detection + in-flight reclaim, more heartbeat traffic. CLOACI-T-0639. |
+| `--agent-liveness-misses <N>` | `CLOACINA_AGENT_LIVENESS_MISSES` | `3` | Consecutive missed heartbeats before an agent is declared dead and its in-flight work reclaimed. Effective dead-after = interval × misses (default 45s). CLOACI-T-0639. |
+
 ### `server stop` / `status` / `health`
 
 Same shape as the daemon equivalents, but use the server's PID file
@@ -232,6 +242,36 @@ cloacinactl compiler start [--bind <ADDR>] [--database-url <URL>]
 `stop` / `status` / `health` follow the same pattern as `server`: PID
 file for stop, HTTP `GET /v1/status` for status, HTTP `GET /health`
 for health.
+
+## `agent`
+
+The execution-agent (`cloacina-agent`) is a **DB-less** worker that joins a
+server's [fleet]({{< ref "/platform/explanation/execution-agent-fleet" >}}). It
+registers over REST, opens the delivery WebSocket, fetches compiled workflow
+cdylibs by digest, executes the task in-process, and reports the result back —
+holding no database connection of its own. It is a standalone binary, not a
+`cloacinactl` subcommand.
+
+```text
+cloacina-agent --server <URL> --api-key <KEY>
+               [--agent-id <ID>] [--max-concurrency <N>]
+               [--capabilities <TAG,TAG>] [--target-triple-override <TRIPLE>]
+               [--cache-dir <PATH>]
+```
+
+| Flag | Env Var | Default | Description |
+|---|---|---|---|
+| `--server <URL>` | `CLOACINA_SERVER` | (required) | Base URL of the server to register with (REST + WS ticket mint). |
+| `--api-key <KEY>` | `CLOACINA_API_KEY` | (required) | API key for REST + WS auth. Its tenant scope determines which tenants' work the agent may receive (REQ-008). |
+| `--agent-id <ID>` | | (server-assigned) | Optional caller-chosen agent id. If omitted, the server assigns one. |
+| `--max-concurrency <N>` | | `4` | Max work packets the agent runs concurrently. The server's capacity-aware selection won't exceed this; a saturated agent refuses further packets. |
+| `--capabilities <TAG,TAG>` | | (none) | Free-form capability tags advertised at registration. |
+| `--target-triple-override <TRIPLE>` | | (host triple) | Override the advertised host target triple. Rarely needed — the server only dispatches a cdylib built for the agent's triple (OQ-6 fail-closed), so this is mainly for testing that path. |
+| `--cache-dir <PATH>` | `CLOACINA_AGENT_CACHE_DIR` | `<TMPDIR>/cloacina-agent-cache` | Where fetched cdylibs are cached by digest; a cache hit skips the REST fetch. |
+
+The agent exposes no HTTP surface of its own — observe it via its logs and the
+server's fleet metrics (`cloacina_fleet_*`). See the how-to guide
+[Deploy an execution-agent fleet]({{< ref "/platform/how-to-guides/deploy-an-execution-agent-fleet" >}}).
 
 ---
 

--- a/docs/content/platform/reference/environment-variables.md
+++ b/docs/content/platform/reference/environment-variables.md
@@ -56,8 +56,27 @@ These are specified via `clap`'s `env = "..."` attribute and can be set as envir
 | `CLOACINA_VERIFICATION_ORG_ID` | `--verification-org-id` | None | Trusted org UUID |
 | `CLOACINA_TENANT_RUNNER_CACHE_SIZE` | `--tenant-runner-cache-size` | `256` | Per-tenant runner cache cap |
 | `CLOACINA_TENANT_DELETION_DRAIN_TIMEOUT_S` | `--tenant-deletion-drain-timeout-s` | `30` | Drain timeout during teardown |
+| `CLOACINA_FLEET_ROUTES` | `--route` | (none) | Task-glob → executor routing rules, comma-separated `glob=executor_key` (e.g. `**=fleet`). Matching tasks dispatch to the [execution-agent fleet]({{< ref "/platform/explanation/execution-agent-fleet" >}}); unmatched tasks run on the in-process `default` executor. CLOACI-I-0114. |
+| `CLOACINA_AGENT_HEARTBEAT_INTERVAL_S` | `--agent-heartbeat-interval-s` | `15` | Heartbeat interval (seconds) the server advertises to fleet agents and uses as its liveness-sweep cadence. Lower = faster dead-agent detection + in-flight reclaim, at the cost of more heartbeat traffic. CLOACI-T-0639. |
+| `CLOACINA_AGENT_LIVENESS_MISSES` | `--agent-liveness-misses` | `3` | Consecutive missed heartbeats before the server marks a fleet agent dead and reclaims its in-flight work. Effective dead-after = interval × misses (default 15s × 3 = 45s). CLOACI-T-0639. |
+
+These three flags are read by the `cloacina-server` binary directly (and via the env vars above); the `cloacinactl server start` wrapper does **not** forward them, so set them on `cloacina-server` itself or through the environment.
 
 The bind address (`--bind`, default `127.0.0.1:8080`), `--reconcile-interval-s`, and `--log-retention-days` are CLI-only and do not have environment variable equivalents.
+
+---
+
+## Execution Agent
+
+The [execution-agent fleet]({{< ref "/platform/explanation/execution-agent-fleet" >}}) (`cloacina-agent`) is a DB-less worker that registers with a server, fetches compiled workflow artifacts, executes tasks, and reports results. It holds **no** database connection; all of its configuration is server + API-key oriented.
+
+| Variable | Purpose | Default | Example | Component | Required |
+|----------|---------|---------|---------|-----------|----------|
+| `CLOACINA_SERVER` | Base URL of the `cloacina-server` the agent registers with (used for both REST and the WebSocket ticket mint). Equivalent to `--server`. | None | `http://cloacina-server:8080` | Agent | Yes |
+| `CLOACINA_API_KEY` | API key the agent authenticates with. Its tenant scope determines which tenants' work the agent may receive (REQ-008 tenant isolation). Equivalent to `--api-key`. | None | `sk-...` | Agent | Yes |
+| `CLOACINA_AGENT_CACHE_DIR` | Directory used to cache fetched workflow cdylibs by digest, so a cache hit skips the REST fetch. Equivalent to `--cache-dir`. | `<TMPDIR>/cloacina-agent-cache` | `/var/lib/cloacina-agent/cache` | Agent | No |
+
+The remaining agent options — `--agent-id`, `--max-concurrency` (default `4`), `--capabilities`, and `--target-triple-override` — are CLI-only; see the [CLI Reference]({{< ref "cli" >}}#agent).
 
 ---
 
@@ -287,6 +306,12 @@ Quick reference of all Cloacina-specific environment variables:
 | `CLOACINA_VERIFICATION_ORG_ID` | Server | Trusted org UUID for signature verification |
 | `CLOACINA_TENANT_RUNNER_CACHE_SIZE` | Server | Per-tenant runner LRU cap |
 | `CLOACINA_TENANT_DELETION_DRAIN_TIMEOUT_S` | Server | Drain timeout during tenant teardown |
+| `CLOACINA_FLEET_ROUTES` | Server | Task-glob → executor routing rules |
+| `CLOACINA_AGENT_HEARTBEAT_INTERVAL_S` | Server | Advertised fleet heartbeat interval + sweep cadence |
+| `CLOACINA_AGENT_LIVENESS_MISSES` | Server | Missed heartbeats before an agent is declared dead |
+| `CLOACINA_SERVER` | Agent | Server base URL the agent registers with |
+| `CLOACINA_API_KEY` | Agent | Agent API key (tenant scope) |
+| `CLOACINA_AGENT_CACHE_DIR` | Agent | Fetched-cdylib cache directory |
 | `CLOACINA_COMPILER_BUILD_TIMEOUT_S` | Compiler | Per-build wall-clock cap |
 | `CLOACINA_COMPILER_VENDOR_DIR` | Compiler | Curated vendored cargo registry path |
 | `CLOACINA_COMPILER_BUILD_RLIMIT_*` | Compiler | Per-build setrlimit caps |

--- a/docs/content/platform/reference/metrics-catalog.md
+++ b/docs/content/platform/reference/metrics-catalog.md
@@ -49,6 +49,8 @@ used as labels. Adding a new metric should preserve this invariant; see
 | `cloacina_reactor_persist_failures_total` | `graph`, `reactor`, `kind` | Reactor state-persistence failures. `kind` ∈ `cache_serialize`, `dirty_serialize`, `seq_serialize`, `save`. The reactor downgrades to `Degraded` after 5 consecutive failures and recovers on the next success. |
 | `cloacina_accumulator_persist_failures_total` | `graph`, `accumulator`, `kind` | Accumulator persist failures. `kind` ∈ `checkpoint` (polling save), `boundary` (persist_boundary), `batch_buffer` (batch buffer save). |
 | `cloacina_context_merge_failures_total` | `kind` | Failures merging dependency contexts. `kind` ∈ `parse` (JSON deserialize failed — fails the task as `ContextLoadFailed`), `merge` (Context API rejected an insert/update; counted but does not fail the task). Closes COR-11. |
+| `cloacina_fleet_agents_evicted_total` | — | Execution-agent fleet: agents removed by the heartbeat sweeper after their heartbeat went stale (older than `--agent-liveness-misses` × the advertised interval). Sustained non-zero means agents are dying or losing connectivity. CLOACI-I-0114 / T-0634. |
+| `cloacina_fleet_work_reassigned_total` | — | Execution-agent fleet: in-flight `delivery_outbox` rows re-targeted from an evicted (dead) agent to a live agent by the sweeper's reclaim path. Tracks how much work crashed agents shed onto the rest of the fleet. CLOACI-T-0634. |
 
 ### Histograms
 
@@ -70,6 +72,7 @@ used as labels. Adding a new metric should preserve this invariant; see
 | `cloacina_accumulator_buffer_depth` | `graph`, `accumulator` | Current internal buffer size for buffered accumulators. Meaningful for `batch` and stateful `stream` kinds; `passthrough` and `polling` emit `0` from runtime startup so dashboards see a stable series per (graph, accumulator). |
 | `cloacina_reactor_cache_age_seconds` | `graph`, `reactor`, `source` | Age in seconds of the most-recent emission per source held in the reactor's input cache. Refreshed on every boundary arrival (all known sources re-emitted, so silent sources show increasing staleness). |
 | `cloacina_ws_connections_active` | `endpoint` | Currently open WebSocket connections. `endpoint` ∈ `accumulator`, `reactor`. RAII-guarded so panics inside the handler still decrement on Drop. |
+| `cloacina_delivery_outbox_open` | — | Current count of non-`acked` rows in `delivery_outbox` (`pending` + `delivered`) — the durable push queue that carries fleet work packets to agents. Sustained growth means delivery is wedged (no live agent for the recipient, or the relay isn't draining). CLOACI-I-0115. |
 
 ## Example PromQL queries
 


### PR DESCRIPTION
Documents the execution-agent fleet (I-0114), which shipped with no doc coverage. Part of T-0635 (the docs deliverable; soak + optional Helm agent chart remain).

## New
- **explanation/execution-agent-fleet** — what the fleet is + the full register → route → claim → deliver → fetch+dlopen → execute → reconcile path, dead-agent reclaim, tenant isolation, OQ-6 triple/profile match, when to use fleet vs single-DB multi-runner vs in-process, observability.
- **how-to-guides/deploy-an-execution-agent-fleet** — route a glob to the fleet, run agents, verify, tune liveness, operate.

## Reference drift fixed
- **cli** — server fleet/liveness flags (`--route`, `--agent-heartbeat-interval-s`, `--agent-liveness-misses`) + a new `cloacina-agent` section.
- **environment-variables** — `CLOACINA_FLEET_ROUTES`, `CLOACINA_AGENT_HEARTBEAT_INTERVAL_S`/`_LIVENESS_MISSES`, and agent vars (`CLOACINA_SERVER`, `CLOACINA_API_KEY`, `CLOACINA_AGENT_CACHE_DIR`).
- **metrics-catalog** — `cloacina_fleet_agents_evicted_total`, `cloacina_fleet_work_reassigned_total`, `cloacina_delivery_outbox_open`.
- **horizontal-scaling** — See-Also cross-link.

`angreal docs build` green (446 pages, no ref errors).