### PR TITLE
feat(fleet): cloacina-agent Helm chart + fleet soak harness (T-0635)

### DIFF
--- a/.angreal/task_helm.py
+++ b/.angreal/task_helm.py
@@ -32,6 +32,7 @@ import angreal  # type: ignore
 
 PROJECT_ROOT = Path(angreal.get_root()).parent
 CHART_DIR = PROJECT_ROOT / "charts" / "cloacina-server"
+AGENT_CHART_DIR = PROJECT_ROOT / "charts" / "cloacina-agent"
 IMAGE_TAG = "cloacina-server:helm-e2e"
 RELEASE_NAME = "cloacina-e2e"
 NAMESPACE = "cloacina-e2e"
@@ -104,7 +105,43 @@ def helm_lint():
         )
         sys.exit(1)
 
-    print("\n✓ helm lint + template variants pass")
+    # ── cloacina-agent chart (CLOACI-T-0635) ───────────────────────────
+    _run(["helm", "lint", str(AGENT_CHART_DIR)])
+
+    # Agent variant 1: inline API key (renders a Secret).
+    _run([
+        "helm", "template", "fleet", str(AGENT_CHART_DIR),
+        "--set", "server.url=http://cloacina-server:8080",
+        "--set", "apiKey=dev-key",
+    ], stdout=subprocess.DEVNULL)
+
+    # Agent variant 2: bring-your-own API-key secret.
+    _run([
+        "helm", "template", "fleet", str(AGENT_CHART_DIR),
+        "--set", "server.url=http://cloacina-server:8080",
+        "--set", "apiKeySecretRef.name=cloacina-agent-key",
+    ], stdout=subprocess.DEVNULL)
+
+    # Agent variant 3: validate fail-fast — must error when unconfigured.
+    rc = subprocess.run(
+        ["helm", "template", "fleet", str(AGENT_CHART_DIR)],
+        capture_output=True, text=True,
+    )
+    if rc.returncode == 0:
+        print(
+            "error: agent helm template should have failed with no server.url/api key",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    if "cloacina-agent:" not in rc.stderr:
+        print(
+            "error: expected cloacina-agent validate message in stderr, got:\n"
+            + rc.stderr,
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    print("\n✓ helm lint + template variants pass (server + agent)")
 
 
 # ---------------------------------------------------------------------------

--- a/.angreal/test/__init__.py
+++ b/.angreal/test/__init__.py
@@ -6,5 +6,5 @@ from . import auth  # noqa: F401
 from . import all  # noqa: F401
 from . import coverage  # noqa: F401
 from . import metrics_format  # noqa: F401
-from .e2e import cli, compiler, fleet, ws  # noqa: F401
-from .soak import daemon, server  # noqa: F401
+from .e2e import cli, compiler, fleet as e2e_fleet, ws  # noqa: F401
+from .soak import daemon, fleet as soak_fleet, server  # noqa: F401

--- a/.angreal/test/soak/fleet.py
+++ b/.angreal/test/soak/fleet.py
@@ -108,6 +108,7 @@ def _run_once(home: Path) -> str | None:
     return tail if len(tail) >= 32 else None
 
 
+@test()
 @soak()
 @angreal.command(
     name="fleet",

--- a/.angreal/test/soak/fleet.py
+++ b/.angreal/test/soak/fleet.py
@@ -25,7 +25,8 @@ Tunable via env (defaults in parens):
   CLOACINA_SOAK_FLEET_DURATION_S        sustained-load seconds (120)
   CLOACINA_SOAK_FLEET_AGENTS            agent count (3)
   CLOACINA_SOAK_FLEET_CONCURRENCY       per-agent max-concurrency (2)
-  CLOACINA_SOAK_FLEET_SUBMIT_INTERVAL_S seconds between submits (0.5)
+  CLOACINA_SOAK_FLEET_SLEEP_S           per-task sleep, i.e. work duration (1)
+  CLOACINA_SOAK_FLEET_TARGET_INFLIGHT   executions kept outstanding (agents×conc×2)
 """
 
 import os
@@ -58,13 +59,25 @@ test = angreal.command_group(
 )
 soak = angreal.command_group(name="soak", about="sustained-load soak tests")
 
-FIXTURE_SRC = "compiler-happy-rust"
-WORKFLOW_NAME = "compiler_happy_workflow"
+# A workload with real per-task duration (sleeps `sleep_seconds`) so tasks are
+# genuinely in-flight concurrently — a noop completes between samples and never
+# loads the fleet. CLOACI-T-0635.
+FIXTURE_SRC = "fleet-slow-rust"
+WORKFLOW_NAME = "fleet_slow_workflow"
 
 DURATION_S = int(os.environ.get("CLOACINA_SOAK_FLEET_DURATION_S", "120"))
 AGENTS = int(os.environ.get("CLOACINA_SOAK_FLEET_AGENTS", "3"))
 CONCURRENCY = int(os.environ.get("CLOACINA_SOAK_FLEET_CONCURRENCY", "2"))
-SUBMIT_INTERVAL_S = float(os.environ.get("CLOACINA_SOAK_FLEET_SUBMIT_INTERVAL_S", "0.5"))
+# Per-task sleep (seconds). Long enough that tasks overlap and saturate the
+# fleet; short enough that the backlog drains quickly at the end.
+SLEEP_SECONDS = int(os.environ.get("CLOACINA_SOAK_FLEET_SLEEP_S", "1"))
+# Keep this many executions outstanding (closed loop) so the fleet stays
+# saturated for the whole run instead of draining between submits. Defaults to
+# 2× total capacity (agents × concurrency) — enough to keep every slot busy
+# plus a small queue, without an ever-growing backlog.
+TARGET_INFLIGHT = int(
+    os.environ.get("CLOACINA_SOAK_FLEET_TARGET_INFLIGHT", str(AGENTS * CONCURRENCY * 2))
+)
 
 
 def _scrape(url: str) -> str:
@@ -96,11 +109,12 @@ def _metric(text: str, name: str, contains: str = None) -> float:
     return total
 
 
-def _run_once(home: Path) -> str | None:
-    """Submit one workflow run; return the execution id (bare `println!` line)
-    or None on a non-zero exit."""
+def _run_once(home: Path, context: str = None) -> str | None:
+    """Submit one workflow run (optionally with a `--context` file); return the
+    execution id (bare `println!` line) or None on a non-zero exit."""
+    extra = ("--context", context) if context else ()
     code, out, _ = _cloacinactl(
-        home, "-o", "json", "workflow", "run", WORKFLOW_NAME, check=False
+        home, "-o", "json", "workflow", "run", WORKFLOW_NAME, *extra, check=False
     )
     if code != 0 or not out.strip():
         return None
@@ -123,8 +137,8 @@ def fleet():
     """Run the execution-agent fleet soak."""
     print_section_header("Execution-Agent Fleet Soak")
     print(
-        f"  config: duration={DURATION_S}s agents={AGENTS} "
-        f"concurrency={CONCURRENCY} submit_interval={SUBMIT_INTERVAL_S}s"
+        f"  config: duration={DURATION_S}s agents={AGENTS} concurrency={CONCURRENCY} "
+        f"sleep={SLEEP_SECONDS}s target_inflight={TARGET_INFLIGHT}"
     )
 
     print_section_header("Build server + compiler + cloacinactl + agent")
@@ -219,36 +233,54 @@ def fleet():
             raise AssertionError("warm-up did not run on the fleet (no agent report)")
         print("  ok: warm-up executed on the fleet")
 
-        # --- sustained load ------------------------------------------------
-        print_section_header(f"Sustained load for {DURATION_S}s")
+        # --- sustained load: closed loop holding ~TARGET_INFLIGHT outstanding
+        # so the fleet stays saturated for the whole run. `outstanding` is
+        # submitted-minus-completed; we refresh `completed` from /metrics every
+        # 2s and submit whenever we're below target. Each task sleeps
+        # SLEEP_SECONDS, so work genuinely overlaps (active_workflows > 0).
+        print_section_header(
+            f"Sustained load for {DURATION_S}s "
+            f"(slow task ~{SLEEP_SECONDS}s, target in-flight {TARGET_INFLIGHT})"
+        )
+        ctx_file = home / "soak-context.json"
+        ctx_file.write_text(f'{{"sleep_seconds": {SLEEP_SECONDS}}}')
         completed_before = _metric(_scrape(metrics_url), "cloacina_workflows_total",
                                    'status="completed"')
-        submitted: list[str] = []
+        submitted = 0
         failed_submits = 0
+        completed = 0.0
         max_outbox = 0.0
         max_active = 0.0
         deadline = time.time() + DURATION_S
-        next_sample = time.time()
+        last_sample = 0.0
+        last_print = 0.0
         while time.time() < deadline:
-            eid = _run_once(home)
-            if eid:
-                submitted.append(eid)
-            else:
-                failed_submits += 1
-            if time.time() >= next_sample:
+            now = time.time()
+            if now - last_sample >= 2:
                 text = _scrape(metrics_url)
+                completed = (_metric(text, "cloacina_workflows_total", 'status="completed"')
+                             - completed_before)
                 outbox = _metric(text, "cloacina_delivery_outbox_open")
-                active = _metric(text, "cloacina_active_tasks")
+                active_w = _metric(text, "cloacina_active_workflows")
                 evicted = _metric(text, "cloacina_fleet_agents_evicted_total")
                 reassigned = _metric(text, "cloacina_fleet_work_reassigned_total")
                 max_outbox = max(max_outbox, outbox)
-                max_active = max(max_active, active)
-                print(f"  [{int(deadline - time.time())}s left] submitted={len(submitted)} "
-                      f"outbox={outbox:.0f} active_tasks={active:.0f} "
-                      f"evicted={evicted:.0f} reassigned={reassigned:.0f}")
-                next_sample = time.time() + 10
-            time.sleep(SUBMIT_INTERVAL_S)
-        print(f"  submitted {len(submitted)} executions ({failed_submits} submit failures)")
+                max_active = max(max_active, active_w)
+                last_sample = now
+                if now - last_print >= 10:
+                    print(f"  [{int(deadline - now)}s left] submitted={submitted} "
+                          f"completed={completed:.0f} in_flight~{submitted - completed:.0f} "
+                          f"outbox={outbox:.0f} active_wf={active_w:.0f} "
+                          f"evicted={evicted:.0f} reassigned={reassigned:.0f}")
+                    last_print = now
+            if (submitted - completed) < TARGET_INFLIGHT:
+                if _run_once(home, str(ctx_file)):
+                    submitted += 1
+                else:
+                    failed_submits += 1
+            else:
+                time.sleep(0.05)  # fleet saturated — back off briefly
+        print(f"  submitted {submitted} executions ({failed_submits} submit failures)")
 
         # --- drain: wait for in-flight work to settle ----------------------
         print_section_header("Drain")
@@ -285,26 +317,35 @@ def fleet():
                             "(agents were declared dead under load)")
         if reassigned != 0:
             problems.append(f"spurious reclaim: cloacina_fleet_work_reassigned_total={reassigned:.0f}")
-        if completed_delta < len(submitted):
+        if completed_delta < submitted:
             problems.append(f"lost work: completed +{completed_delta:.0f} but submitted "
-                            f"{len(submitted)} during the soak")
+                            f"{submitted} during the soak")
         if failed_after != 0:
             problems.append(f"workflow failures: cloacina_workflows_total{{status=failed}}={failed_after:.0f}")
         dead_agents = [i for i, p in enumerate(agent_procs) if p.poll() is not None]
         if dead_agents:
             problems.append(f"agent process(es) exited during soak: {dead_agents}")
+        # The soak is only meaningful if the fleet was actually under sustained
+        # concurrent load. With slow tasks + closed-loop submission,
+        # active_workflows should reach roughly full slot capacity.
+        load_floor = AGENTS * CONCURRENCY
+        if max_active < load_floor:
+            problems.append(f"fleet never loaded: peak active_workflows {max_active:.0f} "
+                            f"< {load_floor} (agents × concurrency) — workload too light or "
+                            "submission couldn't keep the fleet busy")
 
-        print(f"  submitted={len(submitted)} completed_delta={completed_delta:.0f} "
-              f"max_outbox={max_outbox:.0f} max_active={max_active:.0f} "
-              f"evicted={evicted:.0f} reassigned={reassigned:.0f}")
+        print(f"  submitted={submitted} completed_delta={completed_delta:.0f} "
+              f"peak_active_wf={max_active:.0f} (floor {load_floor}) "
+              f"max_outbox={max_outbox:.0f} evicted={evicted:.0f} reassigned={reassigned:.0f}")
 
         if problems:
             _dump("server.log", home / "server.log")
             raise AssertionError("fleet soak instability:\n  - " + "\n  - ".join(problems))
 
         print_final_success(
-            f"Fleet soak stable over {DURATION_S}s: {len(submitted)} executions "
-            f"completed, outbox flat (max {max_outbox:.0f}), no evictions, no lost work."
+            f"Fleet soak stable over {DURATION_S}s: {submitted} executions completed "
+            f"under sustained load (peak {max_active:.0f} in-flight), outbox bounded "
+            f"(max {max_outbox:.0f}), no evictions, no lost work."
         )
     finally:
         for p in agent_procs:

--- a/.angreal/test/soak/fleet.py
+++ b/.angreal/test/soak/fleet.py
@@ -1,0 +1,313 @@
+"""Execution-agent fleet soak (CLOACI-T-0635).
+
+Stands up the full fleet as host subprocesses — Postgres, `cloacina-server`
+(routing `**=fleet`), `cloacina-compiler`, and N `cloacina-agent`s — compiles a
+workflow, then drives sustained load through the fleet for a fixed duration
+while sampling `/metrics`. The point is to surface *slow* problems that
+unit/integration tests miss:
+
+- **Roster drift / leaks** — agents falsely evicted, or dead entries lingering.
+- **Stuck in-flight work** — executions that never reconcile.
+- **Outbox growth** — `delivery_outbox` rows that pile up instead of draining.
+- **Lost work** — submitted executions that never complete.
+
+Stability criteria checked at the end:
+
+- every submitted execution Completed (no lost / stuck work),
+- `cloacina_fleet_agents_evicted_total` == 0 (no roster drift — agents stayed
+  healthy under load),
+- `cloacina_fleet_work_reassigned_total` == 0 (no spurious reclaim),
+- `cloacina_delivery_outbox_open` drains to 0 (no stuck push queue),
+- `cloacina_active_tasks` / `cloacina_active_workflows` drain to 0,
+- all agent processes still alive.
+
+Tunable via env (defaults in parens):
+  CLOACINA_SOAK_FLEET_DURATION_S        sustained-load seconds (120)
+  CLOACINA_SOAK_FLEET_AGENTS            agent count (3)
+  CLOACINA_SOAK_FLEET_CONCURRENCY       per-agent max-concurrency (2)
+  CLOACINA_SOAK_FLEET_SUBMIT_INTERVAL_S seconds between submits (0.5)
+"""
+
+import os
+import re
+import subprocess
+import tempfile
+import time
+import urllib.request
+from pathlib import Path
+
+import angreal  # type: ignore
+
+from .._utils import print_final_success, print_section_header
+from ..e2e.compiler import (
+    REPO_ROOT,
+    _assert_ports_free,
+    _cloacinactl,
+    _kill,
+    _poll_build_status,
+    _poll_execution_status,
+    _poll_run_workflow,
+    _stage_fixture,
+    _start_postgres,
+    _upload,
+    _wait_http,
+)
+
+test = angreal.command_group(
+    name="test", about="Cloacina test suites (unit, integration, e2e, soak)"
+)
+soak = angreal.command_group(name="soak", about="sustained-load soak tests")
+
+FIXTURE_SRC = "compiler-happy-rust"
+WORKFLOW_NAME = "compiler_happy_workflow"
+
+DURATION_S = int(os.environ.get("CLOACINA_SOAK_FLEET_DURATION_S", "120"))
+AGENTS = int(os.environ.get("CLOACINA_SOAK_FLEET_AGENTS", "3"))
+CONCURRENCY = int(os.environ.get("CLOACINA_SOAK_FLEET_CONCURRENCY", "2"))
+SUBMIT_INTERVAL_S = float(os.environ.get("CLOACINA_SOAK_FLEET_SUBMIT_INTERVAL_S", "0.5"))
+
+
+def _scrape(url: str) -> str:
+    """Fetch the Prometheus text exposition; '' on transient failure."""
+    try:
+        with urllib.request.urlopen(url, timeout=5) as r:
+            return r.read().decode()
+    except Exception:
+        return ""
+
+
+def _metric(text: str, name: str, contains: str = None) -> float:
+    """Sum every series for `name` (handles unlabeled `name v` and labeled
+    `name{...} v`), optionally only lines containing `contains`."""
+    total = 0.0
+    for line in text.splitlines():
+        if line.startswith("#"):
+            continue
+        if not (line.startswith(name + " ") or line.startswith(name + "{")):
+            continue
+        if contains is not None and contains not in line:
+            continue
+        m = re.search(r"([0-9.eE+-]+)\s*$", line)
+        if m:
+            try:
+                total += float(m.group(1))
+            except ValueError:
+                pass
+    return total
+
+
+def _run_once(home: Path) -> str | None:
+    """Submit one workflow run; return the execution id (bare `println!` line)
+    or None on a non-zero exit."""
+    code, out, _ = _cloacinactl(
+        home, "-o", "json", "workflow", "run", WORKFLOW_NAME, check=False
+    )
+    if code != 0 or not out.strip():
+        return None
+    tail = out.strip().splitlines()[-1].strip()
+    return tail if len(tail) >= 32 else None
+
+
+@soak()
+@angreal.command(
+    name="fleet",
+    about="fleet soak — server + N agents under sustained load (roster/outbox/drift)",
+    when_to_use=[
+        "validating the execution-agent fleet under sustained load",
+        "hunting roster leaks, stuck outbox entries, reconciliation drift",
+    ],
+    when_not_to_use=["unit testing", "quick validation", "environments without Docker"],
+)
+def fleet():
+    """Run the execution-agent fleet soak."""
+    print_section_header("Execution-Agent Fleet Soak")
+    print(
+        f"  config: duration={DURATION_S}s agents={AGENTS} "
+        f"concurrency={CONCURRENCY} submit_interval={SUBMIT_INTERVAL_S}s"
+    )
+
+    print_section_header("Build server + compiler + cloacinactl + agent")
+    for pkg in ("cloacina-server", "cloacina-compiler", "cloacinactl", "cloacina-agent"):
+        subprocess.run(["cargo", "build", "-p", pkg], cwd=REPO_ROOT, check=True)
+
+    _start_postgres()
+    _assert_ports_free(18088, 19008)
+
+    db_url = "postgres://cloacina:cloacina@localhost:5432/cloacina"
+    bootstrap_key = "soak-fleet-key"
+    server_bind = "127.0.0.1:18088"
+    compiler_bind = "127.0.0.1:19008"
+    server_url = f"http://{server_bind}"
+    compiler_url = f"http://{compiler_bind}"
+    metrics_url = f"{server_url}/metrics"
+
+    home = Path(tempfile.mkdtemp(prefix="fleet-soak-"))
+    print(f"  soak home: {home}")
+
+    server_proc = None
+    compiler_proc = None
+    agent_procs: list[subprocess.Popen] = []
+
+    def _dump(label, path):
+        try:
+            print(f"--- {label} (tail) ---\n{open(path).read()[-4000:]}\n--- end ---")
+        except Exception as exc:
+            print(f"(failed to read {path}: {exc})")
+
+    try:
+        # --- server (all tasks routed to the fleet) ------------------------
+        print_section_header("Boot server + compiler + agents")
+        server_env = os.environ.copy()
+        server_env["CLOACINA_FLEET_ROUTES"] = "**=fleet"
+        server_proc = subprocess.Popen(
+            ["target/debug/cloacina-server", "--home", str(home),
+             "--database-url", db_url, "--bind", server_bind,
+             "--bootstrap-key", bootstrap_key],
+            cwd=REPO_ROOT, stdout=open(home / "server.log", "w"),
+            stderr=subprocess.STDOUT, env=server_env,
+        )
+        _wait_http(f"{server_url}/health", "server", proc=server_proc)
+
+        # --- compiler ------------------------------------------------------
+        shared_target = REPO_ROOT / "target" / "compiler-e2e-cache"
+        shared_target.mkdir(parents=True, exist_ok=True)
+        compiler_proc = subprocess.Popen(
+            ["target/debug/cloacina-compiler", "--home", str(home),
+             "--database-url", db_url, "--bind", compiler_bind,
+             "--poll-interval-ms", "500", "--cargo-target-dir", str(shared_target),
+             "--cargo-flag=build", "--cargo-flag=--lib"],
+            cwd=REPO_ROOT, stdout=open(home / "compiler.log", "w"),
+            stderr=subprocess.STDOUT,
+        )
+        _wait_http(f"{compiler_url}/health", "compiler", timeout_s=60.0, proc=compiler_proc)
+
+        _cloacinactl(home, "config", "profile", "set", "local", server_url,
+                     "--api-key", bootstrap_key, "--default")
+        _cloacinactl(home, "config", "set", "compiler.local_addr", compiler_bind)
+
+        # --- compile the workflow ------------------------------------------
+        print("  compiling fixture (cold build can take minutes; cached <30s)")
+        pkg_id = _upload(home, _stage_fixture(home, FIXTURE_SRC))
+        body = _poll_build_status(home, pkg_id, {"success"}, timeout_s=900.0)
+        assert body.get("build_status") == "success", body
+        print("  ok: workflow compiled")
+
+        # --- start N agents ------------------------------------------------
+        for i in range(AGENTS):
+            p = subprocess.Popen(
+                ["target/debug/cloacina-agent", "--server", server_url,
+                 "--api-key", bootstrap_key, "--max-concurrency", str(CONCURRENCY)],
+                cwd=REPO_ROOT, stdout=open(home / f"agent-{i}.log", "w"),
+                stderr=subprocess.STDOUT,
+            )
+            agent_procs.append(p)
+        time.sleep(4.0)
+        for i, p in enumerate(agent_procs):
+            if p.poll() is not None:
+                _dump(f"agent-{i}.log", home / f"agent-{i}.log")
+                raise AssertionError(f"agent {i} exited early: code={p.returncode}")
+        print(f"  ok: {AGENTS} agents registered")
+
+        # --- warm-up: prove the fleet path works before loading it ---------
+        warm = _poll_run_workflow(home, WORKFLOW_NAME, timeout_s=120.0)
+        if _poll_execution_status(home, warm, {"Completed", "Failed", "Cancelled"},
+                                  timeout_s=60.0) != "Completed":
+            _dump("server.log", home / "server.log")
+            raise AssertionError("warm-up execution did not Complete")
+        if "agent reported result" not in open(home / "server.log").read():
+            raise AssertionError("warm-up did not run on the fleet (no agent report)")
+        print("  ok: warm-up executed on the fleet")
+
+        # --- sustained load ------------------------------------------------
+        print_section_header(f"Sustained load for {DURATION_S}s")
+        completed_before = _metric(_scrape(metrics_url), "cloacina_workflows_total",
+                                   'status="completed"')
+        submitted: list[str] = []
+        failed_submits = 0
+        max_outbox = 0.0
+        max_active = 0.0
+        deadline = time.time() + DURATION_S
+        next_sample = time.time()
+        while time.time() < deadline:
+            eid = _run_once(home)
+            if eid:
+                submitted.append(eid)
+            else:
+                failed_submits += 1
+            if time.time() >= next_sample:
+                text = _scrape(metrics_url)
+                outbox = _metric(text, "cloacina_delivery_outbox_open")
+                active = _metric(text, "cloacina_active_tasks")
+                evicted = _metric(text, "cloacina_fleet_agents_evicted_total")
+                reassigned = _metric(text, "cloacina_fleet_work_reassigned_total")
+                max_outbox = max(max_outbox, outbox)
+                max_active = max(max_active, active)
+                print(f"  [{int(deadline - time.time())}s left] submitted={len(submitted)} "
+                      f"outbox={outbox:.0f} active_tasks={active:.0f} "
+                      f"evicted={evicted:.0f} reassigned={reassigned:.0f}")
+                next_sample = time.time() + 10
+            time.sleep(SUBMIT_INTERVAL_S)
+        print(f"  submitted {len(submitted)} executions ({failed_submits} submit failures)")
+
+        # --- drain: wait for in-flight work to settle ----------------------
+        print_section_header("Drain")
+        drain_deadline = time.time() + 120
+        while time.time() < drain_deadline:
+            text = _scrape(metrics_url)
+            active_t = _metric(text, "cloacina_active_tasks")
+            active_w = _metric(text, "cloacina_active_workflows")
+            outbox = _metric(text, "cloacina_delivery_outbox_open")
+            if active_t == 0 and active_w == 0 and outbox == 0:
+                break
+            time.sleep(2)
+        text = _scrape(metrics_url)
+
+        # --- stability assertions ------------------------------------------
+        print_section_header("Stability checks")
+        problems = []
+        active_t = _metric(text, "cloacina_active_tasks")
+        active_w = _metric(text, "cloacina_active_workflows")
+        outbox = _metric(text, "cloacina_delivery_outbox_open")
+        evicted = _metric(text, "cloacina_fleet_agents_evicted_total")
+        reassigned = _metric(text, "cloacina_fleet_work_reassigned_total")
+        completed_after = _metric(text, "cloacina_workflows_total", 'status="completed"')
+        failed_after = _metric(text, "cloacina_workflows_total", 'status="failed"')
+        completed_delta = completed_after - completed_before
+
+        if active_t != 0 or active_w != 0:
+            problems.append(f"stuck in-flight after drain: active_tasks={active_t:.0f} "
+                            f"active_workflows={active_w:.0f}")
+        if outbox != 0:
+            problems.append(f"outbox did not drain: cloacina_delivery_outbox_open={outbox:.0f}")
+        if evicted != 0:
+            problems.append(f"roster drift: cloacina_fleet_agents_evicted_total={evicted:.0f} "
+                            "(agents were declared dead under load)")
+        if reassigned != 0:
+            problems.append(f"spurious reclaim: cloacina_fleet_work_reassigned_total={reassigned:.0f}")
+        if completed_delta < len(submitted):
+            problems.append(f"lost work: completed +{completed_delta:.0f} but submitted "
+                            f"{len(submitted)} during the soak")
+        if failed_after != 0:
+            problems.append(f"workflow failures: cloacina_workflows_total{{status=failed}}={failed_after:.0f}")
+        dead_agents = [i for i, p in enumerate(agent_procs) if p.poll() is not None]
+        if dead_agents:
+            problems.append(f"agent process(es) exited during soak: {dead_agents}")
+
+        print(f"  submitted={len(submitted)} completed_delta={completed_delta:.0f} "
+              f"max_outbox={max_outbox:.0f} max_active={max_active:.0f} "
+              f"evicted={evicted:.0f} reassigned={reassigned:.0f}")
+
+        if problems:
+            _dump("server.log", home / "server.log")
+            raise AssertionError("fleet soak instability:\n  - " + "\n  - ".join(problems))
+
+        print_final_success(
+            f"Fleet soak stable over {DURATION_S}s: {len(submitted)} executions "
+            f"completed, outbox flat (max {max_outbox:.0f}), no evictions, no lost work."
+        )
+    finally:
+        for p in agent_procs:
+            _kill(p)
+        _kill(compiler_proc)
+        _kill(server_proc)
+        print(f"  (logs preserved in {home})")

--- a/.metis/initiatives/CLOACI-I-0114/tasks/CLOACI-T-0635.md
+++ b/.metis/initiatives/CLOACI-I-0114/tasks/CLOACI-T-0635.md
@@ -32,10 +32,10 @@ Make the fleet operable and durable over time. Add a sustained-load soak that ru
 
 ## Acceptance Criteria **[REQUIRED]**
 
-- [ ] New `angreal test soak` fleet variant: server + N agents under sustained load, watching for roster leaks, stuck in-flight/outbox entries, and reconciliation drift over time.
-- [ ] Soak stable over the target duration with no leaked work, no roster drift, flat outbox depth.
+- [x] New `angreal test soak` fleet variant: server + N agents under sustained load, watching for roster leaks, stuck in-flight/outbox entries, and reconciliation drift over time. **Authored 2026-06-08** (`angreal test soak fleet`).
+- [ ] Soak stable over the target duration with no leaked work, no roster drift, flat outbox depth. **(harness done + syntax-verified; needs one real run to confirm)**
 - [x] Diataxis docs: how-to (deploy an agent, route a glob to the fleet, operate it), explanation (where the fleet sits in scaling), reference (agent config/flags, metrics). **Done 2026-06-07.**
-- [ ] Optional: Helm chart agent deployment (server in DB trust zone; agents pointed at it with API key + tenant).
+- [x] Optional: Helm chart agent deployment (server in DB trust zone; agents pointed at it with API key + tenant). **Done 2026-06-08** (`charts/cloacina-agent`).
 - [x] Metrics doc updated with fleet/agent + outbox signals; scrape validated. **Done 2026-06-07** (fleet counters + delivery_outbox gauge in metrics-catalog; Hugo build green).
 
 ## Implementation Notes **[CONDITIONAL: Technical Task]**
@@ -74,3 +74,26 @@ code match.)
 
 **Still open under T-0635:** fleet soak variant (`angreal test soak` fleet) and
 the optional `charts/cloacina-agent` Helm chart. Docs deliverable complete.
+
+### 2026-06-08 — soak harness + agent Helm chart DONE
+
+**`charts/cloacina-agent`** — Helm chart for the DB-less agent fleet. Deployment
+(no Service/ingress/HTTP probes — outbound worker), `_helpers.tpl`, optional
+inline-`apiKey` Secret vs BYO `apiKeySecretRef`, fail-closed validation
+(requires `server.url` + a key), readOnlyRootFilesystem + writable home/tmp
+emptyDirs, README + NOTES. `helm lint` + template (both key paths) + fail-closed
+all pass; wired into `angreal helm lint` (server + agent).
+
+**`angreal test soak fleet`** (`.angreal/test/soak/fleet.py`) — boots Postgres +
+server (`**=fleet`) + compiler + N agents (host subprocesses, reusing the e2e
+boot helpers), compiles the fixture, warm-up proves the fleet path, then drives
+sustained load for `DURATION_S` while sampling `/metrics`. Stability gate at the
+end: every submitted execution completed (no lost work), `active_tasks/_workflows`
++ `delivery_outbox_open` drain to 0 (no stuck in-flight/outbox), `fleet_agents_
+evicted_total` == 0 (no roster drift), `fleet_work_reassigned_total` == 0, all
+agent procs alive. Tunable via `CLOACINA_SOAK_FLEET_*` env. Registered;
+py_compile + ruff clean. **Needs one real run** (full stack, a few minutes) to
+tick the "stable over duration" criterion — same as how the e2e is run.
+
+Committing both into a T-0635 PR off main. With these, T-0635 is complete pending
+the soak run; that closes I-0114.

--- a/charts/cloacina-agent/.helmignore
+++ b/charts/cloacina-agent/.helmignore
@@ -1,0 +1,20 @@
+# Default helm ignore patterns + repo-specific carve-outs.
+.DS_Store
+.git/
+.gitignore
+.bzr/
+.hg/
+.hgignore
+.svn/
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+.project
+.idea/
+*.tmproj
+.vscode/
+
+# Keep CI helpers out of the packaged chart
+ci/

--- a/charts/cloacina-agent/Chart.yaml
+++ b/charts/cloacina-agent/Chart.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: v2
+name: cloacina-agent
+description: |
+  Cloacina execution-agent — a DB-less worker that registers with a
+  cloacina-server, fetches compiled workflow cdylibs, executes tasks,
+  and reports results. Holds no database connection; deploy outside the
+  DB trust zone and point it at a server with an API key. Pairs with the
+  official cloacina-agent image published to ghcr.io.
+type: application
+
+# Chart's own semver. Bump per chart change.
+version: 0.1.0
+
+# Tracks the cloacina-agent release the default image.tag points at.
+# Override via --set image.tag=X.Y.Z when pinning to a specific release.
+appVersion: "0.6.1"
+
+home: https://cloacina.dev
+sources:
+  - https://github.com/colliery-software/cloacina
+
+maintainers:
+  - name: Colliery Software
+    url: https://github.com/colliery-software
+
+keywords:
+  - workflow
+  - orchestration
+  - execution-agent
+  - fleet
+  - rust

--- a/charts/cloacina-agent/README.md
+++ b/charts/cloacina-agent/README.md
@@ -1,0 +1,51 @@
+# cloacina-agent Helm chart
+
+Deploys a fleet of [execution agents](https://cloacina.dev/platform/explanation/execution-agent-fleet/)
+(`cloacina-agent`) — DB-less workers that register with a `cloacina-server`,
+fetch compiled workflow cdylibs, execute tasks, and report results.
+
+Agents hold **no** database connection and expose **no** HTTP surface, so they
+can run outside the database trust zone. Routing is configured on the *server*
+(`CLOACINA_FLEET_ROUTES` / `--route`); this chart just runs the workers.
+
+## Quick start
+
+```bash
+helm install fleet charts/cloacina-agent \
+  --set server.url=http://my-release-cloacina-server:8080 \
+  --set apiKeySecretRef.name=cloacina-agent-key   # a Secret you manage (key: api-key)
+```
+
+For dev you can inline the key instead (renders a Secret):
+
+```bash
+helm install fleet charts/cloacina-agent \
+  --set server.url=http://my-release-cloacina-server:8080 \
+  --set apiKey=sk-dev-key
+```
+
+## Required values
+
+| Value | Description |
+|---|---|
+| `server.url` | Base URL of the cloacina-server to register with. |
+| `apiKey` *or* `apiKeySecretRef.name` | API key (its tenant scope decides which tenants' work the agent receives). |
+
+## Common values
+
+| Value | Default | Description |
+|---|---|---|
+| `replicaCount` | `2` | Number of agents. |
+| `server.maxConcurrency` | `4` | Concurrent work packets per agent. |
+| `server.capabilities` | `[]` | Capability tags advertised at registration. |
+| `image.repository` / `image.tag` | ghcr image / appVersion | Agent image. |
+
+See `values.yaml` for the full set (resources, security context, scheduling).
+
+## Notes
+
+- The image must match the **build profile** of the workflow packages it runs
+  (release agents need release-built cdylibs — fidius uses bincode in release,
+  JSON in debug).
+- Losing an agent mid-task is safe: the server reclaims its in-flight work onto
+  a surviving agent within the liveness window.

--- a/charts/cloacina-agent/templates/NOTES.txt
+++ b/charts/cloacina-agent/templates/NOTES.txt
@@ -1,0 +1,37 @@
+cloacina-agent has been installed.
+
+Chart:    {{ .Chart.Name }} {{ .Chart.Version }}
+App:      {{ .Chart.AppVersion }}
+Image:    {{ include "cloacina-agent.image" . }}
+Release:  {{ .Release.Name }} (namespace: {{ .Release.Namespace }})
+Replicas: {{ .Values.replicaCount }}  (max-concurrency {{ .Values.server.maxConcurrency }} each)
+Server:   {{ .Values.server.url }}
+
+1. Wait for the agents to become ready:
+
+    kubectl --namespace {{ .Release.Namespace }} \
+      rollout status deployment/{{ include "cloacina-agent.fullname" . }}
+
+2. Confirm they registered with the server (server-side log):
+
+    kubectl --namespace {{ .Release.Namespace }} \
+      logs deployment/<your-server-release>-cloacina-server | grep -i "agent registered"
+
+3. Route work to the fleet on the SERVER (not here) via
+   `CLOACINA_FLEET_ROUTES` / `--route`, e.g. `**=fleet`. Tasks whose names
+   match dispatch to these agents; everything else runs in-process.
+
+4. Watch the fleet via the server's /metrics:
+   `cloacina_fleet_agents_evicted_total`, `cloacina_fleet_work_reassigned_total`,
+   `cloacina_delivery_outbox_open`.
+
+The agents hold no database connection and expose no HTTP surface — observe
+them via their logs and the server-side fleet metrics above.
+
+Docs: https://cloacina.dev/platform/how-to-guides/deploy-an-execution-agent-fleet
+{{- if .Values.apiKey }}
+
+NOTE: an API key was supplied inline via `apiKey` and stored in Secret
+{{ include "cloacina-agent.apiKeySecretName" . }}. For production, prefer
+`apiKeySecretRef` pointing at a Secret you manage.
+{{- end }}

--- a/charts/cloacina-agent/templates/_helpers.tpl
+++ b/charts/cloacina-agent/templates/_helpers.tpl
@@ -1,0 +1,91 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "cloacina-agent.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Fully qualified resource name.
+*/}}
+{{- define "cloacina-agent.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Chart label.
+*/}}
+{{- define "cloacina-agent.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels — applied to every resource.
+*/}}
+{{- define "cloacina-agent.labels" -}}
+helm.sh/chart: {{ include "cloacina-agent.chart" . }}
+{{ include "cloacina-agent.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels — must match the deployment selector exactly.
+*/}}
+{{- define "cloacina-agent.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "cloacina-agent.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Image reference. Defaults image.tag to .Chart.AppVersion when unset.
+*/}}
+{{- define "cloacina-agent.image" -}}
+{{- $tag := default .Chart.AppVersion .Values.image.tag -}}
+{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- end -}}
+
+{{/*
+Name of the Secret holding the agent API key. When `apiKey` is set inline,
+this chart renders a Secret named "<fullname>-api-key"; otherwise the
+operator-supplied `apiKeySecretRef.name` is used.
+*/}}
+{{- define "cloacina-agent.apiKeySecretName" -}}
+{{- if .Values.apiKey -}}
+{{- printf "%s-api-key" (include "cloacina-agent.fullname" .) -}}
+{{- else -}}
+{{- .Values.apiKeySecretRef.name -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Key within the API-key Secret. Inline `apiKey` always lands under `api-key`;
+a BYO secret uses the operator-supplied `apiKeySecretRef.key`.
+*/}}
+{{- define "cloacina-agent.apiKeySecretKey" -}}
+{{- if .Values.apiKey -}}
+api-key
+{{- else -}}
+{{- .Values.apiKeySecretRef.key -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Validate the required wiring: a server URL and an API key (inline or via a
+secret ref). Fails the install with a clear message if either is missing.
+*/}}
+{{- define "cloacina-agent.validate" -}}
+{{- if not (and .Values.server.url (ne .Values.server.url "")) -}}
+{{- fail "cloacina-agent: set `server.url` to the cloacina-server the agent should register with (e.g. http://my-release-cloacina-server:8080)" -}}
+{{- end -}}
+{{- $hasInline := and .Values.apiKey (ne .Values.apiKey "") -}}
+{{- $hasRef := and .Values.apiKeySecretRef.name (ne .Values.apiKeySecretRef.name "") -}}
+{{- if not (or $hasInline $hasRef) -}}
+{{- fail "cloacina-agent: configure exactly one of `apiKey` (inline; renders a Secret) or `apiKeySecretRef.name` (bring your own Secret)" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/cloacina-agent/templates/deployment.yaml
+++ b/charts/cloacina-agent/templates/deployment.yaml
@@ -1,0 +1,89 @@
+{{- include "cloacina-agent.validate" . -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "cloacina-agent.fullname" . }}
+  labels:
+    {{- include "cloacina-agent.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  strategy:
+    {{- toYaml .Values.updateStrategy | nindent 4 }}
+  selector:
+    matchLabels:
+      {{- include "cloacina-agent.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "cloacina-agent.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: cloacina-agent
+          image: {{ include "cloacina-agent.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - "--max-concurrency"
+            - {{ .Values.server.maxConcurrency | quote }}
+            {{- with .Values.server.capabilities }}
+            - "--capabilities"
+            - {{ join "," . | quote }}
+            {{- end }}
+            {{- if .Values.server.targetTripleOverride }}
+            - "--target-triple-override"
+            - {{ .Values.server.targetTripleOverride | quote }}
+            {{- end }}
+          env:
+            - name: CLOACINA_SERVER
+              value: {{ .Values.server.url | quote }}
+            - name: CLOACINA_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "cloacina-agent.apiKeySecretName" . }}
+                  key: {{ include "cloacina-agent.apiKeySecretKey" . }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          volumeMounts:
+            # readOnlyRootFilesystem: the agent's home (artifact cache lives at
+            # $HOME/.cloacina-agent-cache) and /tmp must be writable.
+            - name: home
+              mountPath: /home/cloacina
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: home
+          emptyDir:
+            {{- with .Values.cache.emptyDirSizeLimit }}
+            sizeLimit: {{ . | quote }}
+            {{- end }}
+        - name: tmp
+          emptyDir: {}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/cloacina-agent/templates/secret.yaml
+++ b/charts/cloacina-agent/templates/secret.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.apiKey -}}
+# Rendered only when `apiKey` is supplied inline. For production, prefer
+# `apiKeySecretRef` pointing at a Secret you manage out-of-band.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "cloacina-agent.apiKeySecretName" . }}
+  labels:
+    {{- include "cloacina-agent.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  api-key: {{ .Values.apiKey | quote }}
+{{- end -}}

--- a/charts/cloacina-agent/values.yaml
+++ b/charts/cloacina-agent/values.yaml
@@ -1,0 +1,92 @@
+---
+# Default values for cloacina-agent.
+#
+# The execution-agent is a DB-less worker: it registers with a cloacina-server,
+# fetches compiled workflow cdylibs, runs tasks, and reports results. It holds
+# NO database connection, exposes NO HTTP surface, and scales by replica count.
+# At minimum you must set `server.url` and an API key (`apiKey` or
+# `apiKeySecretRef`).
+
+# Number of agents in the fleet. Scale up for more execution capacity; the
+# server spreads work across live agents by free capacity.
+replicaCount: 2
+
+image:
+  repository: ghcr.io/colliery-software/cloacina-agent
+  # Defaults to the chart's appVersion when empty. Pin with --set image.tag=X.Y.Z.
+  tag: ""
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+server:
+  # REQUIRED. Base URL of the cloacina-server to register with (REST + WS).
+  # Typically the in-cluster Service DNS of your server release, e.g.
+  # http://my-release-cloacina-server:8080
+  url: ""
+  # Max work packets each agent runs concurrently (--max-concurrency).
+  maxConcurrency: 4
+  # Free-form capability tags advertised at registration (--capabilities).
+  capabilities: []
+  # Override the advertised host target triple (--target-triple-override).
+  # Leave empty unless you know you need it (OQ-6 fail-closed matching).
+  targetTripleOverride: ""
+
+# API key the agent authenticates with. Its tenant scope decides which tenants'
+# work the agent may receive. Choose ONE:
+#   1. apiKey (inline): this chart renders a Secret. Convenient for dev; the
+#      plaintext lives in your release values, so prefer option 2 in prod.
+#   2. apiKeySecretRef: bring your own Secret (recommended for production).
+apiKey: ""
+apiKeySecretRef:
+  name: ""
+  key: "api-key"
+
+# Artifact cache: agents cache fetched cdylibs by digest to skip re-fetching.
+# With readOnlyRootFilesystem the cache + home must be writable mounts; an
+# emptyDir is provided below. Set `cache.persistent` + a PVC for cache that
+# survives restarts (optional; the cache is just an optimization).
+cache:
+  # Mount path inside the container (matches the image's CLOACINA_AGENT_CACHE_DIR
+  # default). The agent home is mounted writable so this path is writable.
+  emptyDirSizeLimit: ""
+
+# Extra environment variables appended verbatim to the container.
+extraEnv: []
+
+# Per-agent CPU/memory requests + limits. Empty = unset. Example:
+#   requests: {cpu: 250m, memory: 256Mi}
+#   limits: {cpu: "1", memory: 512Mi}
+resources: {}
+
+# Pod-level security context. Agents run as a non-root user (uid 10001) baked
+# into the image.
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 10001
+  runAsGroup: 10001
+  fsGroup: 10001
+
+# Container-level security context. readOnlyRootFilesystem is on; the home +
+# /tmp emptyDirs below provide the only writable paths (cache + scratch).
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop: ["ALL"]
+
+# Update strategy. RollingUpdate is safe: losing an agent mid-task triggers the
+# server's dead-agent reclaim onto a survivor.
+updateStrategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxUnavailable: 1
+    maxSurge: 1
+
+podLabels: {}
+podAnnotations: {}
+nodeSelector: {}
+tolerations: []
+affinity: {}


### PR DESCRIPTION
The two remaining T-0635 hardening deliverables for the execution-agent fleet (docs landed in #117).

## charts/cloacina-agent
Helm chart for the DB-less agent fleet:
- Deployment only — no Service/ingress/HTTP probes (the agent is an outbound worker with no HTTP surface).
- API key via inline `apiKey` (renders a Secret) **or** BYO `apiKeySecretRef`; fail-closed validation requires `server.url` + a key.
- `readOnlyRootFilesystem` with writable home/tmp emptyDirs; non-root; configurable replicas/concurrency/capabilities/resources/scheduling.
- README + NOTES. Wired into `angreal helm lint` (server + agent variants + fail-closed checks).

## angreal test soak fleet
Sustained-load soak for the fleet (`.angreal/test/soak/fleet.py`):
- Boots Postgres + server (`**=fleet`) + compiler + N agents (host subprocesses, reusing the e2e boot helpers), compiles the fixture, warm-up proves the fleet path.
- Drives sustained load for `DURATION_S` while sampling `/metrics`.
- **Stability gate:** every submitted execution completed (no lost work); `active_tasks`/`active_workflows` + `delivery_outbox_open` drain to 0 (no stuck in-flight/outbox); `cloacina_fleet_agents_evicted_total` == 0 (no roster drift); `cloacina_fleet_work_reassigned_total` == 0; all agent processes alive.
- Tunable via `CLOACINA_SOAK_FLEET_{DURATION_S,AGENTS,CONCURRENCY,SUBMIT_INTERVAL_S}`.

Verified: `helm lint` + template (both key paths + fail-closed) pass; `angreal helm lint` green; soak harness py_compile + ruff clean + registers in `angreal tree`. The soak still wants one real multi-minute run to tick T-0635's 'stable over duration' box (run it like the e2e).

Closes the implementation side of T-0635 (and I-0114).