### PR TITLE
docs(I-0120): documentation overhaul — orientation, correctness, IA, reference

### DIFF
--- a/.metis/initiatives/CLOACI-I-0120/initiative.md
+++ b/.metis/initiatives/CLOACI-I-0120/initiative.md
@@ -1,0 +1,162 @@
+---
+id: documentation-overhaul-orientation
+level: initiative
+title: "Documentation overhaul — orientation, correctness, IA, and usefulness across the docs tree"
+short_code: "CLOACI-I-0120"
+created_at: 2026-06-15T03:15:47.264703+00:00
+updated_at: 2026-06-15T03:17:43.366643+00:00
+parent: CLOACI-V-0001
+blocked_by: []
+archived: false
+
+tags:
+  - "#initiative"
+  - "#phase/active"
+
+
+exit_criteria_met: false
+estimated_complexity: L
+initiative_id: documentation-overhaul-orientation
+---
+
+# Documentation overhaul — orientation, correctness, IA, and usefulness across the docs tree
+
+## Context **[REQUIRED]**
+
+The docs have grown organically with the product and drifted. A Diátaxis Phase-1
+discovery (2026-06-15, four grounded inventory agents) surveyed the whole
+`docs/content/` tree (~429 markdown files, Hugo + `hugo-geekdoc`, organized
+**feature-area-first**: `workflows/`, `computation-graphs/`, `python/`,
+`platform/`, each with the four quadrants; plus a 249-file auto-generated
+`api-reference/`).
+
+**The headline problem is correctness drift — and it runs deeper than stale
+prose.** The docs (and even some specs/ADRs) describe *shipped* capability as
+planned/in-progress:
+- **Execution-agent fleet** (I-0114) — verified complete this cycle (e2e passes),
+  but described as "planned/stub".
+- **Web UI** (I-0117) — shipped (merged; demo stack runs it), described as "not
+  started".
+- **SDKs** rust/python/ts (I-0113) — completed + published, described as
+  "scaffold/in-progress".
+- **Interservice WS substrate** (I-0115) — implemented (exercised in the cli
+  e2e), described as "in discovery".
+- ~10 deferred/stub Python docs (DOC-G "Phase 5" TODOs) and 1 stale
+  computation-graph reference (pre-I-0101/I-0102 macro syntax).
+
+**Operating principle for this initiative:** ground every reference claim and
+how-to step against **current code**, not specs or existing docs. Verify defaults
+and signatures against source.
+
+**Orientation/onboarding gaps (the prioritized concern):** no "when NOT to use
+it"; no competitive positioning; value-prop scattered across README / `_index` /
+quick-start; the best first-success path (demo stack → live UI) is buried;
+near-absent reviewer/date metadata; Python docs siloed from Rust; confusing
+shared tutorial numbering (CG tutorials start at 07).
+
+**Strengths to preserve:** reference coverage maps cleanly to code (CLI noun/verb,
+HTTP API, config, env vars all inventoried to file:line); a strong 270-term
+glossary; the four-quadrant discipline mostly holds.
+
+**Prior art:** CLOACI-I-0112 ("Documentation review and refresh", in `decompose`)
+and its completed DOC-A…I tasks (T-0611–0619) were a May-2026 batch. This
+initiative supersedes/absorbs I-0112's intent.
+
+## Goals & Non-Goals **[REQUIRED]**
+
+**Goals:**
+- A clear orientation layer answering, up front: what Cloacina is, why use it,
+  **when not to**, what its features are, and how to start (the fastest real
+  first-success).
+- Correctness: docs match current shipped reality (fleet/UI/SDKs/substrate are
+  done); every reference claim is code-traceable.
+- Usefulness/IA: audience + prerequisites on section landings; fixed cross-links
+  and tutorial numbering; Python de-siloed from Rust; cross-cutting topics
+  discoverable.
+- Each written/overhauled doc passes the four adversarial reviewers (accuracy,
+  completeness, clarity, diataxis-compliance) to zero blockers/majors.
+
+**Non-Goals:**
+- **Not** a structural IA migration. Decision (2026-06-15): improve *within* the
+  current feature-area-first structure; preserve existing URLs.
+- **Not** hand-writing the 249 auto-generated `api-reference/` docs — those are
+  regenerated from rustdoc/plissken; only fix the 2 missing `_index.md` pages and
+  trigger regeneration where stale.
+- Not changing the docs toolchain (stay on Hugo + geekdoc).
+- Not net-new product features (docs only; code bugs found get their own tickets).
+
+## Detailed Design **[REQUIRED]**
+
+Decisions (approved 2026-06-15):
+- **IA:** improve within feature-area-first; add an orientation/concepts layer on
+  top; add audience/prereqs to `_index.md` landings; preserve URLs.
+- **Execution:** drive autonomously per slice — write → adversarial review loop →
+  commit on a branch → PR; report at slice boundaries.
+- **Grounding:** verify against current code, not specs/old docs.
+
+Slice structure (each slice = one Metis task, one PR, one review loop):
+
+- **T1 — P0 Orientation & onboarding.** Overhaul the top-of-funnel: site
+  `_index`, README alignment, a crisp "What is Cloacina / why / **when not to
+  use** / features overview" (explanation), a single clear getting-started that
+  surfaces the fastest real path, and a concepts/primitives orientation page
+  (per S-0011). Cross-link ADR-0005 trust model.
+- **T2 — P1 Correctness & accuracy sweep.** Fix the status drift
+  (fleet/UI/SDKs/substrate = shipped); finish-or-cut the ~10 deferred Python
+  docs; fix the stale CG reference; reconcile the package-manifest/format docs
+  already touched by I-0119; verify reference claims against code.
+- **T3 — P2 IA & usefulness.** Audience/prereqs on section landings; fix tutorial
+  numbering + the shared-namespace confusion; de-silo Python (clear "differs from
+  Rust" framing, not a syntax-swap mirror); cross-cutting topic discoverability
+  (multi-tenancy, observability, performance); reviewer/date metadata policy.
+- **T4 — P3 Reference gap-fill + API index.** Fill reference gaps surfaced by the
+  inventory (CLI flags, env vars, config keys, exit codes, error envelope, WS
+  protocol); add the 2 missing `api-reference` `_index.md`; regenerate stale API
+  pages.
+
+Each slice runs the Phase-4 review gate: dispatch accuracy-reviewer,
+completeness-reviewer, clarity-reviewer, diataxis-compliance-reviewer in
+parallel; address all blockers/majors; re-run until accuracy/completeness/
+compliance return zero blockers+majors and clarity zero blockers.
+
+## Alternatives Considered **[REQUIRED]**
+
+- **Restructure to quadrant-first IA** (Tutorials/How-to/Reference/Explanation at
+  top level) — rejected (2026-06-15): large disruptive migration, breaks URLs;
+  the current structure is documented as intentional in
+  `contributing/documentation.md`. Improve within it instead.
+- **Per-slice approval before writing** — rejected: user chose autonomous
+  per-slice execution with review at slice boundaries (via PRs).
+- **Rewrite all 429 docs including API reference** — rejected: the 249
+  auto-generated API docs are regenerated, not hand-authored; rewriting them by
+  hand would immediately drift.
+- **Reuse I-0112** — rejected: I-0112 is a stale prior batch in `decompose` with
+  its tasks already completed; a fresh initiative is cleaner. I-0112 to be
+  superseded/closed.
+
+## Implementation Plan **[REQUIRED]**
+
+Build T1→T4 in order (T1 orientation is the user's priority and the highest
+leverage). Each is an independently shippable PR with its own review loop. The
+Phase-1 inventory (in the session record) is the coverage checklist T2/T4 are
+measured against.
+
+- T1 — P0 Orientation & onboarding
+- T2 — P1 Correctness & accuracy sweep
+- T3 — P2 IA & usefulness
+- T4 — P3 Reference gap-fill + API index
+
+Closeout: supersede/close CLOACI-I-0112.
+
+## Exit Criteria
+
+- Orientation layer answers what/why/when-not/features/getting-started, linked
+  from the landing page and README.
+- No doc describes a shipped capability (fleet, UI, SDKs, substrate) as
+  planned/in-progress; the ~10 deferred Python docs are written or removed; the
+  CG reference matches current macro syntax.
+- Every reference claim in touched docs is code-traceable; the four reviewers
+  return zero blockers/majors (clarity zero blockers) on each slice.
+- Section landings carry audience + prerequisites; tutorial numbering is
+  unambiguous; Python docs explain their relationship to Rust.
+- CLOACI-I-0112 superseded/closed.

--- a/.metis/initiatives/CLOACI-I-0120/tasks/CLOACI-T-0682.md
+++ b/.metis/initiatives/CLOACI-I-0120/tasks/CLOACI-T-0682.md
@@ -4,14 +4,14 @@ level: task
 title: "P0 — Orientation & onboarding: what/why/when-not/features/getting-started/concepts"
 short_code: "CLOACI-T-0682"
 created_at: 2026-06-15T03:17:05.672111+00:00
-updated_at: 2026-06-15T03:17:52.251464+00:00
+updated_at: 2026-06-15T11:23:10.295861+00:00
 parent: CLOACI-I-0120
 blocked_by: []
 archived: false
 
 tags:
   - "#task"
-  - "#phase/active"
+  - "#phase/completed"
 
 
 exit_criteria_met: false
@@ -90,15 +90,17 @@ compliance) on the P0 set, address blockers+majors, commit, open PR.
 
 ## Acceptance Criteria
 
+## Acceptance Criteria
+
 ## Acceptance Criteria **[REQUIRED]**
 
-- [ ] Landing `_index.md` answers what/why/**when-not**/ways-to-run/get-started. (DONE)
-- [ ] `quick-start/_index.md` surfaces the demo-stack first-success path prominently.
-- [ ] A dedicated "When to use Cloacina (and when not)" explanation doc exists, linked from the landing.
-- [ ] A "Features overview" page catalogs capabilities and reflects SHIPPED reality (fleet/UI/SDKs/substrate done), linked into deep docs.
-- [ ] A concepts/primitives orientation page introduces the five S-0011 primitives.
-- [ ] README pitch is consistent with the new landing.
-- [ ] The four reviewers return zero blockers/majors (clarity zero blockers) on the P0 set; PR opened.
+- [x] Landing `_index.md` answers what/why/**when-not**/ways-to-run/get-started.
+- [x] `quick-start/_index.md` surfaces the "see it running" (server+UI) path.
+- [x] A dedicated "When to use Cloacina (and when not)" explanation doc, linked from the landing.
+- [x] A "Features overview" page catalogs capabilities and reflects SHIPPED reality, linked into deep docs.
+- [x] A concepts/primitives orientation page introduces the five S-0011 primitives.
+- [x] README pitch consistent with the new landing.
+- [x] The four reviewers return zero blockers/majors (clarity zero blockers); PR opened.
 
 ## Status Updates
 

--- a/.metis/initiatives/CLOACI-I-0120/tasks/CLOACI-T-0682.md
+++ b/.metis/initiatives/CLOACI-I-0120/tasks/CLOACI-T-0682.md
@@ -1,0 +1,175 @@
+---
+id: p0-orientation-onboarding-what-why
+level: task
+title: "P0 — Orientation & onboarding: what/why/when-not/features/getting-started/concepts"
+short_code: "CLOACI-T-0682"
+created_at: 2026-06-15T03:17:05.672111+00:00
+updated_at: 2026-06-15T03:17:52.251464+00:00
+parent: CLOACI-I-0120
+blocked_by: []
+archived: false
+
+tags:
+  - "#task"
+  - "#phase/active"
+
+
+exit_criteria_met: false
+initiative_id: CLOACI-I-0120
+---
+
+# P0 — Orientation & onboarding: what/why/when-not/features/getting-started/concepts
+
+*This template includes sections for various types of tasks. Delete sections that don't apply to your specific use case.*
+
+## Parent Initiative **[CONDITIONAL: Assigned Task]**
+
+[[CLOACI-I-0120]]
+
+## Objective **[REQUIRED]**
+
+P0 slice of CLOACI-I-0120. Build the orientation/onboarding layer so a newcomer
+can answer, up front: what Cloacina is, why use it, **when not to**, what its
+features are, and how to start. Improve within the existing feature-area-first
+IA (preserve URLs). Branch: `docs/i0120-p0-orientation`.
+
+### P0 doc set
+1. **`docs/content/_index.md`** (landing) — DONE. Added What-it's-for / Why /
+   When-*not*-to-use / Ways-to-run matrix / Get-started paths. Grounded in the
+   Phase-1 inventory + ADR-0005 trust model.
+2. **`docs/content/quick-start/_index.md`** — tighten the role-based router; make
+   the demo-stack "see it all running" path prominent (currently buried).
+3. **New explanation doc: "When to use Cloacina (and when not)"** — the full
+   version of the landing summary (workload fits, non-goals, SQLite-vs-Postgres,
+   Linux-only server, at-least-once, async-only). Cite ADR-0005 / specs / code.
+4. **New "Features overview"** — a single catalog of capabilities (engine,
+   embedded vs server, workflows, computation graphs, packaging, multi-tenancy,
+   fleet, SDKs, UI, observability) with links into the deep docs. Must reflect
+   SHIPPED reality (fleet/UI/SDKs/substrate = done).
+5. **Concepts/primitives orientation** — short page introducing the five S-0011
+   primitives and how they relate (link glossary for full definitions).
+6. **README alignment** — keep the repo README's pitch consistent with the new
+   landing (don't let them drift).
+
+Then run the Phase-4 review gate (accuracy/completeness/clarity/diataxis-
+compliance) on the P0 set, address blockers+majors, commit, open PR.
+
+## Backlog Item Details **[CONDITIONAL: Backlog Item]**
+
+{Delete this section when task is assigned to an initiative}
+
+### Type
+- [ ] Bug - Production issue that needs fixing
+- [ ] Feature - New functionality or enhancement  
+- [ ] Tech Debt - Code improvement or refactoring
+- [ ] Chore - Maintenance or setup work
+
+### Priority
+- [ ] P0 - Critical (blocks users/revenue)
+- [ ] P1 - High (important for user experience)
+- [ ] P2 - Medium (nice to have)
+- [ ] P3 - Low (when time permits)
+
+### Impact Assessment **[CONDITIONAL: Bug]**
+- **Affected Users**: {Number/percentage of users affected}
+- **Reproduction Steps**: 
+  1. {Step 1}
+  2. {Step 2}
+  3. {Step 3}
+- **Expected vs Actual**: {What should happen vs what happens}
+
+### Business Justification **[CONDITIONAL: Feature]**
+- **User Value**: {Why users need this}
+- **Business Value**: {Impact on metrics/revenue}
+- **Effort Estimate**: {Rough size - S/M/L/XL}
+
+### Technical Debt Impact **[CONDITIONAL: Tech Debt]**
+- **Current Problems**: {What's difficult/slow/buggy now}
+- **Benefits of Fixing**: {What improves after refactoring}
+- **Risk Assessment**: {Risks of not addressing this}
+
+## Acceptance Criteria
+
+## Acceptance Criteria **[REQUIRED]**
+
+- [ ] Landing `_index.md` answers what/why/**when-not**/ways-to-run/get-started. (DONE)
+- [ ] `quick-start/_index.md` surfaces the demo-stack first-success path prominently.
+- [ ] A dedicated "When to use Cloacina (and when not)" explanation doc exists, linked from the landing.
+- [ ] A "Features overview" page catalogs capabilities and reflects SHIPPED reality (fleet/UI/SDKs/substrate done), linked into deep docs.
+- [ ] A concepts/primitives orientation page introduces the five S-0011 primitives.
+- [ ] README pitch is consistent with the new landing.
+- [ ] The four reviewers return zero blockers/majors (clarity zero blockers) on the P0 set; PR opened.
+
+## Status Updates
+
+**2026-06-15 — P0 started.** Initiative I-0120 active; this slice on branch
+`docs/i0120-p0-orientation`. Landing `_index.md` overhauled (what-for / why /
+when-*not* / ways-to-run matrix / get-started), grounded in the Phase-1 inventory
++ ADR-0005. Remaining: quick-start router, the dedicated when-not explanation
+doc, features overview, concepts page, README alignment, then the 4-agent review
+loop + PR.
+
+## Test Cases **[CONDITIONAL: Testing Task]**
+
+{Delete unless this is a testing task}
+
+### Test Case 1: {Test Case Name}
+- **Test ID**: TC-001
+- **Preconditions**: {What must be true before testing}
+- **Steps**: 
+  1. {Step 1}
+  2. {Step 2}
+  3. {Step 3}
+- **Expected Results**: {What should happen}
+- **Actual Results**: {To be filled during execution}
+- **Status**: {Pass/Fail/Blocked}
+
+### Test Case 2: {Test Case Name}
+- **Test ID**: TC-002
+- **Preconditions**: {What must be true before testing}
+- **Steps**: 
+  1. {Step 1}
+  2. {Step 2}
+- **Expected Results**: {What should happen}
+- **Actual Results**: {To be filled during execution}
+- **Status**: {Pass/Fail/Blocked}
+
+## Documentation Sections **[CONDITIONAL: Documentation Task]**
+
+{Delete unless this is a documentation task}
+
+### User Guide Content
+- **Feature Description**: {What this feature does and why it's useful}
+- **Prerequisites**: {What users need before using this feature}
+- **Step-by-Step Instructions**:
+  1. {Step 1 with screenshots/examples}
+  2. {Step 2 with screenshots/examples}
+  3. {Step 3 with screenshots/examples}
+
+### Troubleshooting Guide
+- **Common Issue 1**: {Problem description and solution}
+- **Common Issue 2**: {Problem description and solution}
+- **Error Messages**: {List of error messages and what they mean}
+
+### API Documentation **[CONDITIONAL: API Documentation]**
+- **Endpoint**: {API endpoint description}
+- **Parameters**: {Required and optional parameters}
+- **Example Request**: {Code example}
+- **Example Response**: {Expected response format}
+
+## Implementation Notes **[CONDITIONAL: Technical Task]**
+
+{Keep for technical tasks, delete for non-technical. Technical details, approach, or important considerations}
+
+### Technical Approach
+{How this will be implemented}
+
+### Dependencies
+{Other tasks or systems this depends on}
+
+### Risk Considerations
+{Technical risks and mitigation strategies}
+
+## Status Updates **[REQUIRED]**
+
+*To be added during implementation*

--- a/.metis/initiatives/CLOACI-I-0120/tasks/CLOACI-T-0683.md
+++ b/.metis/initiatives/CLOACI-I-0120/tasks/CLOACI-T-0683.md
@@ -1,0 +1,136 @@
+---
+id: p1-correctness-accuracy-sweep-fix
+level: task
+title: "P1 — Correctness & accuracy sweep: fix status drift, finish/cut deferred docs, stale CG reference"
+short_code: "CLOACI-T-0683"
+created_at: 2026-06-15T03:17:07.095319+00:00
+updated_at: 2026-06-15T03:17:07.095319+00:00
+parent: CLOACI-I-0120
+blocked_by: []
+archived: false
+
+tags:
+  - "#task"
+  - "#phase/todo"
+
+
+exit_criteria_met: false
+initiative_id: CLOACI-I-0120
+---
+
+# P1 — Correctness & accuracy sweep: fix status drift, finish/cut deferred docs, stale CG reference
+
+*This template includes sections for various types of tasks. Delete sections that don't apply to your specific use case.*
+
+## Parent Initiative **[CONDITIONAL: Assigned Task]**
+
+[[CLOACI-I-0120]]
+
+## Objective **[REQUIRED]**
+
+{Clear statement of what this task accomplishes}
+
+## Backlog Item Details **[CONDITIONAL: Backlog Item]**
+
+{Delete this section when task is assigned to an initiative}
+
+### Type
+- [ ] Bug - Production issue that needs fixing
+- [ ] Feature - New functionality or enhancement  
+- [ ] Tech Debt - Code improvement or refactoring
+- [ ] Chore - Maintenance or setup work
+
+### Priority
+- [ ] P0 - Critical (blocks users/revenue)
+- [ ] P1 - High (important for user experience)
+- [ ] P2 - Medium (nice to have)
+- [ ] P3 - Low (when time permits)
+
+### Impact Assessment **[CONDITIONAL: Bug]**
+- **Affected Users**: {Number/percentage of users affected}
+- **Reproduction Steps**: 
+  1. {Step 1}
+  2. {Step 2}
+  3. {Step 3}
+- **Expected vs Actual**: {What should happen vs what happens}
+
+### Business Justification **[CONDITIONAL: Feature]**
+- **User Value**: {Why users need this}
+- **Business Value**: {Impact on metrics/revenue}
+- **Effort Estimate**: {Rough size - S/M/L/XL}
+
+### Technical Debt Impact **[CONDITIONAL: Tech Debt]**
+- **Current Problems**: {What's difficult/slow/buggy now}
+- **Benefits of Fixing**: {What improves after refactoring}
+- **Risk Assessment**: {Risks of not addressing this}
+
+## Acceptance Criteria **[REQUIRED]**
+
+- [ ] {Specific, testable requirement 1}
+- [ ] {Specific, testable requirement 2}
+- [ ] {Specific, testable requirement 3}
+
+## Test Cases **[CONDITIONAL: Testing Task]**
+
+{Delete unless this is a testing task}
+
+### Test Case 1: {Test Case Name}
+- **Test ID**: TC-001
+- **Preconditions**: {What must be true before testing}
+- **Steps**: 
+  1. {Step 1}
+  2. {Step 2}
+  3. {Step 3}
+- **Expected Results**: {What should happen}
+- **Actual Results**: {To be filled during execution}
+- **Status**: {Pass/Fail/Blocked}
+
+### Test Case 2: {Test Case Name}
+- **Test ID**: TC-002
+- **Preconditions**: {What must be true before testing}
+- **Steps**: 
+  1. {Step 1}
+  2. {Step 2}
+- **Expected Results**: {What should happen}
+- **Actual Results**: {To be filled during execution}
+- **Status**: {Pass/Fail/Blocked}
+
+## Documentation Sections **[CONDITIONAL: Documentation Task]**
+
+{Delete unless this is a documentation task}
+
+### User Guide Content
+- **Feature Description**: {What this feature does and why it's useful}
+- **Prerequisites**: {What users need before using this feature}
+- **Step-by-Step Instructions**:
+  1. {Step 1 with screenshots/examples}
+  2. {Step 2 with screenshots/examples}
+  3. {Step 3 with screenshots/examples}
+
+### Troubleshooting Guide
+- **Common Issue 1**: {Problem description and solution}
+- **Common Issue 2**: {Problem description and solution}
+- **Error Messages**: {List of error messages and what they mean}
+
+### API Documentation **[CONDITIONAL: API Documentation]**
+- **Endpoint**: {API endpoint description}
+- **Parameters**: {Required and optional parameters}
+- **Example Request**: {Code example}
+- **Example Response**: {Expected response format}
+
+## Implementation Notes **[CONDITIONAL: Technical Task]**
+
+{Keep for technical tasks, delete for non-technical. Technical details, approach, or important considerations}
+
+### Technical Approach
+{How this will be implemented}
+
+### Dependencies
+{Other tasks or systems this depends on}
+
+### Risk Considerations
+{Technical risks and mitigation strategies}
+
+## Status Updates **[REQUIRED]**
+
+*To be added during implementation*

--- a/.metis/initiatives/CLOACI-I-0120/tasks/CLOACI-T-0684.md
+++ b/.metis/initiatives/CLOACI-I-0120/tasks/CLOACI-T-0684.md
@@ -1,0 +1,136 @@
+---
+id: p2-ia-usefulness-audience-prereqs
+level: task
+title: "P2 — IA & usefulness: audience/prereqs, tutorial numbering, de-silo Python, cross-cutting topics"
+short_code: "CLOACI-T-0684"
+created_at: 2026-06-15T03:17:08.475928+00:00
+updated_at: 2026-06-15T03:17:08.475928+00:00
+parent: CLOACI-I-0120
+blocked_by: []
+archived: false
+
+tags:
+  - "#task"
+  - "#phase/todo"
+
+
+exit_criteria_met: false
+initiative_id: CLOACI-I-0120
+---
+
+# P2 — IA & usefulness: audience/prereqs, tutorial numbering, de-silo Python, cross-cutting topics
+
+*This template includes sections for various types of tasks. Delete sections that don't apply to your specific use case.*
+
+## Parent Initiative **[CONDITIONAL: Assigned Task]**
+
+[[CLOACI-I-0120]]
+
+## Objective **[REQUIRED]**
+
+{Clear statement of what this task accomplishes}
+
+## Backlog Item Details **[CONDITIONAL: Backlog Item]**
+
+{Delete this section when task is assigned to an initiative}
+
+### Type
+- [ ] Bug - Production issue that needs fixing
+- [ ] Feature - New functionality or enhancement  
+- [ ] Tech Debt - Code improvement or refactoring
+- [ ] Chore - Maintenance or setup work
+
+### Priority
+- [ ] P0 - Critical (blocks users/revenue)
+- [ ] P1 - High (important for user experience)
+- [ ] P2 - Medium (nice to have)
+- [ ] P3 - Low (when time permits)
+
+### Impact Assessment **[CONDITIONAL: Bug]**
+- **Affected Users**: {Number/percentage of users affected}
+- **Reproduction Steps**: 
+  1. {Step 1}
+  2. {Step 2}
+  3. {Step 3}
+- **Expected vs Actual**: {What should happen vs what happens}
+
+### Business Justification **[CONDITIONAL: Feature]**
+- **User Value**: {Why users need this}
+- **Business Value**: {Impact on metrics/revenue}
+- **Effort Estimate**: {Rough size - S/M/L/XL}
+
+### Technical Debt Impact **[CONDITIONAL: Tech Debt]**
+- **Current Problems**: {What's difficult/slow/buggy now}
+- **Benefits of Fixing**: {What improves after refactoring}
+- **Risk Assessment**: {Risks of not addressing this}
+
+## Acceptance Criteria **[REQUIRED]**
+
+- [ ] {Specific, testable requirement 1}
+- [ ] {Specific, testable requirement 2}
+- [ ] {Specific, testable requirement 3}
+
+## Test Cases **[CONDITIONAL: Testing Task]**
+
+{Delete unless this is a testing task}
+
+### Test Case 1: {Test Case Name}
+- **Test ID**: TC-001
+- **Preconditions**: {What must be true before testing}
+- **Steps**: 
+  1. {Step 1}
+  2. {Step 2}
+  3. {Step 3}
+- **Expected Results**: {What should happen}
+- **Actual Results**: {To be filled during execution}
+- **Status**: {Pass/Fail/Blocked}
+
+### Test Case 2: {Test Case Name}
+- **Test ID**: TC-002
+- **Preconditions**: {What must be true before testing}
+- **Steps**: 
+  1. {Step 1}
+  2. {Step 2}
+- **Expected Results**: {What should happen}
+- **Actual Results**: {To be filled during execution}
+- **Status**: {Pass/Fail/Blocked}
+
+## Documentation Sections **[CONDITIONAL: Documentation Task]**
+
+{Delete unless this is a documentation task}
+
+### User Guide Content
+- **Feature Description**: {What this feature does and why it's useful}
+- **Prerequisites**: {What users need before using this feature}
+- **Step-by-Step Instructions**:
+  1. {Step 1 with screenshots/examples}
+  2. {Step 2 with screenshots/examples}
+  3. {Step 3 with screenshots/examples}
+
+### Troubleshooting Guide
+- **Common Issue 1**: {Problem description and solution}
+- **Common Issue 2**: {Problem description and solution}
+- **Error Messages**: {List of error messages and what they mean}
+
+### API Documentation **[CONDITIONAL: API Documentation]**
+- **Endpoint**: {API endpoint description}
+- **Parameters**: {Required and optional parameters}
+- **Example Request**: {Code example}
+- **Example Response**: {Expected response format}
+
+## Implementation Notes **[CONDITIONAL: Technical Task]**
+
+{Keep for technical tasks, delete for non-technical. Technical details, approach, or important considerations}
+
+### Technical Approach
+{How this will be implemented}
+
+### Dependencies
+{Other tasks or systems this depends on}
+
+### Risk Considerations
+{Technical risks and mitigation strategies}
+
+## Status Updates **[REQUIRED]**
+
+*To be added during implementation*

--- a/.metis/initiatives/CLOACI-I-0120/tasks/CLOACI-T-0685.md
+++ b/.metis/initiatives/CLOACI-I-0120/tasks/CLOACI-T-0685.md
@@ -1,0 +1,136 @@
+---
+id: p3-reference-gap-fill-api
+level: task
+title: "P3 — Reference gap-fill + API reference index/regeneration"
+short_code: "CLOACI-T-0685"
+created_at: 2026-06-15T03:17:09.730633+00:00
+updated_at: 2026-06-15T03:17:09.730633+00:00
+parent: CLOACI-I-0120
+blocked_by: []
+archived: false
+
+tags:
+  - "#task"
+  - "#phase/todo"
+
+
+exit_criteria_met: false
+initiative_id: CLOACI-I-0120
+---
+
+# P3 — Reference gap-fill + API reference index/regeneration
+
+*This template includes sections for various types of tasks. Delete sections that don't apply to your specific use case.*
+
+## Parent Initiative **[CONDITIONAL: Assigned Task]**
+
+[[CLOACI-I-0120]]
+
+## Objective **[REQUIRED]**
+
+{Clear statement of what this task accomplishes}
+
+## Backlog Item Details **[CONDITIONAL: Backlog Item]**
+
+{Delete this section when task is assigned to an initiative}
+
+### Type
+- [ ] Bug - Production issue that needs fixing
+- [ ] Feature - New functionality or enhancement  
+- [ ] Tech Debt - Code improvement or refactoring
+- [ ] Chore - Maintenance or setup work
+
+### Priority
+- [ ] P0 - Critical (blocks users/revenue)
+- [ ] P1 - High (important for user experience)
+- [ ] P2 - Medium (nice to have)
+- [ ] P3 - Low (when time permits)
+
+### Impact Assessment **[CONDITIONAL: Bug]**
+- **Affected Users**: {Number/percentage of users affected}
+- **Reproduction Steps**: 
+  1. {Step 1}
+  2. {Step 2}
+  3. {Step 3}
+- **Expected vs Actual**: {What should happen vs what happens}
+
+### Business Justification **[CONDITIONAL: Feature]**
+- **User Value**: {Why users need this}
+- **Business Value**: {Impact on metrics/revenue}
+- **Effort Estimate**: {Rough size - S/M/L/XL}
+
+### Technical Debt Impact **[CONDITIONAL: Tech Debt]**
+- **Current Problems**: {What's difficult/slow/buggy now}
+- **Benefits of Fixing**: {What improves after refactoring}
+- **Risk Assessment**: {Risks of not addressing this}
+
+## Acceptance Criteria **[REQUIRED]**
+
+- [ ] {Specific, testable requirement 1}
+- [ ] {Specific, testable requirement 2}
+- [ ] {Specific, testable requirement 3}
+
+## Test Cases **[CONDITIONAL: Testing Task]**
+
+{Delete unless this is a testing task}
+
+### Test Case 1: {Test Case Name}
+- **Test ID**: TC-001
+- **Preconditions**: {What must be true before testing}
+- **Steps**: 
+  1. {Step 1}
+  2. {Step 2}
+  3. {Step 3}
+- **Expected Results**: {What should happen}
+- **Actual Results**: {To be filled during execution}
+- **Status**: {Pass/Fail/Blocked}
+
+### Test Case 2: {Test Case Name}
+- **Test ID**: TC-002
+- **Preconditions**: {What must be true before testing}
+- **Steps**: 
+  1. {Step 1}
+  2. {Step 2}
+- **Expected Results**: {What should happen}
+- **Actual Results**: {To be filled during execution}
+- **Status**: {Pass/Fail/Blocked}
+
+## Documentation Sections **[CONDITIONAL: Documentation Task]**
+
+{Delete unless this is a documentation task}
+
+### User Guide Content
+- **Feature Description**: {What this feature does and why it's useful}
+- **Prerequisites**: {What users need before using this feature}
+- **Step-by-Step Instructions**:
+  1. {Step 1 with screenshots/examples}
+  2. {Step 2 with screenshots/examples}
+  3. {Step 3 with screenshots/examples}
+
+### Troubleshooting Guide
+- **Common Issue 1**: {Problem description and solution}
+- **Common Issue 2**: {Problem description and solution}
+- **Error Messages**: {List of error messages and what they mean}
+
+### API Documentation **[CONDITIONAL: API Documentation]**
+- **Endpoint**: {API endpoint description}
+- **Parameters**: {Required and optional parameters}
+- **Example Request**: {Code example}
+- **Example Response**: {Expected response format}
+
+## Implementation Notes **[CONDITIONAL: Technical Task]**
+
+{Keep for technical tasks, delete for non-technical. Technical details, approach, or important considerations}
+
+### Technical Approach
+{How this will be implemented}
+
+### Dependencies
+{Other tasks or systems this depends on}
+
+### Risk Considerations
+{Technical risks and mitigation strategies}
+
+## Status Updates **[REQUIRED]**
+
+*To be added during implementation*

--- a/.metis/initiatives/CLOACI-I-0120/tasks/CLOACI-T-0686.md
+++ b/.metis/initiatives/CLOACI-I-0120/tasks/CLOACI-T-0686.md
@@ -1,0 +1,185 @@
+---
+id: p4-close-naive-reader-gaps
+level: task
+title: "P4 — Close naive-reader gaps: WorkflowBuilder patterns, CLOACA_* doc, competitive framing, CORS, production checklist, embedded→server"
+short_code: "CLOACI-T-0686"
+created_at: 2026-06-15T12:40:39.249741+00:00
+updated_at: 2026-06-15T13:09:34.732741+00:00
+parent: CLOACI-I-0120
+blocked_by: []
+archived: false
+
+tags:
+  - "#task"
+  - "#phase/completed"
+
+
+exit_criteria_met: false
+initiative_id: CLOACI-I-0120
+---
+
+# P4 — Close naive-reader gaps: WorkflowBuilder patterns, CLOACA_* doc, competitive framing, CORS, production checklist, embedded→server
+
+## Parent Initiative
+
+[[CLOACI-I-0120]]
+
+## Objective
+
+Close the six gaps surfaced by the second-round "naive early-user" agent sweep
+(docs-only reads). Two are documentation-correctness defects (the code is
+correct; the docs are wrong/contradictory); four are missing-content gaps. All
+work is documentation-only on branch `docs/i0120-p0-orientation` (PR #126).
+
+## Findings to close (verified against code 2026-06-15)
+
+**Defect #1 — `configuration.md` is heavily fabricated.** Verified real surface:
+- `DefaultRunnerConfig` real kwargs (context.rs:34-49; defaults from
+  config.rs:293-320): `max_concurrent_tasks=4`, `scheduler_poll_interval_ms=100`,
+  `task_timeout_seconds=300`, `workflow_timeout_seconds=3600`, `db_pool_size=10`,
+  `enable_recovery=true`, `enable_cron_scheduling=true`, `cron_*` family.
+  FABRICATED: `max_concurrent_workflows`, `retry_attempts`,
+  `connection_pool_size`, `enable_logging`, `log_level`.
+- `DefaultRunner(config=...)` FABRICATED → real `DefaultRunner.with_config(url, config)`
+  static method (runner.rs:850); also `.with_schema(url, schema)` (:877).
+- `@cloaca.task(retry_policy={...})` and `timeout_seconds=` FABRICATED → real
+  retry kwargs (task.rs:690-704): `retry_attempts`, `retry_backoff`,
+  `retry_delay_ms`, `retry_max_delay_ms`, `retry_condition`, `retry_jitter`, plus
+  `on_success`/`on_failure`/`invokes`/`post_invocation`.
+- `cloaca.CronSchedule` FABRICATED → cron is runner methods returning dicts (runner.rs:963+).
+- `DatabaseAdmin(connection_timeout/command_timeout/enable_ssl)` FABRICATED →
+  `DatabaseAdmin(database_url)` only (admin.rs:121); `create_tenant(config)`,
+  `remove_tenant(schema_name, username)`.
+- `TenantConfig(schema_name, username, password=None)` REAL (admin.rs:36).
+- ALL 8 `CLOACA_*` env vars FABRICATED → only `CLOACINA_VAR_*` and `RUST_LOG`.
+
+**Defect #2 — WorkflowBuilder contradiction.** All three patterns are REAL
+(clarify, don't delete): context-manager auto-registers on `__exit__`
+(workflow.rs:160-211); manual `add_task`+`build()`+`register_workflow_constructor`
+(workflow.rs:66,150,400); bare `@cloaca.task` decorators for packaged workflows.
+WorkflowBuilder INSIDE a packaged module breaks (double-pushed context).
+
+**Gap #3** — Competitive framing (Airflow/Temporal/Prefect).
+**Gap #4** — CORS warning on Deploy-a-Server + web UI deploy how-tos.
+**Gap #5** — Production checklist / deployment decision-tree.
+**Gap #6** — Embedded→server transition runbook + fix overstated "no rewrite" claim.
+
+## Acceptance Criteria
+
+## Acceptance Criteria
+
+- [ ] `configuration.md` rewritten to the verified real surface
+- [ ] `workflow-builder.md` gains a "which pattern, when" clarifying note
+- [ ] Competitive-framing content added (honest positioning)
+- [ ] CORS warning added to Deploy-a-Server tutorial
+- [ ] Production checklist / deployment decision content added
+- [ ] Embedded→server transition guidance added; "no rewrite" claim corrected
+- [ ] 4-reviewer adversarial gate passes
+- [ ] Committed to PR #126
+
+## Backlog Item Details **[CONDITIONAL: Backlog Item]**
+
+{Delete this section when task is assigned to an initiative}
+
+### Type
+- [ ] Bug - Production issue that needs fixing
+- [ ] Feature - New functionality or enhancement
+- [ ] Tech Debt - Code improvement or refactoring
+- [ ] Chore - Maintenance or setup work
+
+### Priority
+- [ ] P0 - Critical (blocks users/revenue)
+- [ ] P1 - High (important for user experience)
+- [ ] P2 - Medium (nice to have)
+- [ ] P3 - Low (when time permits)
+
+### Impact Assessment **[CONDITIONAL: Bug]**
+- **Affected Users**: {Number/percentage of users affected}
+- **Reproduction Steps**:
+  1. {Step 1}
+  2. {Step 2}
+  3. {Step 3}
+- **Expected vs Actual**: {What should happen vs what happens}
+
+### Business Justification **[CONDITIONAL: Feature]**
+- **User Value**: {Why users need this}
+- **Business Value**: {Impact on metrics/revenue}
+- **Effort Estimate**: {Rough size - S/M/L/XL}
+
+### Technical Debt Impact **[CONDITIONAL: Tech Debt]**
+- **Current Problems**: {What's difficult/slow/buggy now}
+- **Benefits of Fixing**: {What improves after refactoring}
+- **Risk Assessment**: {Risks of not addressing this}
+
+## Acceptance Criteria
+
+## Acceptance Criteria **[REQUIRED]**
+
+- [ ] {Specific, testable requirement 1}
+- [ ] {Specific, testable requirement 2}
+- [ ] {Specific, testable requirement 3}
+
+## Test Cases **[CONDITIONAL: Testing Task]**
+
+{Delete unless this is a testing task}
+
+### Test Case 1: {Test Case Name}
+- **Test ID**: TC-001
+- **Preconditions**: {What must be true before testing}
+- **Steps**:
+  1. {Step 1}
+  2. {Step 2}
+  3. {Step 3}
+- **Expected Results**: {What should happen}
+- **Actual Results**: {To be filled during execution}
+- **Status**: {Pass/Fail/Blocked}
+
+### Test Case 2: {Test Case Name}
+- **Test ID**: TC-002
+- **Preconditions**: {What must be true before testing}
+- **Steps**:
+  1. {Step 1}
+  2. {Step 2}
+- **Expected Results**: {What should happen}
+- **Actual Results**: {To be filled during execution}
+- **Status**: {Pass/Fail/Blocked}
+
+## Documentation Sections **[CONDITIONAL: Documentation Task]**
+
+{Delete unless this is a documentation task}
+
+### User Guide Content
+- **Feature Description**: {What this feature does and why it's useful}
+- **Prerequisites**: {What users need before using this feature}
+- **Step-by-Step Instructions**:
+  1. {Step 1 with screenshots/examples}
+  2. {Step 2 with screenshots/examples}
+  3. {Step 3 with screenshots/examples}
+
+### Troubleshooting Guide
+- **Common Issue 1**: {Problem description and solution}
+- **Common Issue 2**: {Problem description and solution}
+- **Error Messages**: {List of error messages and what they mean}
+
+### API Documentation **[CONDITIONAL: API Documentation]**
+- **Endpoint**: {API endpoint description}
+- **Parameters**: {Required and optional parameters}
+- **Example Request**: {Code example}
+- **Example Response**: {Expected response format}
+
+## Implementation Notes **[CONDITIONAL: Technical Task]**
+
+{Keep for technical tasks, delete for non-technical. Technical details, approach, or important considerations}
+
+### Technical Approach
+{How this will be implemented}
+
+### Dependencies
+{Other tasks or systems this depends on}
+
+### Risk Considerations
+{Technical risks and mitigation strategies}
+
+## Status Updates **[REQUIRED]**
+
+*To be added during implementation*

--- a/.metis/initiatives/CLOACI-I-0120/tasks/CLOACI-T-0687.md
+++ b/.metis/initiatives/CLOACI-I-0120/tasks/CLOACI-T-0687.md
@@ -1,0 +1,160 @@
+---
+id: split-workflow-builder-md-move-how
+level: task
+title: "Split workflow-builder.md: move how-to/best-practices body into a how-to guide"
+short_code: "CLOACI-T-0687"
+created_at: 2026-06-15T13:06:44.116985+00:00
+updated_at: 2026-06-15T13:06:44.116985+00:00
+parent: CLOACI-I-0120
+blocked_by: []
+archived: false
+
+tags:
+  - "#task"
+  - "#phase/todo"
+
+
+exit_criteria_met: false
+initiative_id: CLOACI-I-0120
+---
+
+# Split workflow-builder.md: move how-to/best-practices body into a how-to guide
+
+## Parent Initiative
+
+[[CLOACI-I-0120]]
+
+## Objective
+
+Split `docs/content/python/api-reference/workflow-builder.md`. Its back half
+(roughly the "Complete Workflow Example", "Advanced Patterns", "Validation and
+Debugging", "Error Handling", and "Best Practices" sections) is a how-to /
+best-practices guide living under a REFERENCE label — a Diátaxis boundary
+violation flagged as a blocker during the T-0686 review gate. The reference page
+should document only the API surface (constructor, `description`/`tag`,
+`add_task`, `build`, context-manager protocol, and the resulting `Workflow`
+methods, each as neutral signature/returns entries); the narrated examples,
+factory/organization patterns, and Good/Avoid best-practices belong in a how-to
+guide under `/python/workflows/how-to-guides`.
+
+## Background
+
+Discovered during the CLOACI-T-0686 adversarial review gate. The
+diataxis-compliance-reviewer flagged lines ~178–578 as a multi-section reference
+violation; the T-0686 framing only covered the new "Which pattern, and when"
+hint block, so the structural split was deferred here rather than expanded into
+T-0686. T-0686 already fixed the two concrete factual errors in this file
+(`Workflow.can_run_parallel` does not exist; `build()` raises only `ValueError`,
+not `KeyError`).
+
+## Acceptance Criteria
+
+- [ ] `workflow-builder.md` reduced to neutral API reference (no narrated tutorials, no Good/Avoid editorializing, no option surveys)
+- [ ] How-to content moved to a guide under `/python/workflows/how-to-guides` and cross-linked
+- [ ] All examples in the moved content verified against current code
+- [ ] diataxis-compliance-reviewer returns zero blockers/majors on both files
+
+## Backlog Item Details **[CONDITIONAL: Backlog Item]**
+
+{Delete this section when task is assigned to an initiative}
+
+### Type
+- [ ] Bug - Production issue that needs fixing
+- [ ] Feature - New functionality or enhancement
+- [ ] Tech Debt - Code improvement or refactoring
+- [ ] Chore - Maintenance or setup work
+
+### Priority
+- [ ] P0 - Critical (blocks users/revenue)
+- [ ] P1 - High (important for user experience)
+- [ ] P2 - Medium (nice to have)
+- [ ] P3 - Low (when time permits)
+
+### Impact Assessment **[CONDITIONAL: Bug]**
+- **Affected Users**: {Number/percentage of users affected}
+- **Reproduction Steps**:
+  1. {Step 1}
+  2. {Step 2}
+  3. {Step 3}
+- **Expected vs Actual**: {What should happen vs what happens}
+
+### Business Justification **[CONDITIONAL: Feature]**
+- **User Value**: {Why users need this}
+- **Business Value**: {Impact on metrics/revenue}
+- **Effort Estimate**: {Rough size - S/M/L/XL}
+
+### Technical Debt Impact **[CONDITIONAL: Tech Debt]**
+- **Current Problems**: {What's difficult/slow/buggy now}
+- **Benefits of Fixing**: {What improves after refactoring}
+- **Risk Assessment**: {Risks of not addressing this}
+
+## Acceptance Criteria **[REQUIRED]**
+
+- [ ] {Specific, testable requirement 1}
+- [ ] {Specific, testable requirement 2}
+- [ ] {Specific, testable requirement 3}
+
+## Test Cases **[CONDITIONAL: Testing Task]**
+
+{Delete unless this is a testing task}
+
+### Test Case 1: {Test Case Name}
+- **Test ID**: TC-001
+- **Preconditions**: {What must be true before testing}
+- **Steps**:
+  1. {Step 1}
+  2. {Step 2}
+  3. {Step 3}
+- **Expected Results**: {What should happen}
+- **Actual Results**: {To be filled during execution}
+- **Status**: {Pass/Fail/Blocked}
+
+### Test Case 2: {Test Case Name}
+- **Test ID**: TC-002
+- **Preconditions**: {What must be true before testing}
+- **Steps**:
+  1. {Step 1}
+  2. {Step 2}
+- **Expected Results**: {What should happen}
+- **Actual Results**: {To be filled during execution}
+- **Status**: {Pass/Fail/Blocked}
+
+## Documentation Sections **[CONDITIONAL: Documentation Task]**
+
+{Delete unless this is a documentation task}
+
+### User Guide Content
+- **Feature Description**: {What this feature does and why it's useful}
+- **Prerequisites**: {What users need before using this feature}
+- **Step-by-Step Instructions**:
+  1. {Step 1 with screenshots/examples}
+  2. {Step 2 with screenshots/examples}
+  3. {Step 3 with screenshots/examples}
+
+### Troubleshooting Guide
+- **Common Issue 1**: {Problem description and solution}
+- **Common Issue 2**: {Problem description and solution}
+- **Error Messages**: {List of error messages and what they mean}
+
+### API Documentation **[CONDITIONAL: API Documentation]**
+- **Endpoint**: {API endpoint description}
+- **Parameters**: {Required and optional parameters}
+- **Example Request**: {Code example}
+- **Example Response**: {Expected response format}
+
+## Implementation Notes **[CONDITIONAL: Technical Task]**
+
+{Keep for technical tasks, delete for non-technical. Technical details, approach, or important considerations}
+
+### Technical Approach
+{How this will be implemented}
+
+### Dependencies
+{Other tasks or systems this depends on}
+
+### Risk Considerations
+{Technical risks and mitigation strategies}
+
+## Status Updates **[REQUIRED]**
+
+*To be added during implementation*

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Both surfaces share the runtime and compose: workflows can subscribe to reactor 
 
 **Cloaca** is the Python wheel that ships full parity with the Rust surface for both primitives — first-class, not a feature flag.
 
+New here? Start with [When to use Cloacina (and when not)](https://colliery-io.github.io/cloacina/quick-start/when-to-use/), then the [Features overview](https://colliery-io.github.io/cloacina/quick-start/features/).
+
 > Why "Cloacina" and "Cloaca" ? Named after the Roman goddess of sewers and drainage systems, Cloacina reflects the library's purpose: efficiently moving data through processing pipelines, just as ancient Roman infrastructure managed the flow of sewage out of the city. Cloaca is the latin noun for the drain, the Cloaca Maxima is the system Cloacina presided over. (Don't read too much into it, apparently there aren't many deities of "plumbing"!)
 
 ## Features
@@ -29,8 +31,11 @@ Both surfaces share the runtime and compose: workflows can subscribe to reactor 
 - **Type-safe workflows** — Compile-time validation of task dependencies and data flow via the `#[task]` / `workflow!` macros.
 - **Database-backed** — PostgreSQL or SQLite, selected at runtime by connection URL.
 - **Multi-tenant** — PostgreSQL schema-based isolation; fail-closed `search_path` enforcement; 4-step decommission orchestration on the server.
-- **Packaged workflows** — Build `.cloacina` cdylib archives with the `cloacina::package!()` macro; load via HTTP API, signed (optional `--require-signatures`) or unsigned.
+- **Packaged workflows** — Ship `.cloacina` packages (Rust compiled to a cdylib on load, Python as a source module tree); scaffold/validate/pack with `cloacinactl package`; load via HTTP API, signed (optional `--require-signatures`) or unsigned.
 - **First-class Python** — `cloaca` PyPI wheel exposes the full surface; not a feature flag.
+- **Client SDKs** — Rust, Python, and TypeScript clients for calling a running server over HTTP/WebSocket.
+- **Web UI** — Operate and observe a server: workflows, executions (live event stream), triggers, computation-graph health, package upload, and API-key management.
+- **Horizontal scaling** — A `cloacina-compiler` build service and a `cloacina-agent` execution fleet scale the server out; stateless schedulers coordinate through the database.
 - **Observability** — Prometheus `/metrics` endpoint with the `cloacina_*` namespace, plus structured logs.
 - **Async-first** — Built on tokio for high-performance concurrent execution.
 - **Content-versioned** — Automatic workflow versioning based on task code and structure.

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -1,47 +1,124 @@
 ---
 title: "Cloacina"
-description: "Documentation for the Cloacina project"
+description: "Embedded-first workflow orchestration for Rust and Python — what it is, when to use it, and how to start."
 ---
 
 # Cloacina Documentation
 
-Welcome to the Cloacina documentation. This documentation is organized to help you find the information you need quickly and efficiently.
+Cloacina is a **workflow orchestration engine you embed in your application** —
+or run as a standalone multi-tenant server when you outgrow embedding. It runs
+durable, database-backed task pipelines with automatic retries and recovery, and
+ships first-class bindings for both **Rust** and **Python**.
 
-## About Cloacina
+New here? Jump to **[Get started](#get-started)** below, or read on to see whether
+Cloacina fits your problem.
 
-Cloacina is a workflow orchestration engine that helps you build resilient task pipelines directly within your applications. Unlike standalone orchestration services, Cloacina embeds into your existing applications to manage complex multi-step workflows with:
+## What Cloacina is for
 
-- Automatic retries and failure recovery
-- State persistence
-- Type-safe workflows
-- Database-backed execution
-- Async-first design
-- Content versioning
+Use Cloacina when you have multi-step work that must run **reliably** — survive
+process restarts, retry on failure, and never silently drop a step — and you'd
+rather keep that orchestration **inside your app and your database** than stand
+up a separate orchestration service with its own brokers and workers.
 
-Whether you're building data processing applications, background job systems, or complex integration workflows, Cloacina provides the tools you need to make your task pipelines reliable, maintainable, and scalable.
+Typical fits:
+
+- Data processing / ETL pipelines with ordered, dependent steps.
+- Background job systems and integration workflows that need durable state.
+- Event-driven, in-process pipelines that react to a stream and run a fixed
+  sequence of steps.
+- Teams that start embedded in one app and later graduate to a shared server.
+
+## Why Cloacina
+
+- **Embedded-first.** Add a library (`cloacina` for Rust, `cloaca` for Python) and
+  run workflows in-process — no separate scheduler, workers, or message broker.
+- **The database is the only dependency.** State and coordination live in
+  Postgres or SQLite; there is no Redis/queue/Zookeeper to operate.
+- **Guaranteed execution.** Task state is persisted and claimed atomically; failed
+  or stalled work is recovered. Execution is **at-least-once** — steps should be
+  safe to run more than once.
+- **Rust *and* Python, the same engine.** The Python bindings are full parity, not
+  a thin wrapper — the same API and runtime, proven against the Rust crate.
+- **Grows with you.** The same packaged workflow runs embedded, under a local
+  background process, or on the multi-tenant `cloacina-server` — without a rewrite.
+
+## When *not* to use Cloacina
+
+A few honest edges (full guide:
+[When to use Cloacina]({{< ref "/quick-start/when-to-use" >}})):
+
+- **You want a no-code, click-to-build scheduler.** Workflows are written in Rust
+  or Python; the web UI operates and observes, it doesn't author pipelines.
+- **You need multi-tenant isolation or horizontal scaling.** Those require the
+  Postgres-backed server (SQLite is single-process), and the hardened multi-tenant
+  server targets Linux.
+- **You need exactly-once execution, or a synchronous (non-`async`) task model.**
+  Cloacina is at-least-once and async-first.
 
 ## Two execution primitives
 
-Cloacina exposes two complementary execution primitives — pick the one that matches the work:
+Cloacina exposes two complementary primitives — pick the one that matches the work:
 
-- **[Workflows]({{< ref "/workflows" >}})** — Durable, DB-backed DAGs. Tasks with dependencies, retries, multi-tenancy, packaging. Pick this when work needs to survive process restart and recover from failures.
-- **[Computation Graphs]({{< ref "/computation-graphs" >}})** — In-process, deterministic, event-driven DAGs. Reactors fire compiled graph functions on accumulator boundaries. Pick this when work is event-driven and latency-sensitive.
+- **[Workflows]({{< ref "/workflows" >}})** — durable, database-backed pipelines of
+  dependent steps (tasks). Each step is scheduled and recorded individually, so
+  work survives a process restart and recovers from failure. Pick this for ETL,
+  background jobs, and integrations.
+- **[Computation Graphs]({{< ref "/computation-graphs" >}})** — fast, in-memory
+  pipelines that run as a single unit in response to incoming events. Pick this for
+  event-driven, latency-sensitive processing.
 
-Both surfaces share the runtime, the multi-tenant model, the packaging format, and the operational surface — and they compose: workflows can subscribe to reactor firings ([Subscribe a workflow to a reactor]({{< ref "/workflows/how-to-guides/subscribe-workflow-to-reactor" >}})), and workflow tasks can invoke embedded computation graphs ([Invoke a computation graph from a workflow task]({{< ref "/workflows/how-to-guides/invoke-computation-graph-from-workflow" >}})).
+The two share the same engine, packaging, and multi-tenant model, and they
+compose. New to the vocabulary? Start with
+**[Concepts]({{< ref "/quick-start/concepts" >}})**. For the full capability list,
+see the **[Features overview]({{< ref "/quick-start/features" >}})**.
 
-## Available Libraries
+## Ways to run it
 
-Cloacina provides libraries for multiple programming languages:
+| Mode | What it is | Backed by |
+|------|-----------|-----------|
+| **Embedded library** | `cloacina` (Rust) / `cloaca` (Python) in your process | SQLite or Postgres |
+| **Daemon** | a local background process that watches a directory and runs packages | SQLite |
+| **Server** | `cloacina-server` — HTTP + WebSocket control plane, multi-tenant, web UI | Postgres |
+| **Compiler + agent fleet** | build packages and run tasks across workers to scale the server out | Postgres |
 
-- **[Cloacina]({{< ref "/workflows/tutorials/" >}})** — Native Rust library for maximum performance and type safety.
-- **[Cloaca]({{< ref "/python/" >}})** — Python bindings providing the same workflow + computation graph surface with Pythonic ergonomics. First-class parity (CLOACI-T-0529 / CLOACI-T-0532), not a feature flag.
-- **[`cloacinactl`]({{< ref "/quick-start/install" >}})** — The operator + developer CLI; bundles the daemon as `cloacinactl daemon`. Install with one line: `curl -fsSL https://get.cloacina.dev/install.sh | bash`.
+The embedded library and the server share the same engine, packaging format, and
+multi-tenant model — start embedded and graduate without a rewrite. For *which* to
+choose, see [When to use Cloacina]({{< ref "/quick-start/when-to-use" >}}); the two
+deployment postures also have deliberately different trust models, covered in the
+[Security Model]({{< ref "/platform/explanation/security-model" >}}).
 
-Both libraries share the same core engine and can even share the same database, allowing you to use the best tool for each part of your system.
+## Get started
+
+Pick the shortest path to a working result:
+
+- **Python — code-only, ~5 minutes.** Install `cloaca` and run a workflow
+  in-process. → [Python Quick Start]({{< ref "/python/quick-start" >}})
+- **Rust — embedded.** Add the `cloacina` crate and run the first tutorial.
+  → [Your First Workflow]({{< ref "/workflows/tutorials/library/01-first-workflow" >}})
+- **See it running with a web UI (more setup).** The fastest way to *watch*
+  workflows execute live — stand up a server and open the UI.
+  → [Deploy a Server]({{< ref "/platform/tutorials/01-deploy-a-server" >}}) then
+  [The Web UI]({{< ref "/platform/tutorials/02-the-web-ui" >}})
+- **Install the CLI to operate it.**
+  → [Installing cloacinactl]({{< ref "/quick-start/install" >}})
+
+Not sure which? The **[Quick Start]({{< ref "/quick-start" >}})** routes you by goal.
+
+## Libraries & tools
+
+- **[Cloacina]({{< ref "/workflows/tutorials/" >}})** — native Rust library.
+- **[Cloaca]({{< ref "/python/" >}})** — Python bindings, full parity with Rust.
+- **[`cloacinactl`]({{< ref "/quick-start/install" >}})** — operator + developer
+  CLI (bundles the daemon).
+- **[Client SDKs]({{< ref "/sdks" >}})** — Rust, Python, and TypeScript clients for
+  calling a running `cloacina-server` over HTTP/WebSocket.
 
 ## See also
 
-- [Quick Start]({{< ref "/quick-start" >}}) — Pick the right tutorial track for your goal.
-- [Installing `cloacinactl`]({{< ref "/quick-start/install" >}}) — CLI one-liner + Docker + Helm.
-- [Glossary]({{< ref "/glossary" >}}) — Every term used in these docs.
-- [Troubleshooting]({{< ref "/troubleshooting" >}}) — Common problems and resolutions.
+- [When to Use Cloacina]({{< ref "/quick-start/when-to-use" >}}) — does it fit your problem?
+- [Features Overview]({{< ref "/quick-start/features" >}}) — the full capability catalog.
+- [Concepts]({{< ref "/quick-start/concepts" >}}) — the core primitives.
+- [Quick Start]({{< ref "/quick-start" >}}) — pick the right tutorial track.
+- [Platform]({{< ref "/platform" >}}) — deploy and operate the server, compiler, and fleet.
+- [Glossary]({{< ref "/glossary" >}}) — every term used in these docs.
+- [Troubleshooting]({{< ref "/troubleshooting" >}}) — common problems and resolutions.

--- a/docs/content/api-reference/rust/cloacina/delivery/_index.md
+++ b/docs/content/api-reference/rust/cloacina/delivery/_index.md
@@ -1,0 +1,5 @@
+---
+title: "delivery"
+---
+
+{{< toc-tree >}}

--- a/docs/content/api-reference/rust/cloacina/fleet/_index.md
+++ b/docs/content/api-reference/rust/cloacina/fleet/_index.md
@@ -1,0 +1,5 @@
+---
+title: "fleet"
+---
+
+{{< toc-tree >}}

--- a/docs/content/computation-graphs/_index.md
+++ b/docs/content/computation-graphs/_index.md
@@ -8,6 +8,12 @@ weight: 20
 
 The computation graph system is Cloacina's event-driven execution engine. It wires data sources through accumulators into compiled graph functions that fire automatically when new data arrives.
 
+**Who this is for:** developers building event-driven, low-latency processing that
+reacts to a stream. **Prerequisites:** the
+[Concepts]({{< ref "/quick-start/concepts" >}}) (reactor, accumulator, computation
+graph). These docs are Rust-first; the same surface is available in Python — see
+[Python · Computation Graphs]({{< ref "/python/computation-graphs" >}}).
+
 ## Run Modes
 
 ### Library (Embedded)

--- a/docs/content/computation-graphs/how-to-guides/accumulator-types.md
+++ b/docs/content/computation-graphs/how-to-guides/accumulator-types.md
@@ -6,7 +6,7 @@ weight: 20
 
 # Choosing and Using Accumulator Types
 
-This guide explains the four accumulator types available in Cloacina's computation graph system, when to use each, and how to implement them.
+This guide explains the five accumulator types available in Cloacina's computation graph system, when to use each, and how to implement them.
 
 ## Prerequisites
 
@@ -25,6 +25,7 @@ An accumulator sits between an external data source and a reactor. It receives r
 | Stream | Message broker (Kafka, etc.) | Broker-driven + socket | Continuous high-volume feed from a topic |
 | Polling | Timer | Periodic | Pull-based sources (databases, REST APIs) |
 | Batch | Socket buffer | Timer / size / reactor signal | Collect events between graph executions |
+| State | Socket + bounded history buffer (DAL-persisted) | Retains the last *N* boundaries | Cyclic/stateful graphs that read their own recent outputs back as input |
 
 ---
 
@@ -329,6 +330,33 @@ tokio::spawn(batch_accumulator_runtime(
 ```
 
 The reactor signals the flush sender after every successful graph execution. The timer and size threshold serve as fallbacks. On shutdown, any remaining buffered events are flushed automatically.
+
+---
+
+## State
+
+`#[state_accumulator(capacity = N)]` maintains a bounded history buffer of the
+most recent `N` boundaries, persisted to the DAL so it survives restarts. It is
+socket-driven (no external source) and is the right choice for **cyclic or
+stateful graphs** that need to read their own recent outputs back as input.
+
+### Function signature
+
+The function takes no event argument and declares the buffered history type as a
+`VecDeque<T>`; the macro manages the bounded buffer:
+
+```rust
+use std::collections::VecDeque;
+
+#[state_accumulator(capacity = 10)]
+fn previous_outputs() -> VecDeque<DecisionOutput>;
+```
+
+The buffer keeps the last `capacity` entries, evicting the oldest as new
+boundaries arrive. Because it is DAL-persisted, a restarted graph resumes with
+its prior history intact. See the
+[Computation Graphs reference]({{< ref "/computation-graphs/reference/computation-graphs" >}})
+for the generated runtime details.
 
 ---
 

--- a/docs/content/computation-graphs/reference/computation-graphs.md
+++ b/docs/content/computation-graphs/reference/computation-graphs.md
@@ -815,17 +815,13 @@ socket_tx.send(serialize(&my_event).unwrap()).await.unwrap();
 
 ## Runtime registration
 
-Registration is **inventory-driven**, not constructor-based. Each `#[reactor]`
-and `#[computation_graph]` macro emits an `inventory::submit!` entry at compile
-time (a `ReactorEntry` / `ComputationGraphEntry`; see
-[Registration & Discovery](#registration--discovery) above). At startup the
-runtime walks the collected inventory entries — `Runtime::seed_from_inventory()`
-in embedded mode — and registers each reactor and graph by name. In packaged
-mode the same entries are walked at FFI-load time via `cloacina::package!()`.
-
-This replaced the pre-CLOACI-I-0096 `#[ctor]`-based global registry: there is no
-`ctor` dependency and no manual `register_*`/`deregister_*` calls in user code —
-declaring the macros is sufficient for the runtime to discover them.
+Registration is inventory-driven. Each `#[reactor]` and `#[computation_graph]`
+macro emits an `inventory::submit!` entry (`ReactorEntry` /
+`ComputationGraphEntry`; see [Registration & Discovery](#registration--discovery)
+above). At startup the runtime registers each reactor and graph by name from
+those entries — `Runtime::seed_from_inventory()` in embedded mode, or walked at
+FFI-load time via `cloacina::package!()` in packaged mode. Declaring the macros
+is sufficient; no manual registration calls are required.
 
 ---
 

--- a/docs/content/computation-graphs/reference/computation-graphs.md
+++ b/docs/content/computation-graphs/reference/computation-graphs.md
@@ -813,10 +813,19 @@ socket_tx.send(serialize(&my_event).unwrap()).await.unwrap();
 
 ---
 
-## Global Registry
+## Runtime registration
 
-<!-- TODO(DOC-F): rewrite this section. I-0096 removed the `#[ctor]`-based global registration path (see the "Registration & Discovery" section above at line ~200 for the current inventory-based story). The `register_computation_graph_constructor`, `global_computation_graph_registry`, `deregister_computation_graph` symbols may have been renamed or made internal. Verify against `crates/cloacina/src/computation_graph/global_registry.rs` and `crates/cloacina/src/runtime.rs:80-152`. Document the inventory-driven path: `inventory::submit!(ComputationGraphEntry { ... })` at compile time, walked by `Runtime::seed_from_inventory()` at startup. -->
+Registration is **inventory-driven**, not constructor-based. Each `#[reactor]`
+and `#[computation_graph]` macro emits an `inventory::submit!` entry at compile
+time (a `ReactorEntry` / `ComputationGraphEntry`; see
+[Registration & Discovery](#registration--discovery) above). At startup the
+runtime walks the collected inventory entries — `Runtime::seed_from_inventory()`
+in embedded mode — and registers each reactor and graph by name. In packaged
+mode the same entries are walked at FFI-load time via `cloacina::package!()`.
 
+This replaced the pre-CLOACI-I-0096 `#[ctor]`-based global registry: there is no
+`ctor` dependency and no manual `register_*`/`deregister_*` calls in user code —
+declaring the macros is sufficient for the runtime to discover them.
 
 ---
 

--- a/docs/content/computation-graphs/tutorials/_index.md
+++ b/docs/content/computation-graphs/tutorials/_index.md
@@ -8,6 +8,12 @@ weight: 10
 
 Learn Cloacina's computation graph system through progressive, hands-on tutorials.
 
+> **About the numbering:** the computation-graph tutorials are a self-contained
+> track — read them in the order listed below. The file numbers (Library 07–10,
+> Service 07–09) are historical and do **not** imply a continuation of the
+> [workflow tutorials]({{< ref "/workflows/tutorials" >}}); treat this list's
+> order as authoritative.
+
 ## Library (Embedded)
 
 Start here. These tutorials teach you to define and run computation graphs directly in your Rust application.

--- a/docs/content/platform/_index.md
+++ b/docs/content/platform/_index.md
@@ -8,7 +8,17 @@ weight: 30
 
 Platform documentation covers cross-cutting concerns that apply regardless of whether you're using workflows, computation graphs, or both — and regardless of whether you're in library or service mode.
 
+**Who this is for:** operators and developers deploying and running Cloacina as a
+service (the `cloacina-server`, compiler, and agent fleet) — applies to both
+Rust- and Python-authored packages. **Prerequisites:** a working package (see
+[Creating Your First Package]({{< ref "/platform/how-to-guides/creating-your-first-package" >}}))
+and a Postgres database for multi-tenant/production deployments.
+
 ## Topics
+
+### Tutorials
+- [Deploy a Server]({{< ref "/platform/tutorials/01-deploy-a-server" >}}) — first deployment, end to end
+- [The Web UI]({{< ref "/platform/tutorials/02-the-web-ui" >}}) — operate and observe a running server
 
 ### Reference
 - [CLI Reference]({{< ref "/platform/reference/cli" >}}) — `cloacinactl` commands and flags

--- a/docs/content/platform/how-to-guides/production-deployment.md
+++ b/docs/content/platform/how-to-guides/production-deployment.md
@@ -94,7 +94,7 @@ The server binds to `127.0.0.1` (localhost only) when behind a reverse proxy —
 Configure your load balancer to check:
 
 - **Liveness**: `GET /health` — returns 200 if the process is alive
-- **Readiness**: `GET /ready` — returns 200 if the database is connected and migrations are applied
+- **Readiness**: `GET /ready` — returns 200 when the database connection pool is reachable **and** no loaded computation graph has crashed; otherwise 503 with a `reason` field (`database unreachable` or `crashed computation graphs`)
 
 ## Docker Compose Example
 
@@ -111,11 +111,14 @@ services:
 
   cloacina:
     build: .
-    command: ["serve", "--database-url", "postgres://cloacina:cloacina@postgres:5432/cloacina", "--bind", "0.0.0.0:8080"]
+    # cloacina-server takes its flags directly (no subcommand). Binding
+    # 0.0.0.0 is safe here because the port is NOT published to the host —
+    # only Caddy (443) is reachable from outside the compose network.
+    command: ["--database-url", "postgres://cloacina:cloacina@postgres:5432/cloacina", "--bind", "0.0.0.0:8080"]
     depends_on:
       - postgres
-    ports:
-      - "8080:8080"
+    expose:
+      - "8080"
 
   caddy:
     image: caddy:2
@@ -127,3 +130,41 @@ services:
 volumes:
   pgdata:
 ```
+
+## Choosing a deployment shape first
+
+Before productionizing, confirm you're deploying the right shape — embedded
+library, local daemon, single server, or server + compiler + agent fleet. The
+[When to Use Cloacina]({{< ref "/quick-start/when-to-use" >}}#choosing-a-mode)
+decision table maps each goal to a mode. This guide assumes the **server** shape;
+for the horizontally-scaled fleet see
+[Deploy an Execution Agent Fleet]({{< ref "/platform/how-to-guides/deploy-an-execution-agent-fleet" >}}).
+
+## Production readiness checklist
+
+Work through this before exposing a server to real traffic. Each item links to
+the guide that covers it in depth.
+
+**Network & transport**
+- [ ] TLS terminated at a reverse proxy (Caddy/nginx above); the server itself binds plain HTTP.
+- [ ] Server bound to `127.0.0.1` (or a private interface) — never `0.0.0.0` reachable from the internet without the proxy in front. Don't publish the raw `8080` port.
+- [ ] Reverse-proxy `client_max_body_size` matches the server's 100 MB package-upload limit.
+- [ ] WebSocket upgrade headers proxied (needed for live execution streams and event ingestion).
+
+**Authentication & access**
+- [ ] Bootstrap admin key captured into a secret manager on first start, then the `~/.cloacina/bootstrap-key` file removed or locked down. It is shown only once.
+- [ ] Application clients use **tenant-scoped** keys (`cloacinactl key create … --role …`), never the admin key. See [01 - Deploy a Server]({{< ref "/platform/tutorials/01-deploy-a-server" >}}).
+- [ ] CORS configured **only if** a browser UI calls the server cross-origin — via the `CLOACINA_CORS_ALLOWED_ORIGINS` env var (works with `cloacinactl server start`) or the `--cors-allowed-origins` flag on the `cloacina-server` binary. The value is the origin users load the UI from. See [Deploy the Web UI]({{< ref "/platform/how-to-guides/deploy-the-web-ui" >}}).
+
+**Data & isolation**
+- [ ] PostgreSQL (not SQLite) for any multi-tenant or multi-replica deployment. See [Database Backends]({{< ref "/platform/explanation/database-backends" >}}).
+- [ ] Multi-tenant isolation reviewed — in particular that executions actually run against the tenant's own schema (a misconfigured runner can execute against the wrong schema and break isolation). See [Configure a Multi-Tenant Deployment]({{< ref "/platform/how-to-guides/configure-multi-tenant-deployment" >}}).
+- [ ] Database backups and a restore drill in place.
+
+**Supply chain**
+- [ ] In low-trust / multi-tenant deployments, package signing required so unsigned packages are refused — otherwise a compromised or untrusted uploader could get arbitrary code compiled and run in your build sandbox. See [Require Signed Packages]({{< ref "/platform/how-to-guides/require-signed-packages" >}}).
+
+**Operations**
+- [ ] Load-balancer health checks wired to `GET /health` (liveness) and `GET /ready` (readiness — confirms the DB pool is reachable and no computation graph has crashed).
+- [ ] Metrics scraped from `/metrics` and tracing wired up. See [Observe Execution State]({{< ref "/workflows/how-to-guides/observe-execution-state" >}}).
+- [ ] Runner sizing tuned for your load — database connection pool size, task concurrency, and execution timeouts. See [Performance Tuning]({{< ref "/platform/how-to-guides/performance-tuning" >}}) for the server knobs and recommended values.

--- a/docs/content/platform/reference/cli.md
+++ b/docs/content/platform/reference/cli.md
@@ -351,7 +351,7 @@ substring match on the package name.
 |---|---|---|
 | `execution list [--workflow <F>] [--status <S>] [--limit <N>] [--offset <N>]` | `GET /v1/tenants/<tenant>/executions?status=…&workflow=…&limit=…&offset=…` | Default limit: 100, max 1000. `--status` and `--workflow` map to the server query params of the same names (CLOACI-T-0594 / API-02). |
 | `execution status <ID>` | `GET /v1/tenants/<tenant>/executions/<id>` | Returns Pending / Running / Completed / Failed / Cancelled / Paused. |
-| `execution events <ID> [--since <DURATION>]` | `GET /v1/tenants/<tenant>/executions/<id>/events?since=<dur>` | `--follow` is **not yet implemented** — the flag exists for forward compatibility and currently returns exit 1. |
+| `execution events <ID> [--since <DURATION>] [--follow]` | `GET /v1/tenants/<tenant>/executions/<id>/events?since=<dur>` | `--follow` streams live events over the server's WebSocket delivery substrate (CLOACI-I-0115) until interrupted. `--since` cannot be combined with `--follow` (cursor support is future work); use `--since` on a non-follow call for the historical snapshot. |
 
 ## `graph`
 

--- a/docs/content/platform/reference/environment-variables.md
+++ b/docs/content/platform/reference/environment-variables.md
@@ -43,6 +43,9 @@ If none of these are set, the command exits with an error message listing all th
 | `CLOACINA_VERIFICATION_ORG_ID` | Trusted organization UUID used to verify package signatures. **Required when `CLOACINA_REQUIRE_SIGNATURES` is set**. CLOACI-I-0103 / T-0567. | None | `12345678-1234-1234-1234-123456789abc` | Server | Conditional |
 | `CLOACINA_TENANT_RUNNER_CACHE_SIZE` | LRU cap on cached per-tenant `DefaultRunner` instances. Each cached runner has its own scheduler loop, executor pool, and DB pool. Bump for high-cardinality SaaS; drop for memory-tight deployments. CLOACI-T-0580. | `256` | `1024` | Server | No |
 | `CLOACINA_TENANT_DELETION_DRAIN_TIMEOUT_S` | Max seconds to wait for in-flight workflows to drain during tenant teardown (step 2 of the 4-step orchestration). Past this, the runner is hard-evicted; tasks ignoring cooperative cancellation will error on next DB write. CLOACI-T-0581. | `30` | `60` | Server | No |
+| `CLOACINA_CORS_ALLOWED_ORIGINS` | Comma-separated CORS allowed origins. **CORS is disabled by default** — set this to opt in (REQ-009). Use `*` to allow any origin. Needed when a browser app (e.g. the web UI on a different origin) calls the API. | None (CORS off) | `http://localhost:8082,https://app.example.com` | Server | No |
+| `CLOACINA_CORS_ALLOWED_METHODS` | Comma-separated CORS allowed methods. Only applies once origins are set. | `GET,POST,DELETE,OPTIONS` | `GET,POST` | Server | No |
+| `CLOACINA_CORS_ALLOWED_HEADERS` | Comma-separated CORS allowed request headers. Only applies once origins are set. | `authorization,content-type` | `authorization,content-type,x-tenant` | Server | No |
 
 ### Server CLI Flags (also accept env vars)
 
@@ -59,6 +62,9 @@ These are specified via `clap`'s `env = "..."` attribute and can be set as envir
 | `CLOACINA_DEFAULT_EXECUTOR` | `--default-executor` | `default` | Executor every task is dispatched to (CLOACI-T-0640). `default` runs all work on the in-process thread executor; `fleet` sends it to the [execution-agent fleet]({{< ref "/platform/explanation/execution-agent-fleet" >}}). Hard-matched against registered executors at startup. Preferred surface is `[server].default_executor` in `config.toml`, which `cloacinactl server start` forwards. |
 | `CLOACINA_AGENT_HEARTBEAT_INTERVAL_S` | `--agent-heartbeat-interval-s` | `15` | Heartbeat interval (seconds) the server advertises to fleet agents and uses as its liveness-sweep cadence. Lower = faster dead-agent detection + in-flight reclaim, at the cost of more heartbeat traffic. CLOACI-T-0639. |
 | `CLOACINA_AGENT_LIVENESS_MISSES` | `--agent-liveness-misses` | `3` | Consecutive missed heartbeats before the server marks a fleet agent dead and reclaims its in-flight work. Effective dead-after = interval × misses (default 15s × 3 = 45s). CLOACI-T-0639. |
+| `CLOACINA_CORS_ALLOWED_ORIGINS` | `--cors-allowed-origins` | None (CORS off) | Comma-separated allowed origins; CORS is off until set (REQ-009). `*` allows any. |
+| `CLOACINA_CORS_ALLOWED_METHODS` | `--cors-allowed-methods` | `GET,POST,DELETE,OPTIONS` | Comma-separated allowed methods. |
+| `CLOACINA_CORS_ALLOWED_HEADERS` | `--cors-allowed-headers` | `authorization,content-type` | Comma-separated allowed request headers. |
 
 `CLOACINA_DEFAULT_EXECUTOR` / `--default-executor` is forwarded by the
 `cloacinactl server start` wrapper (preferably set via

--- a/docs/content/platform/reference/http-api.md
+++ b/docs/content/platform/reference/http-api.md
@@ -49,15 +49,17 @@ only identifier that ties a client-observed failure to the server's
 logs. If the client supplies an inbound `x-request-id` header the
 middleware honours it (enables end-to-end trace propagation).
 
-### SSE / live-follow (NOT in v1)
+### Live event streaming (WebSocket)
 
-The CLI's `execution events --follow` flag exists for forward
-compatibility but is **not implemented in v1**. There is no SSE
-endpoint, no WebSocket subscription for execution events, and no
-long-poll alternative. Clients that need live event streaming should
-poll `GET /v1/tenants/{tenant_id}/executions/{exec_id}/events?since=…`
-on an interval until the upstream SSE work lands. (Planned but
-unscheduled; tracked outside CLOACI-I-0107.)
+Live execution-event streaming is delivered over the WebSocket delivery
+substrate (CLOACI-I-0115), not SSE. The CLI's `execution events --follow` mints a
+single-use WebSocket ticket (`POST /v1/auth/ws-ticket`), connects to the
+delivery endpoint addressed at `exec_events:<execution_id>`, and tails events
+live until interrupted. For a historical snapshot, poll
+`GET /v1/tenants/{tenant_id}/executions/{exec_id}/events?since=…`; `--since` and
+`--follow` cannot be combined yet (cursor support is future work). See the
+[WebSocket Protocol]({{< ref "/platform/reference/websocket-protocol" >}}) for the
+envelope and ticket flow.
 
 ## Authentication
 

--- a/docs/content/platform/tutorials/01-deploy-a-server.md
+++ b/docs/content/platform/tutorials/01-deploy-a-server.md
@@ -333,6 +333,16 @@ You now have:
 
 ## Where to go next
 
+> **Planning to add the web UI?** The server **rejects browser requests
+> cross-origin by default.** Before you point the web UI at this server, allow
+> its origin. With `cloacinactl server start` (used above), set the environment
+> variable before starting:
+> `CLOACINA_CORS_ALLOWED_ORIGINS=https://ui.example.com` (the value is the URL
+> users load the UI from). The equivalent `--cors-allowed-origins` flag is
+> available when you run the `cloacina-server` binary directly. See
+> [Deploy the Web UI]({{< ref "/platform/how-to-guides/deploy-the-web-ui" >}})
+> for the full wiring.
+
 - [Configure a Multi-Tenant Deployment]({{< ref "/platform/how-to-guides/configure-multi-tenant-deployment" >}})
   — productionize multi-tenancy and learn the operational caveats
   (the runner-schema execution gap is critical for true isolation).

--- a/docs/content/python/_index.md
+++ b/docs/content/python/_index.md
@@ -8,6 +8,19 @@ weight: 15
 
 **Cloaca** is the Python package that provides full access to Cloacina's workflow and computation graph engines. Built with PyO3, it offers native performance with Pythonic ergonomics.
 
+**Who this is for:** Python developers building task pipelines or event-driven
+graphs. **Prerequisites:** Python 3.9+ and a database (SQLite needs nothing
+extra; Postgres for multi-tenancy/scale).
+
+**Relationship to Rust:** Cloaca is *not* a reimplementation — it's a PyO3 layer
+over the same Rust engine the [`cloacina` crate]({{< ref "/workflows" >}}) uses,
+with full surface parity. The same primitives, packaging format, and database
+model apply; where the Python ergonomics differ (decorators + a builder vs.
+macros, owned values vs. borrows, the GIL), the
+[Python Runtime Architecture]({{< ref "/python/workflows/explanation/python-runtime-architecture" >}})
+explains why. Concepts and platform/operations docs in the Rust-side sections
+apply to Python deployments too.
+
 ## Installation
 
 ```bash
@@ -19,11 +32,11 @@ pip install cloaca[postgres]    # PostgreSQL only
 ## Features
 
 - **Workflow orchestration** — Define tasks with `@cloaca.task`, build workflows with the `WorkflowBuilder` context manager, execute with `DefaultRunner`.
-- **Computation graphs** — Author event-driven graphs with `ComputationGraphBuilder` + `@cloaca.reactor` + `@cloaca.accumulator`; embed them as workflow tasks (CLOACI-I-0101) or run them standalone.
-- **Multi-tenancy** — PostgreSQL schema isolation via `DatabaseAdmin` (CLOACI-I-0106: fail-closed `search_path`, decommission flow).
-- **Cron scheduling** — Time-based workflow execution with `CatchupPolicy::Skip` / `RunAll`.
+- **Computation graphs** — Author event-driven graphs with `ComputationGraphBuilder` + `@cloaca.reactor` + the accumulator decorators (`@cloaca.passthrough_accumulator`, `@cloaca.stream_accumulator`, `@cloaca.polling_accumulator`, `@cloaca.batch_accumulator`) + `@cloaca.node`.
+- **Multi-tenancy** — PostgreSQL schema isolation via `DatabaseAdmin` (fail-closed `search_path`, decommission flow).
+- **Cron scheduling** — Time-based workflow execution with skip / run-all catch-up policies.
 - **Event triggers** — `@cloaca.trigger` for external or reactor-sourced workflow firing.
-- **First-class parity** — Python tracks the Rust surface 1:1; the `cloacina-python` crate (CLOACI-T-0529 / CLOACI-T-0532) keeps the PyO3 dependency out of the core library.
+- **First-class parity** — Python tracks the Rust surface 1:1; the PyO3 layer is kept out of the core library so `cloacina` can ship without it.
 
 ## Two surfaces, Diataxis-aligned
 

--- a/docs/content/python/api-reference/configuration.md
+++ b/docs/content/python/api-reference/configuration.md
@@ -1,330 +1,279 @@
 ---
 title: "Configuration"
-description: "Configuration options for Cloaca components"
+description: "Configuration surface for Cloaca: DefaultRunnerConfig, runner construction, retry, cron, multi-tenancy, and environment variables"
 weight: 70
 ---
 
 # Configuration
 
-Configuration classes and options for customizing Cloaca behavior, including runner settings, database connections, and execution parameters.
+This page describes the configuration surface exposed by the `cloaca` package:
+the `DefaultRunnerConfig` class and its fields, how a runner is constructed with
+a configuration, task-level retry options, cron-schedule registration, the
+multi-tenant admin types, and the environment variables Cloaca reads. Every
+field, default, and signature below is taken from the binding source.
 
 ## DefaultRunnerConfig
 
-Configuration for the DefaultRunner with database and execution settings.
+Holds the runner's execution and scheduling settings. The constructor accepts
+every field as an optional keyword argument; any argument left unset (`None`)
+takes the engine default shown in the table.
 
 ### Constructor
 
 ```python
 import cloaca
 
-# Default configuration
+# Engine defaults
 config = cloaca.DefaultRunnerConfig()
 
-# Custom configuration
+# Equivalent explicit form
+config = cloaca.DefaultRunnerConfig.default()
+
+# Override selected fields
 config = cloaca.DefaultRunnerConfig(
-    max_concurrent_workflows=10,
-    task_timeout_seconds=300,
-    retry_attempts=3,
-    connection_pool_size=5
+    max_concurrent_tasks=8,
+    task_timeout_seconds=600,
+    db_pool_size=20,
 )
 ```
 
-### Parameters
+### Fields
 
-- `max_concurrent_workflows` (int, default=5): Maximum number of workflows executing simultaneously
-- `task_timeout_seconds` (int, default=3600): Default timeout for task execution in seconds
-- `retry_attempts` (int, default=2): Default number of retry attempts for failed tasks
-- `connection_pool_size` (int, default=10): Database connection pool size
-- `enable_logging` (bool, default=True): Enable detailed execution logging
-- `log_level` (str, default="INFO"): Logging level (DEBUG, INFO, WARNING, ERROR)
+| Field | Type | Default | Meaning |
+|-------|------|---------|---------|
+| `max_concurrent_tasks` | int | `4` | Maximum tasks executing simultaneously |
+| `scheduler_poll_interval_ms` | int | `100` | Scheduler polling interval, in milliseconds |
+| `task_timeout_seconds` | int | `300` | Per-task execution timeout, in seconds |
+| `workflow_timeout_seconds` | int | `3600` | Per-workflow execution timeout, in seconds |
+| `db_pool_size` | int | `10` | Database connection pool size |
+| `enable_recovery` | bool | `True` | Recover in-flight work after a restart |
+| `enable_cron_scheduling` | bool | `True` | Run the cron scheduler loop |
+| `cron_poll_interval_seconds` | int | `30` | Cron scheduler polling interval, in seconds |
+| `cron_max_catchup_executions` | int | `100` | Maximum missed runs replayed per schedule |
+| `cron_enable_recovery` | bool | `True` | Recover lost cron executions |
+| `cron_recovery_interval_seconds` | int | `300` | Cron recovery sweep interval, in seconds |
+| `cron_lost_threshold_minutes` | int | `10` | Age after which a cron execution is considered lost |
+| `cron_max_recovery_age_seconds` | int | `86400` | Oldest cron execution still eligible for recovery |
+| `cron_max_recovery_attempts` | int | `3` | Maximum recovery attempts per cron execution |
 
-### Example Usage
+Time fields are plain integers in the unit named by the field (seconds or
+milliseconds); there is no `timedelta`/`Duration` surface.
+
+### Methods
+
+- `default()` (static) — returns a `DefaultRunnerConfig` with all engine defaults.
+- `to_dict()` — returns the configuration as a `dict`.
+
+Each field also has a matching read/write property.
+
+## Constructing a runner with a configuration
+
+The `DefaultRunner` constructor takes only a database URL. There is **no**
+`config=` keyword argument on the constructor. To supply a configuration, use
+the `with_config` static method.
 
 ```python
 import cloaca
 
-# Create custom configuration
-config = cloaca.DefaultRunnerConfig(
-    max_concurrent_workflows=20,
-    task_timeout_seconds=600,  # 10 minutes
-    retry_attempts=5,
-    connection_pool_size=15,
-    enable_logging=True,
-    log_level="DEBUG"
-)
+# Default configuration
+runner = cloaca.DefaultRunner("sqlite:///workflows.db")
 
-# Create runner with configuration
-runner = cloaca.DefaultRunner(
-    database_url="sqlite:///workflows.db",
-    config=config
-)
+# Custom configuration
+config = cloaca.DefaultRunnerConfig(max_concurrent_tasks=8, db_pool_size=20)
+runner = cloaca.DefaultRunner.with_config("sqlite:///workflows.db", config)
 ```
 
-## Database Configuration
+### with_schema (PostgreSQL multi-tenancy)
 
-### SQLite Configuration
-
-```python
-# In-memory database (for testing)
-runner = cloaca.DefaultRunner("sqlite:///:memory:")
-
-# File-based SQLite
-runner = cloaca.DefaultRunner("sqlite:///path/to/database.db")
-
-# SQLite with connection parameters
-runner = cloaca.DefaultRunner(
-    "sqlite:///workflows.db?timeout=20&journal_mode=WAL"
-)
-```
-
-### PostgreSQL Configuration
+`with_schema` pins the runner to a single PostgreSQL schema (for schema-isolated
+multi-tenancy). It accepts only `postgresql://` / `postgres://` URLs and rejects
+empty or non-alphanumeric schema names.
 
 ```python
-# Basic PostgreSQL connection
-runner = cloaca.DefaultRunner(
-    "postgresql://username:password@localhost:5432/database"
-)
-
-# PostgreSQL with custom configuration
-config = cloaca.DefaultRunnerConfig(
-    connection_pool_size=20,
-    max_concurrent_workflows=15
-)
-
-runner = cloaca.DefaultRunner(
+runner = cloaca.DefaultRunner.with_schema(
     "postgresql://user:pass@localhost:5432/cloaca",
-    config=config
+    "tenant_acme",
 )
 ```
 
-## Task Configuration
+### Database URLs
 
-### Retry Configuration
+The URL determines the backend; connection parameters are passed in the URL
+string itself.
 
-Configure retry behavior for individual tasks:
+```python
+# SQLite — in-memory (testing)
+cloaca.DefaultRunner("sqlite:///:memory:")
+
+# SQLite — file-backed, with SQLite URL parameters
+cloaca.DefaultRunner("sqlite:///workflows.db?journal_mode=WAL")
+
+# PostgreSQL
+cloaca.DefaultRunner("postgresql://user:pass@localhost:5432/cloaca")
+```
+
+`DefaultRunner` is also a context manager; exiting the `with` block calls
+`shutdown()`.
+
+```python
+with cloaca.DefaultRunner("sqlite:///workflows.db") as runner:
+    result = runner.execute("my_workflow", cloaca.Context())
+```
+
+## Task retry configuration
+
+Retry behaviour is configured with discrete keyword arguments on the
+`@cloaca.task` decorator. There is no `retry_policy` dict argument and no
+`timeout_seconds` argument on the decorator (task timeout is the runner-level
+`task_timeout_seconds` above).
 
 ```python
 @cloaca.task(
     id="resilient_task",
-    retry_policy={
-        "max_attempts": 5,
-        "retry_delay_seconds": 10,
-        "exponential_backoff": True,
-        "max_delay_seconds": 300
-    }
+    retry_attempts=5,
+    retry_backoff="exponential",   # "fixed" | "linear" | "exponential"
+    retry_delay_ms=1000,
+    retry_max_delay_ms=60000,
+    retry_condition="transient",   # "never" | "transient" | "all"
+    retry_jitter=True,
 )
 def resilient_task(context):
-    """Task with custom retry configuration."""
-    # Task implementation
     return context
 ```
 
-### Timeout Configuration
+| Argument | Type | Meaning |
+|----------|------|---------|
+| `retry_attempts` | int | Number of retry attempts after the first failure |
+| `retry_backoff` | str | `"fixed"`, `"linear"`, or `"exponential"` |
+| `retry_delay_ms` | int | Base delay between attempts, in milliseconds |
+| `retry_max_delay_ms` | int | Upper bound on backoff delay, in milliseconds |
+| `retry_condition` | str | `"never"`, `"transient"` (retry only transient errors), or `"all"` |
+| `retry_jitter` | bool | Add randomized jitter to backoff delays |
 
-Set task-specific timeouts:
+See the [Task Decorator]({{< ref "/python/api-reference/task/" >}}) reference for
+the full argument list (including `on_success`, `on_failure`, `invokes`, and
+`post_invocation`).
+
+## Cron scheduling
+
+There is no `CronSchedule` class. Cron schedules are registered and managed
+through methods on a running `DefaultRunner`, and read operations return plain
+dicts.
 
 ```python
-@cloaca.task(
-    id="long_running_task",
-    timeout_seconds=1800  # 30 minutes
+runner = cloaca.DefaultRunner("sqlite:///workflows.db")
+
+# Register — returns the schedule id (str)
+schedule_id = runner.register_cron_workflow(
+    "daily_report",      # workflow_name
+    "0 9 * * *",         # cron_expression
+    "UTC",               # timezone
 )
-def long_running_task(context):
-    """Task that may take a long time."""
-    # Long-running operation
-    return context
+
+# List active schedules (list[dict])
+schedules = runner.list_cron_schedules(enabled_only=True)
+
+# Enable / disable / update / delete
+runner.set_cron_schedule_enabled(schedule_id, False)
+runner.update_cron_schedule(schedule_id, "*/15 * * * *", "America/New_York")
+runner.delete_cron_schedule(schedule_id)
 ```
 
-## Cron Configuration
+Each schedule dict has the keys: `id`, `workflow_name`, `cron_expression`,
+`timezone`, `enabled`, `catchup_policy`, `next_run_at`, `last_run_at`,
+`created_at`, `updated_at`. Execution history and statistics are available via
+`get_cron_execution_history(schedule_id, ...)` and
+`get_cron_execution_stats(since)`. See the
+[DefaultRunner]({{< ref "/python/api-reference/runner/" >}}) reference for the
+full set of cron, trigger, and reactor-subscription (event-driven trigger)
+methods.
 
-### CronSchedule Configuration
+## Multi-tenant configuration
 
-```python
-import cloaca
-
-# Basic cron schedule
-schedule = cloaca.CronSchedule(
-    workflow_name="daily_report",
-    cron_expression="0 9 * * *",  # Daily at 9 AM
-    timezone="UTC",
-    enabled=True
-)
-
-# Advanced cron configuration
-schedule = cloaca.CronSchedule(
-    workflow_name="complex_workflow",
-    cron_expression="*/15 * * * *",  # Every 15 minutes
-    timezone="America/New_York",
-    enabled=True,
-    context=cloaca.Context({"priority": "high"}),
-    max_missed_runs=3,
-    catch_up=False
-)
-```
-
-### Cron Parameters
-
-- `workflow_name` (str): Name of the workflow to execute
-- `cron_expression` (str): Standard cron expression
-- `timezone` (str): Timezone for schedule evaluation
-- `enabled` (bool): Whether the schedule is active
-- `context` (Context): Initial context for scheduled executions
-- `max_missed_runs` (int): Maximum number of missed runs to catch up
-- `catch_up` (bool): Whether to execute missed runs on startup
-
-## Multi-Tenant Configuration
+The multi-tenant admin types require PostgreSQL support; they are not importable
+from a SQLite-only wheel. Install with `pip install cloaca[postgres]` (see
+[Installation]({{< ref "/python" >}}#installation)).
 
 ### TenantConfig
 
-Configuration for tenant provisioning:
-
 ```python
 import cloaca
 
-# Basic tenant configuration
-tenant_config = cloaca.TenantConfig(
+# Auto-generate a secure password (password omitted)
+config = cloaca.TenantConfig(
     schema_name="tenant_acme",
     username="acme_user",
-    password=""  # Auto-generate secure password
 )
 
 # Explicit password
-tenant_config = cloaca.TenantConfig(
+config = cloaca.TenantConfig(
     schema_name="tenant_globex",
     username="globex_user",
-    password="secure_password_123"
+    password="secure_password_123",
 )
 ```
 
-### DatabaseAdmin Configuration
+| Parameter | Type | Meaning |
+|-----------|------|---------|
+| `schema_name` | str | PostgreSQL schema to isolate the tenant in |
+| `username` | str | Role to create for the tenant |
+| `password` | str, optional | Tenant password; omitted/`None` means auto-generate |
+
+`schema_name`, `username`, and `password` are exposed as read-only properties.
+
+### DatabaseAdmin
+
+The constructor takes only a PostgreSQL admin URL. It does **not** accept
+`connection_timeout`, `command_timeout`, or `enable_ssl`; pass connection
+options in the URL. Non-PostgreSQL URLs are rejected.
 
 ```python
-# Admin with default settings
-admin = cloaca.DatabaseAdmin("postgresql://admin:pass@localhost/db")
+admin = cloaca.DatabaseAdmin("postgresql://admin:pass@localhost:5432/cloaca")
 
-# Admin with custom configuration
-admin_config = {
-    "connection_timeout": 30,
-    "command_timeout": 60,
-    "enable_ssl": True
-}
+# Provision a tenant — returns TenantCredentials
+creds = admin.create_tenant(config)
+print(creds.username, creds.connection_string)
 
-admin = cloaca.DatabaseAdmin(
-    "postgresql://admin:pass@localhost/db",
-    **admin_config
-)
+# Decommission a tenant
+admin.remove_tenant("tenant_acme", "acme_user")
 ```
 
-## Environment Configuration
+`create_tenant(config)` returns a `TenantCredentials` object with the read-only
+properties `username`, `password`, `schema_name`, and `connection_string`.
+`remove_tenant(schema_name, username)` drops the tenant. See the
+[DatabaseAdmin]({{< ref "/python/api-reference/database-admin/" >}}) reference
+for the full multi-tenant flow.
 
-### Environment Variables
+## Environment variables
 
-Cloaca respects several environment variables:
+Cloaca reads the following environment variables. There are no `CLOACA_*`
+variables.
 
-```bash
-# Database configuration
-export CLOACA_DATABASE_URL="postgresql://user:pass@localhost/cloaca"
-export CLOACA_LOG_LEVEL="DEBUG"
-export CLOACA_MAX_WORKERS="10"
+| Variable | Read by | Purpose |
+|----------|---------|---------|
+| `CLOACINA_VAR_<NAME>` | `cloaca.var("<NAME>")`, `cloaca.var_or("<NAME>", default)` | User-defined configuration values resolved at runtime |
+| `RUST_LOG` | runtime tracing initialization | Log filter (e.g. `info`, `debug`, `cloacina=debug`); defaults to `info` |
 
-# Multi-tenant configuration
-export CLOACA_ADMIN_DATABASE_URL="postgresql://admin:pass@localhost/cloaca"
-export CLOACA_DEFAULT_SCHEMA="public"
-
-# Performance tuning
-export CLOACA_CONNECTION_POOL_SIZE="20"
-export CLOACA_TASK_TIMEOUT="3600"
-```
-
-### Configuration from Environment
-
-```python
-import os
-import cloaca
-
-# Use environment variables
-database_url = os.environ.get(
-    "CLOACA_DATABASE_URL",
-    "sqlite:///default.db"
-)
-
-log_level = os.environ.get("CLOACA_LOG_LEVEL", "INFO")
-max_workers = int(os.environ.get("CLOACA_MAX_WORKERS", "5"))
-
-config = cloaca.DefaultRunnerConfig(
-    max_concurrent_workflows=max_workers,
-    log_level=log_level
-)
-
-runner = cloaca.DefaultRunner(database_url, config)
-```
-
-## Production Configuration
-
-### Recommended Production Settings
+`cloaca.var(name)` reads the environment variable `CLOACINA_VAR_` + `name`
+**verbatim** (no case conversion) and raises if it is unset;
+`cloaca.var_or(name, default)` returns `default` when the variable is absent.
+Pass the name in the exact case of the environment variable.
 
 ```python
 import cloaca
 
-# Production configuration
-production_config = cloaca.DefaultRunnerConfig(
-    max_concurrent_workflows=50,
-    task_timeout_seconds=1800,  # 30 minutes
-    retry_attempts=3,
-    connection_pool_size=25,
-    enable_logging=True,
-    log_level="INFO"
-)
+# Reads CLOACINA_VAR_DATABASE_URL  (name passed in upper case, matching the env var)
+database_url = cloaca.var_or("DATABASE_URL", "sqlite:///default.db")
 
-# Production database with connection pooling
-database_url = "postgresql://cloaca:secure_password@db.example.com:5432/cloaca_prod?sslmode=require"
-
-runner = cloaca.DefaultRunner(database_url, production_config)
+runner = cloaca.DefaultRunner(database_url)
 ```
 
-### Health Check Configuration
-
-```python
-# Configure health monitoring
-@cloaca.task(id="health_check")
-def health_check(context):
-    """Monitor system health."""
-    import psutil
-
-    health_data = {
-        "cpu_percent": psutil.cpu_percent(),
-        "memory_percent": psutil.virtual_memory().percent,
-        "disk_percent": psutil.disk_usage('/').percent
-    }
-
-    context.set("health_metrics", health_data)
-    return context
-```
-
-## Configuration Validation
-
-Validate configuration before use:
-
-```python
-def validate_config(config):
-    """Validate runner configuration."""
-    if config.max_concurrent_workflows < 1:
-        raise ValueError("max_concurrent_workflows must be positive")
-
-    if config.task_timeout_seconds < 1:
-        raise ValueError("task_timeout_seconds must be positive")
-
-    if config.connection_pool_size < 1:
-        raise ValueError("connection_pool_size must be positive")
-
-    return True
-
-# Usage
-config = cloaca.DefaultRunnerConfig(max_concurrent_workflows=10)
-validate_config(config)
-```
+See the
+[Environment Variables]({{< ref "/python/workflows/reference/environment-variables" >}})
+reference for the full variable-registry conventions.
 
 ## See Also
 
-- **[DefaultRunner]({{< ref "/python/api-reference/runner/" >}})** - Execute workflows with configuration
-- **[DatabaseAdmin]({{< ref "/python/api-reference/database-admin/" >}})** - Multi-tenant configuration
-- **[Task Decorator]({{< ref "/python/api-reference/task/" >}})** - Task-level configuration
+- **[DefaultRunner]({{< ref "/python/api-reference/runner/" >}})** — execute workflows, cron, triggers, reactor subscriptions
+- **[DatabaseAdmin]({{< ref "/python/api-reference/database-admin/" >}})** — multi-tenant provisioning
+- **[Task Decorator]({{< ref "/python/api-reference/task/" >}})** — full task argument surface, including retry

--- a/docs/content/python/api-reference/workflow-builder.md
+++ b/docs/content/python/api-reference/workflow-builder.md
@@ -10,6 +10,20 @@ review_date: "2025-01-07"
 
 The `WorkflowBuilder` class provides a builder pattern for constructing workflows. It allows you to add tasks, set descriptions, configure dependencies, and build executable workflow objects.
 
+{{< hint info >}}
+**Which pattern, and when**
+
+Cloaca has three ways to define a workflow. They are not interchangeable — pick by how the workflow is deployed:
+
+1. **Context manager — `with cloaca.WorkflowBuilder(...) as builder:`** — for **in-process** workflows you run yourself with `DefaultRunner`. Exiting the `with` block builds the workflow and registers it into the runtime your `DefaultRunner` reads from. This is the common case and what the tutorials use.
+2. **Manual builder + `register_workflow_constructor`** — the same in-process scenario, for **dynamic or programmatic** construction (e.g. a factory that builds workflow variants from config). You call `build()` yourself and register a constructor function — see the [Complete Workflow Example](#complete-workflow-example) below.
+3. **Bare `@cloaca.task` decorators (no builder at all)** — for **packaged `.cloacina` workflows** loaded by a server or daemon. The package loader supplies the workflow context, so a packaged module declares tasks with `@cloaca.task` and does **not** construct a `WorkflowBuilder`.
+
+**Pitfall:** a `WorkflowBuilder` inside a packaged workflow module fails to load (the loader has already supplied the workflow context). Packaged modules use bare decorators only — see [Packaging Python Workflows]({{< ref "/python/workflows/how-to-guides/packaging-python-workflows" >}}).
+{{< /hint >}}
+
+This page documents patterns 1 and 2 (in-process). For pattern 3, see the packaging guides.
+
 ## Constructor
 
 ### `WorkflowBuilder(name)`
@@ -114,8 +128,7 @@ Build the workflow and validate its structure.
 **Returns:** Workflow object ready for execution
 
 **Raises:**
-- `ValueError`: If workflow has structural problems
-- `KeyError`: If referenced tasks don't exist
+- `ValueError`: if the workflow has structural problems or references a task that doesn't exist (all builder failures surface as `ValueError`)
 
 **Example:**
 ```python
@@ -411,12 +424,12 @@ def inspect_workflow(workflow):
     for i, level in enumerate(levels):
         print(f"  Level {i}: {level}")
 
-    # Check parallelism opportunities
+    # Tasks within the same execution level have no dependency between them
+    # and therefore run in parallel.
     print("\nParallelism analysis:")
-    for i, task1 in enumerate(topo_order):
-        for task2 in topo_order[i+1:]:
-            if workflow.can_run_parallel(task1, task2):
-                print(f"  {task1} can run parallel with {task2}")
+    for i, level in enumerate(levels):
+        if len(level) > 1:
+            print(f"  Level {i} runs in parallel: {level}")
 ```
 
 ## Error Handling

--- a/docs/content/python/computation-graphs/explanation/python-cg-decorator-surface.md
+++ b/docs/content/python/computation-graphs/explanation/python-cg-decorator-surface.md
@@ -1,39 +1,54 @@
 ---
 title: "Python CG Decorator Surface"
-description: "How the Python computation graph decorators map onto the Rust macro family — `@cloaca.reactor` / `ComputationGraphBuilder` / `@cloaca.accumulator` and friends."
+description: "How cloaca's computation-graph decorators map onto the Rust macro family, and where they differ."
 weight: 10
 ---
 
 # Python CG Decorator Surface
 
-<!-- TODO(DOC-G Phase 5): full content deferred. Sources to read: -->
-<!--   - crates/cloacina-python/src/computation_graph.rs (decorator implementations) -->
-<!--   - crates/cloacina-python/src/reactor.rs (reactor surface) -->
-<!--   - crates/cloacina-macros/src/{reactor_attr.rs,computation_graph/parser.rs} (Rust side) -->
-<!--   - .metis archived I-0101 / I-0102 -->
+`cloaca` exposes the computation-graph surface as decorators and a builder that
+mirror the Rust macros. This page maps the two and explains where Python differs.
 
-This page sketches the 1:1 mapping between the Python CG decorator surface and the Rust macro family. Pending full verification, the headline correspondences are:
+## The mapping
 
-| Rust macro | Python equivalent | Notes |
-|---|---|---|
-| `#[reactor(name = ..., accumulators = [...], criteria = ...)]` | `@cloaca.reactor(name=..., accumulators=[...], criteria=...)` | Per CLOACI-I-0101, the reactor is a standalone publisher; same in Python. |
-| `#[computation_graph(graph = { ... })]` | `cloaca.ComputationGraphBuilder("name", graph={...})` as a context manager | Per CLOACI-I-0101, the trigger is optional in both surfaces. The embedded form (`invokes = computation_graph(...)`) translates to `@cloaca.task(invokes="...")`. |
-| `#[stream_accumulator]` / `#[batch_accumulator]` / `#[state_accumulator]` / `#[passthrough_accumulator]` | `@cloaca.stream_accumulator` / `@cloaca.batch_accumulator` / `@cloaca.state_accumulator` / `@cloaca.passthrough_accumulator` | Same family, same semantics. |
+| Rust macro | Python equivalent |
+|---|---|
+| `#[reactor(name = …, accumulators = […], criteria = when_any/when_all(…))]` | `@cloaca.reactor(name=…, accumulators=[…], mode="when_any"\|"when_all")` (decorates a class) |
+| `#[computation_graph(trigger = reactor("…"), graph = { … })]` | `cloaca.ComputationGraphBuilder("name", reactor=…, graph={…})` (a context manager) |
+| node functions inside the `#[computation_graph]` module | `@cloaca.node` functions inside the builder's `with` block |
+| `#[passthrough_accumulator]` | `@cloaca.passthrough_accumulator` |
+| `#[stream_accumulator(type=…, topic=…, group=…)]` | `@cloaca.stream_accumulator(type=…, topic=…, group=…)` |
+| `#[polling_accumulator(interval=…)]` | `@cloaca.polling_accumulator(interval=…)` |
+| `#[batch_accumulator(flush_interval=…, max_buffer_size=…)]` | `@cloaca.batch_accumulator(flush_interval=…, max_buffer_size=…)` |
 
-## Where it differs
+Reaction criteria is written as `mode="when_any"` / `mode="when_all"` in Python,
+versus the `criteria = when_any(...)` form in Rust.
 
-Where the Python surface departs from the Rust surface, it's usually for ergonomic reasons:
+## Where Python differs from Rust
 
-- **Topology shape**: Python uses a dict (`graph={...}`); Rust uses a token-tree literal (`graph = { ... }`). The Python dict is parsed at build-time inside the context manager rather than at compile-time inside the macro.
-- **Borrow semantics**: Rust node functions take `Option<&T>` (references into the cache); Python node functions get owned values (the GIL boundary forces a copy).
+- **Accumulator types: four, not five.** Python exposes `passthrough`, `stream`,
+  `polling`, and `batch`. The Rust-only `#[state_accumulator]` (a bounded
+  DAL-persisted history buffer) has no Python decorator.
+- **Topology is a dict, parsed at build time.** Rust declares the graph as a
+  token-tree literal inside the macro (compile-time); Python passes a
+  [topology dict]({{< ref "/python/computation-graphs/reference/topology-dict-schema" >}})
+  to `ComputationGraphBuilder`, validated when the `with` block exits.
+- **Node values are owned, not borrowed.** Rust node functions take `Option<&T>`
+  references into the cache; Python node functions receive owned values (the
+  Python/Rust boundary copies them).
+- **Routing returns a tuple.** A Python routing node returns
+  `(variant_name, value)`; the variant name selects the route.
 
-## Single FFI surface (CLOACI-I-0102)
+## One runtime, one package format
 
-Whichever language authors the CG, the resulting package implements the same 9-method FFI vtable per CLOACI-I-0102. The server / runner does not know whether a loaded package is Rust- or Python-authored.
+Whichever language authors a computation graph, the result registers into the
+same engine and packages into the same `.cloacina` format. The server/runner
+loads a Python-authored graph and a Rust-authored graph through the same path —
+it doesn't care which language wrote it. See
+[Package a Python Computation Graph]({{< ref "/python/computation-graphs/how-to-guides/package-a-python-computation-graph" >}}).
 
 ## See also
 
-- [Rust · CG · Reference]({{< ref "/computation-graphs/reference/computation-graphs" >}}).
-- [Rust · CG · Architecture]({{< ref "/computation-graphs/explanation/architecture" >}}).
-- **CLOACI-I-0101** — CG / reactor decouple + embedded CG form.
-- **CLOACI-I-0102** — Unified `cloacina::package!()` shell + 9-method FFI vtable.
+- [Topology Dict Schema]({{< ref "/python/computation-graphs/reference/topology-dict-schema" >}}) — the `graph={...}` format.
+- [Computation Graph (Rust reference)]({{< ref "/computation-graphs/reference/computation-graphs" >}}) — the macro family this mirrors.
+- [Choosing Accumulator Types]({{< ref "/computation-graphs/how-to-guides/accumulator-types" >}}) — what each accumulator does.

--- a/docs/content/python/computation-graphs/how-to-guides/filter-reactor-subscriptions.md
+++ b/docs/content/python/computation-graphs/how-to-guides/filter-reactor-subscriptions.md
@@ -1,22 +1,72 @@
 ---
 title: "Filter Reactor Subscriptions (Python)"
-description: "Python equivalent of the CEL-filter recipe — attach a predicate to a workflow's reactor subscription so only matching firings dispatch (CLOACI-T-0602)."
+description: "Attach a CEL predicate to a workflow's reactor subscription so only matching firings dispatch."
 weight: 20
 ---
 
 # Filter Reactor Subscriptions (Python)
 
-<!-- TODO(DOC-G Phase 5): full content deferred until the Python subscribe-with-predicate surface is verified. Sources to check: -->
-<!--   - crates/cloacina-python/src/bindings/runner.rs (look for subscribe_workflow_to_reactor) -->
-<!--   - examples/features/computation-graphs/python-packaged-graph/ (Python example) -->
-<!--   - The Rust counterpart at /computation-graphs/how-to-guides/filter-reactor-firings-with-cel for reference -->
+When you subscribe a workflow to a reactor, every firing dispatches the workflow
+by default. Pass a **CEL predicate** to fire only on matching firings — the
+Python analog of [Filter reactor firings with CEL]({{< ref "/computation-graphs/how-to-guides/filter-reactor-firings-with-cel" >}}).
 
-This page is the Python analog of [Filter reactor firings with CEL]({{< ref "/computation-graphs/how-to-guides/filter-reactor-firings-with-cel" >}}). The underlying mechanism (a CEL predicate on the `reactor_subscriptions` row) is the same — what's not yet verified is the exact Python API surface (`runner.subscribe_workflow_to_reactor(...)` signature).
+## Subscribe with a filter
 
-In the meantime, use the [Rust how-to]({{< ref "/computation-graphs/how-to-guides/filter-reactor-firings-with-cel" >}}) as the conceptual reference; the predicate language, the fail-closed evaluation semantics, and the idempotency-key recipe are language-agnostic.
+`DefaultRunner.subscribe_workflow_to_reactor` takes an optional keyword-only
+`when` argument — a CEL expression evaluated against each firing:
+
+```python
+import cloaca
+
+runner = cloaca.DefaultRunner("sqlite:///app.db")
+
+# Unfiltered — fires on every reactor firing:
+runner.subscribe_workflow_to_reactor("pricing", "alert_workflow")
+
+# Filtered — fires only when the predicate is true:
+runner.subscribe_workflow_to_reactor(
+    "pricing",
+    "alert_workflow",
+    when="payload.quote.price > 100 && payload.quote.region == 'us-east'",
+)
+```
+
+Signature:
+
+```python
+subscribe_workflow_to_reactor(
+    reactor: str,
+    workflow: str,
+    tenant: str | None = None,
+    *,
+    when: str | None = None,
+) -> str
+```
+
+## What the predicate sees
+
+The CEL expression evaluates against these variables:
+
+| Variable | Type | Meaning |
+|----------|------|---------|
+| `payload` | dict | The firing's boundary data, keyed by accumulator/source name |
+| `reactor` | str | The reactor name |
+| `tenant` | str | The tenant |
+
+## Semantics
+
+- When the predicate evaluates **false**, the workflow is **not** dispatched, but
+  the subscription's watermark still advances (the firing is consumed, not
+  re-delivered).
+- An invalid CEL expression is rejected immediately with a `ValueError` at
+  subscribe time.
+
+The predicate language, fail-closed evaluation, and idempotency behavior are
+identical to the Rust path — see the
+[Rust how-to]({{< ref "/computation-graphs/how-to-guides/filter-reactor-firings-with-cel" >}})
+for the conceptual detail.
 
 ## See also
 
-- [Rust · Filter Reactor Firings with CEL]({{< ref "/computation-graphs/how-to-guides/filter-reactor-firings-with-cel" >}}).
-- [Subscription Fan-out]({{< ref "/computation-graphs/explanation/subscription-fan-out" >}}).
-- **CLOACI-T-0602** — CEL predicate filtering on subscriptions.
+- [Filter Reactor Firings with CEL (Rust)]({{< ref "/computation-graphs/how-to-guides/filter-reactor-firings-with-cel" >}})
+- [Subscription Fan-out]({{< ref "/computation-graphs/explanation/subscription-fan-out" >}})

--- a/docs/content/python/computation-graphs/how-to-guides/filter-reactor-subscriptions.md
+++ b/docs/content/python/computation-graphs/how-to-guides/filter-reactor-subscriptions.md
@@ -27,7 +27,7 @@ runner.subscribe_workflow_to_reactor("pricing", "alert_workflow")
 runner.subscribe_workflow_to_reactor(
     "pricing",
     "alert_workflow",
-    when="payload.quote.price > 100 && payload.quote.region == 'us-east'",
+    when="payload.pricing.price > 100 && payload.pricing.region == 'us-east'",
 )
 ```
 
@@ -49,7 +49,7 @@ The CEL expression evaluates against these variables:
 
 | Variable | Type | Meaning |
 |----------|------|---------|
-| `payload` | dict | The firing's boundary data, keyed by accumulator/source name |
+| `payload` | dict | The firing's boundary data. Top-level keys are accumulator/source names; nested keys are that source's fields — e.g. for a `pricing` accumulator, `payload.pricing.price`. |
 | `reactor` | str | The reactor name |
 | `tenant` | str | The tenant |
 

--- a/docs/content/python/computation-graphs/how-to-guides/package-a-python-computation-graph.md
+++ b/docs/content/python/computation-graphs/how-to-guides/package-a-python-computation-graph.md
@@ -55,9 +55,16 @@ input_strategy = "latest"      # or "sequential"
 requires_python = ">=3.10"
 ```
 
-`reaction_mode` and `input_strategy` are optional (they default to `when_any` /
-`latest`). Importing `entry_module` runs your decorators, which register the
-graph.
+Both are optional (defaults: `reaction_mode = "when_any"`, `input_strategy =
+"latest"`):
+
+- `reaction_mode` should match the `mode=` on your `@cloaca.reactor`
+  (`when_any` = fire when any accumulator has new data; `when_all` = wait for all).
+- `input_strategy` controls how queued boundaries are consumed: `latest`
+  collapses to the newest boundary (one execution on the most recent data);
+  `sequential` runs the graph once per boundary in order.
+
+Importing `entry_module` runs your decorators, which register the graph.
 
 ## Step 3: Validate and pack
 

--- a/docs/content/python/computation-graphs/how-to-guides/package-a-python-computation-graph.md
+++ b/docs/content/python/computation-graphs/how-to-guides/package-a-python-computation-graph.md
@@ -1,36 +1,87 @@
 ---
 title: "Package a Python Computation Graph"
-description: "Build a `.cloacina` archive that contains a Python-authored computation graph plus its reactor and accumulators (CLOACI-I-0101 / CLOACI-I-0102)."
+description: "Build, validate, pack, and upload a .cloacina archive containing a Python computation graph."
 weight: 10
 ---
 
 # Package a Python Computation Graph
 
-<!-- TODO(DOC-G Phase 5): full content deferred. Sources to read: -->
-<!--   - `examples/features/computation-graphs/python-packaged-graph/` (runnable example) -->
-<!--   - `crates/cloacina-python/src/loader.rs` (Python package loader) -->
-<!--   - `crates/cloacina-workflow-plugin/src/types.rs:285-340` (9-method FFI vtable per I-0102) -->
-<!--   - .metis archived I-0102 for the unified `cloacina::package!()` Python equivalent -->
+A Python-authored computation graph packages and deploys exactly like a Python
+workflow: a `package.toml` plus a module tree under `workflow/`. The server loads
+it through the same path as a Rust-authored graph. This how-to packages the
+`market_maker` graph end to end. (For the workflow analog, see
+[Packaging Python Workflows]({{< ref "/python/workflows/how-to-guides/packaging-python-workflows" >}}).)
 
-Per CLOACI-I-0101, a Python-authored computation graph can be packaged into a `.cloacina` archive and loaded by `cloacina-server` exactly like a Rust-authored package. Per CLOACI-I-0102, the FFI vtable is unified — the same 9 methods every package exposes.
+## Prerequisites
 
-This how-to is a placeholder pending verification against `examples/features/computation-graphs/python-packaged-graph/`. The runnable example demonstrates the end-to-end packaging flow:
+- A Python computation graph (see [Python CG Decorator Surface]({{< ref "/python/computation-graphs/explanation/python-cg-decorator-surface" >}})).
+- `cloacinactl` installed, and a running server to upload to.
 
-```sh
-angreal demos features python-packaged-graph
+## Step 1: Lay out the package
+
+```
+market-maker/
+├── package.toml
+└── workflow/
+    └── market_maker/
+        ├── __init__.py
+        └── graph.py        # @cloaca.reactor + ComputationGraphBuilder + @cloaca.node
 ```
 
-Once the recipe is verified, this page will cover:
+The module tree **must** live under `workflow/`. `graph.py` holds the reactor,
+the accumulators, the `ComputationGraphBuilder`, and the `@cloaca.node` functions
+(see the [Topology Dict Schema]({{< ref "/python/computation-graphs/reference/topology-dict-schema" >}})).
 
-1. Declaring the CG with `ComputationGraphBuilder` + `@cloaca.reactor`.
-2. Writing the `package.toml` (Python `interface` + `interface_version`).
-3. Building the archive with `maturin build` + the Cloacina packaging shell.
-4. Uploading via `cloacinactl package upload`.
-5. Verifying with `cloacinactl graph list`.
+## Step 2: Write `package.toml`
+
+A computation-graph package sets `graph_name` (this is what marks it a CG rather
+than a workflow) and `entry_module` (the dotted path, relative to `workflow/`,
+the loader imports):
+
+```toml
+[package]
+name = "market-maker"
+version = "0.1.0"
+interface = "cloacina-workflow-plugin"
+interface_version = 1
+extension = "cloacina"
+
+[metadata]
+language = "python"
+graph_name = "market_maker"
+entry_module = "market_maker.graph"
+reaction_mode = "when_any"     # or "when_all"
+input_strategy = "latest"      # or "sequential"
+requires_python = ">=3.10"
+```
+
+`reaction_mode` and `input_strategy` are optional (they default to `when_any` /
+`latest`). Importing `entry_module` runs your decorators, which register the
+graph.
+
+## Step 3: Validate and pack
+
+```bash
+cloacinactl package validate market-maker
+cloacinactl package pack market-maker --out market-maker-0.1.0.cloacina
+```
+
+`validate` checks the layout and the closed `[metadata]` schema; `pack` writes
+the `.cloacina` archive. (No `maturin`/compile step — a Python package ships
+source.)
+
+## Step 4: Upload and verify
+
+```bash
+cloacinactl --tenant my_tenant package upload market-maker-0.1.0.cloacina
+cloacinactl --tenant my_tenant graph list
+```
+
+Once the server loads it, the graph appears in `graph list` and its health is
+queryable via `cloacinactl graph status market_maker`.
 
 ## See also
 
-- [Rust · CG · Packaging]({{< ref "/computation-graphs/explanation/packaging" >}}) — the underlying packaging model is identical.
-- [Packaging Python Workflows]({{< ref "/python/workflows/how-to-guides/packaging-python-workflows" >}}) — the workflow analog (already documented).
-- **CLOACI-I-0101** — CG / reactor decouple + Python embedded form.
-- **CLOACI-I-0102** — Unified `cloacina::package!()` shell.
+- [Topology Dict Schema]({{< ref "/python/computation-graphs/reference/topology-dict-schema" >}})
+- [Packaging Python Workflows]({{< ref "/python/workflows/how-to-guides/packaging-python-workflows" >}}) — the same packaging model for workflows.
+- [Package Format]({{< ref "/platform/explanation/package-format" >}}) — the `.cloacina` archive structure.

--- a/docs/content/python/computation-graphs/reference/topology-dict-schema.md
+++ b/docs/content/python/computation-graphs/reference/topology-dict-schema.md
@@ -1,37 +1,101 @@
 ---
 title: "Topology Dict Schema"
-description: "The Python-side topology dictionary format consumed by `ComputationGraphBuilder` — node spec, input declaration, terminal-node convention."
+description: "The Python topology dictionary consumed by ComputationGraphBuilder — node spec, inputs, routing, and terminal nodes."
 weight: 10
 ---
 
 # Topology Dict Schema
 
-<!-- TODO(DOC-G Phase 5): full content deferred. Sources to read: -->
-<!--   - crates/cloacina-python/src/computation_graph.rs (topology parser, if separate from Rust) -->
-<!--   - examples/tutorials/python/computation-graphs/0[9-11]-*/ (runnable examples showing the shape) -->
-<!--   - The Rust parser at crates/cloacina-macros/src/computation_graph/parser.rs (the dict ought to map 1:1 to the macro shape) -->
+`cloaca.ComputationGraphBuilder(name, reactor=..., graph={...})` takes a `graph`
+keyword whose value is a **topology dictionary**: a map from node name to a node
+spec. This page is the reference for that dictionary's shape.
 
-The Python `ComputationGraphBuilder` takes a `graph=` keyword whose value is a topology dictionary. This page documents that dictionary's schema.
-
-The general shape:
+## Shape
 
 ```python
-with cloaca.ComputationGraphBuilder("graph_name", graph={
-    "node_name": {"inputs": ["source1", "source2"], "next": "downstream_node"},
+graph = {
+    "<node_name>": {
+        "inputs": ["<accumulator_name>", ...],   # optional
+        # exactly one of the following (or neither, for a terminal node):
+        "next": "<downstream_node>",              # linear edge
+        "routes": {"<Variant>": "<node>", ...},   # conditional routing
+    },
     ...
-}) as builder:
-    ...
+}
 ```
 
-Pending verification:
+Each key is a node name that must have a matching `@cloaca.node`-decorated
+function registered inside the builder's `with` block.
 
-- Whether `"next"` accepts a list (multiple downstream nodes) or only a single string.
-- Whether terminal nodes omit `"next"` or use `"next": []` / `"next": None`.
-- Whether source names refer to accumulator names directly or go through a separate mapping.
+## Node spec keys
 
-Until verified, treat the Rust `graph = { ... }` macro shape (in [`#[computation_graph]`]({{< ref "/computation-graphs/reference/computation-graphs" >}})) as the authoritative model — the Python dict mirrors it.
+| Key | Type | Required | Meaning |
+|-----|------|----------|---------|
+| `inputs` | `list[str]` | No | Accumulator names this node reads as cache inputs. Each must be one of the reactor's `accumulators`. Omit for nodes fed only by upstream node outputs. |
+| `next` | `str` | No | Name of the single downstream node this node's output flows to. Mutually exclusive with `routes`. |
+| `routes` | `dict[str, str]` | No | Conditional routing: maps an output **variant name** to the downstream node for that variant. Mutually exclusive with `next`. |
+
+A node spec with **neither** `next` nor `routes` is a **terminal node** — its
+output is collected into the graph result and not forwarded.
+
+## Routing nodes
+
+A node that declares `routes` must return a `(variant_name, value)` tuple: the
+`variant_name` (a `str`) selects which route fires, and `value` (a dict) is passed
+to that downstream node. For example, a node with
+`"routes": {"Trade": "signal_handler", "NoAction": "audit_logger"}` returns either
+`("Trade", {...})` or `("NoAction", {...})`.
+
+Non-routing nodes return their output value directly.
+
+## Validation
+
+The builder validates the topology when the `with` block exits and raises if:
+
+- a node in the topology has no registered `@cloaca.node` function (or vice versa);
+- a `reactor` is provided and an `inputs` entry isn't one of the reactor's
+  `accumulators`;
+- no `reactor` is provided (trigger-less graph) but a node declares `inputs`.
+
+## Example
+
+```python
+import cloaca
+
+@cloaca.reactor(name="market_maker", accumulators=["orderbook", "pricing"], mode="when_any")
+class MarketMakerReactor:
+    pass
+
+with cloaca.ComputationGraphBuilder(
+    "market_maker",
+    reactor=MarketMakerReactor,
+    graph={
+        "decision": {
+            "inputs": ["orderbook", "pricing"],
+            "routes": {"Trade": "signal_handler", "NoAction": "audit_logger"},
+        },
+        "signal_handler": {},   # terminal
+        "audit_logger": {},     # terminal
+    },
+) as builder:
+
+    @cloaca.node
+    def decision(orderbook, pricing):
+        if orderbook and orderbook.get("spread", 1.0) < 0.2:
+            return ("Trade", {"price": orderbook["mid"]})
+        return ("NoAction", {"reason": "spread too wide"})
+
+    @cloaca.node
+    def signal_handler(signal):
+        return {"executed": True, "price": signal["price"]}
+
+    @cloaca.node
+    def audit_logger(reason):
+        return {"logged": True, "reason": reason["reason"]}
+```
 
 ## See also
 
-- [Python · CG · Tutorial 09]({{< ref "/python/computation-graphs/tutorials/09-computation-graph" >}}) — first concrete example.
-- [Rust · CG · Reference]({{< ref "/computation-graphs/reference/computation-graphs" >}}) — the `graph = { ... }` macro shape.
+- [Python CG Decorator Surface]({{< ref "/python/computation-graphs/explanation/python-cg-decorator-surface" >}}) — the decorators these nodes use.
+- [Computation Graph (Rust reference)]({{< ref "/computation-graphs/reference/computation-graphs" >}}) — the `graph = { ... }` macro this dict mirrors.
+- [Python · CG · Tutorial 09]({{< ref "/python/computation-graphs/tutorials/09-computation-graph" >}}) — a first concrete example.

--- a/docs/content/python/computation-graphs/reference/topology-dict-schema.md
+++ b/docs/content/python/computation-graphs/reference/topology-dict-schema.md
@@ -48,6 +48,19 @@ to that downstream node. For example, a node with
 
 Non-routing nodes return their output value directly.
 
+## Node function arguments
+
+How a node's `@cloaca.node` function is called depends on its place in the graph:
+
+- **Entry nodes** (those with `inputs`) receive one argument **per declared input**,
+  in `inputs` order, named to match — e.g. `inputs: ["orderbook", "pricing"]` →
+  `def decision(orderbook, pricing):`. An input with no data yet is passed as
+  `None`.
+- **Downstream nodes** (reached via `next`/`routes`) receive a **single positional
+  argument**: the value the upstream node produced — for a routing edge, the dict
+  from the upstream's `(variant, value)` tuple. The parameter name is yours to
+  choose (it is positional); e.g. `def signal_handler(signal):`.
+
 ## Validation
 
 The builder validates the topology when the `with` block exits and raises if:

--- a/docs/content/python/computation-graphs/tutorials/09-computation-graph.md
+++ b/docs/content/python/computation-graphs/tutorials/09-computation-graph.md
@@ -15,7 +15,7 @@ In this tutorial you'll build your first computation graph in Python — the sam
 
 ## Prerequisites
 
-- Python 3.8+
+- Python 3.9+
 - `cloaca` installed: `pip install cloaca`
 
 ## The complete example
@@ -114,7 +114,7 @@ Inside the `with` block, decorate each node function with `@cloaca.node`. Node n
 **Node function signatures:**
 
 - **Entry nodes** (`ingest`) receive arguments named after each source listed in `"inputs"`. The value is `None` if that source hasn't been populated yet.
-- **Processing nodes** (`compute_spread`, `format_output`) receive a single `input_data` argument — the dict returned by the upstream node.
+- **Processing nodes** (`compute_spread`, `format_output`) receive a single argument — the dict returned by the upstream node. It's positional, so the name is yours to choose; this tutorial calls it `input_data`.
 - **Return values** are plain Python dicts. The terminal node's return dict becomes the `execute()` result.
 
 ---

--- a/docs/content/python/workflows/explanation/python-runtime-architecture.md
+++ b/docs/content/python/workflows/explanation/python-runtime-architecture.md
@@ -6,13 +6,7 @@ weight: 10
 
 # Python Runtime Architecture
 
-<!-- TODO(DOC-G Phase 5): full content deferred. Code sources to read before filling: -->
-<!--   - `crates/cloacina-python/Cargo.toml` (deps + features) -->
-<!--   - `crates/cloacina-python/src/lib.rs` (pymodule registration) -->
-<!--   - `crates/cloacina-python/src/bindings/{context,runner,admin,trigger}.rs` -->
-<!--   - .metis/initiatives archives for T-0529 / T-0532 (the crate split rationale) -->
-
-This page sketches how the Python `cloaca` module fits onto the underlying Rust runtime. Three points worth knowing:
+This page explains how the Python `cloaca` module fits onto the underlying Rust runtime. Three points worth knowing:
 
 ## The `cloacina-python` crate split (CLOACI-T-0529 / CLOACI-T-0532)
 
@@ -35,7 +29,7 @@ Python is a first-class surface (see the user feedback memory: Python support is
 | Rust | Python equivalent |
 |---|---|
 | `#[task(...)]` | `@cloaca.task(...)` |
-| `#[workflow(...)]` | `@cloaca.workflow(...)` or `WorkflowBuilder` context manager |
+| `#[workflow(...)]` | `cloaca.WorkflowBuilder` context manager (groups `@cloaca.task` definitions; in a packaged workflow, `workflow_name` in `package.toml` names it) |
 | `#[trigger(...)]` | `@cloaca.trigger(...)` |
 | `#[reactor(...)]` | `@cloaca.reactor(...)` |
 | `#[computation_graph(...)]` | `ComputationGraphBuilder` context manager |

--- a/docs/content/python/workflows/explanation/python-runtime-architecture.md
+++ b/docs/content/python/workflows/explanation/python-runtime-architecture.md
@@ -12,14 +12,14 @@ This page explains how the Python `cloaca` module fits onto the underlying Rust 
 
 The Python bindings live in a dedicated `cloacina-python` crate, distinct from the core `cloacina` crate. This split lets `cloacina` ship without PyO3 / maturin in its dependency closure — Python support is a build-time opt-in (`pip install cloaca`) rather than a feature flag on the base library.
 
-The wheel (`cloaca`) wraps `cloacina-python`, which depends on `cloacina` at the Rust source level. The Python surface you call (`cloaca.DefaultRunner`, `@cloaca.task`, `@cloaca.workflow`, etc.) is a PyO3 layer over the same Rust types the Rust crate exposes.
+The wheel (`cloaca`) wraps `cloacina-python`, which depends on `cloacina` at the Rust source level. The Python surface you call (`cloaca.DefaultRunner`, `@cloaca.task`, `cloaca.WorkflowBuilder`, etc.) is a PyO3 layer over the same Rust types the Rust crate exposes.
 
 ## The PyO3 boundary
 
 Every Python call crosses into Rust. Some implications:
 
 - **Tasks run in the Rust async executor**, not the Python event loop. Python `async def` tasks are still polled by the Rust runtime — the PyO3 binding wraps the coroutine and drives it on the tokio executor.
-- **Type marshalling is explicit.** Context values cross via JSON (or `serde_json::Value` equivalents in PyO3). Large/binary state should not round-trip through context for every task — use the DAL surface or pass references.
+- **Type marshalling is explicit.** Context values cross the boundary as JSON (or `serde_json::Value` equivalents in PyO3). Because that marshalling happens at every task boundary, large or binary state is expensive to round-trip through context repeatedly.
 - **The GIL is held while Python code runs.** Cloacina releases the GIL on async boundaries inside Rust (`Python::allow_threads`), but a single Python task body holds the GIL for its duration. Pure-CPU Python tasks will not parallelize across threads in the same way Rust tasks do.
 
 ## What "feature parity" means
@@ -35,7 +35,7 @@ Python is a first-class surface (see the user feedback memory: Python support is
 | `#[computation_graph(...)]` | `ComputationGraphBuilder` context manager |
 | `DefaultRunner` | `cloaca.DefaultRunner` |
 
-Drift between the two surfaces is treated as a bug. If you find a Rust capability missing in Python, file it as a parity gap.
+Drift between the two surfaces is treated as a bug — a Rust capability missing in Python is a parity gap, not an intended limitation.
 
 ## See also
 

--- a/docs/content/python/workflows/how-to-guides/_index.md
+++ b/docs/content/python/workflows/how-to-guides/_index.md
@@ -20,6 +20,7 @@ Practical recipes — each solves one specific problem.
 
 ## Operations
 
-<!-- TODO(DOC-G Phase 5/6): land Python-side analogs of decommission-a-tenant.md once the underlying `runner.decommission_tenant` Python surface is verified against `crates/cloacina-python/src/bindings/admin.rs`. The Rust-side how-to is at /platform/how-to-guides/decommission-a-tenant. -->
-
-> Operational recipes (multi-tenant decommission, signed-package enforcement, CLI profiles) currently live on the [Rust how-to-guides side]({{< ref "/platform/how-to-guides" >}}) — the Python runner inherits the same operational surface.
+Operational recipes (multi-tenant decommission, signed-package enforcement, CLI
+profiles) live on the [platform how-to-guides]({{< ref "/platform/how-to-guides" >}})
+— the Python runner inherits the same operational surface, so they apply
+regardless of authoring language.

--- a/docs/content/python/workflows/reference/environment-variables.md
+++ b/docs/content/python/workflows/reference/environment-variables.md
@@ -14,10 +14,9 @@ The Python runner (`cloaca.DefaultRunner`) reads the same environment variables 
 
 ## No separate `CLOACA_*` prefix
 
-There is **no** distinct `CLOACA_*` environment-variable namespace. The Python
-module reads the same variables as the Rust runtime; the only Cloacina-defined
-convention is `CLOACINA_VAR_*` (the variable registry, below). Any `CLOACA_*`
-reference in older docs is incorrect.
+There is no distinct `CLOACA_*` environment-variable namespace. The Python module
+reads the same variables as the Rust runtime; the only Cloacina-defined
+convention is `CLOACINA_VAR_*` (the variable registry, below).
 
 ## Registry variables (`CLOACINA_VAR_*`)
 

--- a/docs/content/python/workflows/reference/environment-variables.md
+++ b/docs/content/python/workflows/reference/environment-variables.md
@@ -6,24 +6,37 @@ weight: 10
 
 # Python Environment Variables
 
-<!-- TODO(DOC-G Phase 5): full content deferred. The audit found that the existing `python/api-reference/configuration.md` claims `CLOACA_*` env vars exist but they were not verified against `crates/cloacina-python/src/bindings/`. Audit before publishing. Sources to verify: -->
-<!--   - `crates/cloacina-python/src/lib.rs` -->
-<!--   - `crates/cloacina-python/src/bindings/context.rs` -->
-<!--   - `crates/cloacina-python/src/bindings/runner.rs` -->
-
-This page documents environment variables that affect Python workflows. The Python runtime inherits the full [Rust environment variable surface]({{< ref "/platform/reference/environment-variables" >}}); additional Python-specific knobs are listed here.
+This page documents environment variables that affect Python workflows. The Python runtime inherits the full [Rust environment variable surface]({{< ref "/platform/reference/environment-variables" >}}).
 
 ## Inherited from Rust
 
 The Python runner (`cloaca.DefaultRunner`) reads the same environment variables as the Rust `DefaultRunner` — DSN, log level, registry-variable namespace, multi-tenant search path. See the [Rust environment variables reference]({{< ref "/platform/reference/environment-variables" >}}) for the full inventory.
 
-## Python-specific (TBD)
+## No separate `CLOACA_*` prefix
 
-This section is intentionally empty pending verification. The earlier `python/api-reference/configuration.md` referenced a `CLOACA_*` prefix; whether such variables are observed by the Python module separately from `CLOACINA_*` is not yet documented in code. Treat any `CLOACA_*` reference as aspirational until this section is filled.
+There is **no** distinct `CLOACA_*` environment-variable namespace. The Python
+module reads the same variables as the Rust runtime; the only Cloacina-defined
+convention is `CLOACINA_VAR_*` (the variable registry, below). Any `CLOACA_*`
+reference in older docs is incorrect.
 
-## Registry variables
+## Registry variables (`CLOACINA_VAR_*`)
 
-`CLOACINA_VAR_*` env vars are exposed verbatim to Python tasks through the registry variable API — see the [Variable Registry how-to]({{< ref "/workflows/how-to-guides/variable-registry" >}}).
+The variable registry resolves named connections, secrets, and config from
+`CLOACINA_VAR_<NAME>` environment variables at runtime. From Python:
+
+```python
+import cloaca
+
+broker = cloaca.var("KAFKA_BROKER")              # reads CLOACINA_VAR_KAFKA_BROKER; raises if unset
+threshold = cloaca.var_or("MODEL_THRESHOLD", "0.5")  # reads CLOACINA_VAR_MODEL_THRESHOLD, else "0.5"
+```
+
+```bash
+export CLOACINA_VAR_KAFKA_BROKER=localhost:9092
+export CLOACINA_VAR_MODEL_THRESHOLD=0.85
+```
+
+See the [Variable Registry how-to]({{< ref "/workflows/how-to-guides/variable-registry" >}}) for details.
 
 ## See also
 

--- a/docs/content/quick-start/_index.md
+++ b/docs/content/quick-start/_index.md
@@ -13,28 +13,32 @@ explanations) follow the links below into the dedicated tracks.
 
 ## Install the CLI (optional, recommended)
 
-If you'll be running a Cloacina server or compiling packages, install
-`cloacinactl` first:
+If you'll be running a Cloacina server or compiling packages, install the
+`cloacinactl` CLI first → [Installing cloacinactl]({{< ref "install" >}}) (one-line
+installer, version pinning, platform support, Docker / Helm alternatives). The
+embedded-mode Rust tutorials below don't require the CLI; pure Python tutorials
+don't either.
 
-```sh
-curl -fsSL https://get.cloacina.dev/install.sh | bash
-```
+## New to Cloacina?
 
-See [Installing cloacinactl]({{< ref "install" >}}) for version
-pinning, platform support, and Docker / Helm alternatives. The
-embedded-mode Rust tutorials below don't require the CLI; pure Python
-tutorials don't either.
-
-## What Cloacina is
-
-Cloacina is an embedded workflow orchestration framework for Rust
-(with first-class Python bindings via [Cloaca]({{< ref "/python" >}})).
+Cloacina is an embedded workflow orchestration engine for Rust and Python
+(the Python bindings are [Cloaca]({{< ref "/python" >}}), full parity with Rust).
 It runs inside your application rather than as a separate service,
 manages multi-step pipelines with automatic retries and state
-persistence, and ships packaged workflows as `.cloacina` cdylibs.
+persistence, and ships packaged workflows as `.cloacina` packages.
 
-If you'd like the architectural pitch and the design rationale,
-read [Architecture Overview]({{< ref "/workflows/explanation/architecture-overview" >}}).
+Get oriented first:
+
+- [When to Use Cloacina]({{< ref "when-to-use" >}}) — does it fit your problem, and which mode/primitive?
+- [Features Overview]({{< ref "features" >}}) — the full capability catalog.
+- [Concepts]({{< ref "concepts" >}}) — the core primitives, defined.
+- [Architecture Overview]({{< ref "/workflows/explanation/architecture-overview" >}}) — the design rationale.
+
+**Just want to see it run?** The fastest "watch real executions" path is to
+[deploy a server]({{< ref "/platform/tutorials/01-deploy-a-server" >}}) and open
+[the web UI]({{< ref "/platform/tutorials/02-the-web-ui" >}}). For a code-only
+first success, the [Python Quick Start]({{< ref "/python/quick-start" >}}) runs a
+workflow in about five minutes.
 
 ## Pick your starting point
 
@@ -70,12 +74,12 @@ package upload, and your first execution. Once you have a server
 running, branch into:
 
 - [Migrating to Service Mode]({{< ref "/workflows/how-to-guides/migrating-to-service-mode" >}})
-  — convert an embedded-mode workflow into a packaged cdylib.
+  — convert an embedded-mode workflow into a loadable `.cloacina` package.
 - [Use cloacina-compiler Locally]({{< ref "/platform/how-to-guides/use-cloacina-compiler-locally" >}})
   — build packages on your laptop without the long-running compiler
   service.
 
-### "I want to build a computation graph (event-driven, reactor-based)."
+### "I want to build a computation graph (event-driven, low-latency)."
 
 → [Computation Graphs Tutorials]({{< ref "/computation-graphs/tutorials" >}})
 
@@ -105,10 +109,13 @@ For lookup-style information rather than learning paths:
   schema.
 - [HTTP API Reference]({{< ref "/platform/reference/http-api" >}}) —
   every endpoint, auth model, operational caveats.
-- [`package!()` Macro Reference]({{< ref "/platform/reference/package-shell-macro" >}}) — the unified plugin shell.
-- [FFI Vtable Reference]({{< ref "/platform/reference/ffi-vtable" >}}) — methods 0–8.
 - [Glossary]({{< ref "/glossary" >}}) — every term used in these
   docs, in one place.
+
+Advanced (only if you implement package loading by hand):
+
+- [`package!()` Macro Reference]({{< ref "/platform/reference/package-shell-macro" >}}) — the macro that wraps a Rust package for loading.
+- [FFI Vtable Reference]({{< ref "/platform/reference/ffi-vtable" >}}) — the low-level plugin ABI.
 
 ## Need help?
 

--- a/docs/content/quick-start/concepts.md
+++ b/docs/content/quick-start/concepts.md
@@ -1,0 +1,58 @@
+---
+title: "Concepts"
+description: "The core Cloacina primitives and how they relate."
+weight: 4
+---
+
+# Concepts
+
+Cloacina is built from a small set of primitives. This page introduces them and
+how they fit together; the [Glossary]({{< ref "/glossary" >}}) has the full,
+precise definition of every term.
+
+## The primitives
+
+- **Task** — the unit of work in a workflow: an `async` function that reads and
+  writes a shared **context** (defined next). The task is also the unit of
+  **scheduling** — the engine claims, runs, and records one task at a time.
+- **Context** — the typed key/value state passed along a workflow's edges; how
+  data flows from one task to the next.
+- **Workflow** — a DAG of tasks with dependencies. Durable and database-backed:
+  it survives restarts, retries failures, and recovers. See
+  [Workflows]({{< ref "/workflows" >}}).
+- **Computation graph** — a DAG whose **entire traversal** is the unit of
+  scheduling. Once triggered, all nodes run together with in-memory channels
+  between them — deterministic and low-latency. See
+  [Computation Graphs]({{< ref "/computation-graphs" >}}).
+- **Trigger** — an event source (a cron schedule, an external event) that starts
+  a workflow or graph.
+- **Accumulator** — an adapter that consumes an external stream or source (Kafka,
+  a polled query, pushed events) and emits **boundary events** — the discrete
+  events a computation graph reacts to.
+- **Reactor** — a specialized trigger that watches one or more accumulators and
+  fires a computation graph when its criteria are met.
+
+These names are used consistently across the code, CLI, HTTP API, and docs, so
+what you read here matches what you see in every interface.
+
+## How they relate
+
+```
+ Trigger ───────────────▶ Workflow   (cron / event starts a durable DAG of tasks)
+
+ Accumulator ──events──▶ Reactor ───fires──▶ Computation graph
+                                              (one deterministic traversal)
+```
+
+- A **workflow** is driven by **triggers** (e.g. a cron schedule) and runs **tasks**.
+- A **computation graph** is driven by a **reactor**, which consumes **accumulator**
+  boundary events.
+- The two compose: a workflow can **subscribe** to a reactor's firings, and a
+  workflow **task** can **invoke** an embedded computation graph.
+
+## Where to go next
+
+- [When to Use Cloacina]({{< ref "/quick-start/when-to-use" >}}) — pick the right primitive and mode.
+- [Features Overview]({{< ref "/quick-start/features" >}}) — the full capability catalog.
+- [Workflows]({{< ref "/workflows" >}}) / [Computation Graphs]({{< ref "/computation-graphs" >}}) — the deep tracks.
+- [Glossary]({{< ref "/glossary" >}}) — every term, precisely defined.

--- a/docs/content/quick-start/features.md
+++ b/docs/content/quick-start/features.md
@@ -1,0 +1,139 @@
+---
+title: "Features Overview"
+description: "A catalog of what Cloacina can do, with links into the detailed docs."
+weight: 3
+---
+
+# Features Overview
+
+A single catalog of Cloacina's capabilities. Each item links to the detailed
+tutorial, how-to, reference, or explanation. For *whether* Cloacina fits your
+problem, see [When to Use Cloacina]({{< ref "/quick-start/when-to-use" >}}).
+
+## Execution engine
+
+- **Durable, database-backed execution** — task and execution state persist in
+  Postgres or SQLite; nothing lives only in memory.
+- **At-least-once with recovery** — work is claimed atomically; failed or stalled
+  work is recovered. Tasks and graph nodes must be idempotent.
+- **Automatic retries** — configurable retry policies per task, including
+  [conditional retries]({{< ref "/workflows/how-to-guides/conditional-retries" >}}).
+- **Content-versioned workflows** — a workflow's version is derived from its task
+  code and structure, so changes are explicit and safe. See
+  [Workflow Versioning]({{< ref "/workflows/explanation/workflow-versioning" >}}).
+- **Async-first** — built on Tokio; blocking work is offloaded explicitly.
+- **Conditional task execution** — per-task trigger rules (`all` / `any` / `none`
+  over upstream task states) enable branching and conditional fan-in. See
+  [Trigger Rules]({{< ref "/workflows/explanation/trigger-rules" >}}).
+- **External config & secrets** — reference connections, secrets, and config by
+  name and resolve them from `CLOACINA_VAR_*` environment variables at runtime
+  (`cloaca.var()` / `var_or()`). See
+  [Variable Registry]({{< ref "/workflows/how-to-guides/variable-registry" >}}).
+- **Two database backends, chosen at runtime** — Postgres or SQLite via the
+  connection URL, no recompile. See
+  [Database Backends]({{< ref "/platform/explanation/database-backends" >}}).
+
+## Two execution primitives
+
+- **[Workflows]({{< ref "/workflows" >}})** — durable DAGs of tasks with
+  dependencies, retries, and recovery; the task is the unit of scheduling.
+- **[Computation Graphs]({{< ref "/computation-graphs" >}})** — in-process,
+  deterministic, event-driven DAGs; the whole traversal is the unit.
+- **They compose** — workflows can
+  [subscribe to a reactor]({{< ref "/workflows/how-to-guides/subscribe-workflow-to-reactor" >}})
+  and a task can
+  [invoke a computation graph]({{< ref "/workflows/how-to-guides/invoke-computation-graph-from-workflow" >}}).
+
+## Computation-graph capabilities
+
+These build on reactors and accumulators — see [Concepts]({{< ref "/quick-start/concepts" >}})
+first if those terms are new.
+
+- **Accumulators** — adapters that turn an external stream or source into
+  *boundary events* (the discrete events a graph reacts to), in several flavors
+  (passthrough, stream, polling, batch, state). See
+  [Accumulator Types]({{< ref "/computation-graphs/how-to-guides/accumulator-types" >}}).
+- **Reactors** — fire a graph when their criteria are met (`when_any` /
+  [`when_all`]({{< ref "/computation-graphs/how-to-guides/when-all-criteria" >}}))
+  with a [`latest` or `sequential`]({{< ref "/computation-graphs/how-to-guides/sequential-strategy" >}})
+  input strategy.
+- **Routing** — enum-variant routing propagates results conditionally between
+  nodes.
+- **Kafka stream accumulators** — consume topics via the `kafka` feature; see
+  [Kafka Stream]({{< ref "/computation-graphs/tutorials/service/09-kafka-stream" >}}).
+- **CEL firing filters** — filter reactor firings with CEL (Common Expression
+  Language) expressions; see
+  [Filter Reactor Firings with CEL]({{< ref "/computation-graphs/how-to-guides/filter-reactor-firings-with-cel" >}}).
+
+## Scheduling & triggers
+
+- **Cron schedules** — run workflows on a schedule; see
+  [Cron Scheduling]({{< ref "/workflows/explanation/cron-scheduling" >}}).
+- **Event triggers** — start work from external events; see
+  [Event Triggers]({{< ref "/python/workflows/tutorials/07-event-triggers" >}}).
+
+## Deployment modes
+
+- **Embedded library** — `cloacina` (Rust) / `cloaca` (Python) in your process.
+- **Daemon** — `cloacinactl daemon` watches a directory and runs packages locally.
+  See [Running the Daemon]({{< ref "/platform/how-to-guides/running-the-daemon" >}}).
+- **Server** — `cloacina-server`, an HTTP + WebSocket control plane. See
+  [Deploy a Server]({{< ref "/platform/tutorials/01-deploy-a-server" >}}).
+- **Compiler service** — `cloacina-compiler` builds uploaded packages in a
+  sandbox. See [Running the Compiler]({{< ref "/platform/how-to-guides/running-the-compiler" >}}).
+- **Execution-agent fleet** — `cloacina-agent` workers run tasks off the server
+  for horizontal scale. See
+  [Deploy an Execution-Agent Fleet]({{< ref "/platform/how-to-guides/deploy-an-execution-agent-fleet" >}})
+  and [Execution-Agent Fleet]({{< ref "/platform/explanation/execution-agent-fleet" >}}).
+
+## Packaging
+
+- **`.cloacina` packages** — a `package.toml` plus source (Python module tree, or
+  Rust compiled on the server at load). Scaffold, validate, pack, and upload with
+  `cloacinactl package`. See
+  [Creating Your First Package]({{< ref "/platform/how-to-guides/creating-your-first-package" >}})
+  and the [Package Format]({{< ref "/platform/explanation/package-format" >}}).
+- **Reconciler** — the server loads and registers uploaded packages
+  automatically. See
+  [Reconciler Pipeline]({{< ref "/platform/explanation/reconciler-pipeline" >}}).
+
+## Multi-tenancy & auth
+
+- **Schema-per-tenant isolation** (Postgres) — see
+  [Multi-Tenancy]({{< ref "/platform/explanation/multi-tenancy" >}}) and
+  [Configure a Multi-Tenant Deployment]({{< ref "/platform/how-to-guides/configure-multi-tenant-deployment" >}}).
+- **API keys with roles** — admin / write / read, managed via `cloacinactl key`
+  and the API.
+
+## Clients & UI
+
+- **Client SDKs** — Rust, Python, and TypeScript clients for calling a running
+  server over HTTP/WebSocket. See [Client SDKs]({{< ref "/sdks" >}}).
+- **Web UI** — operate and observe a server: workflows, executions (with a live
+  event stream), triggers, computation-graph health, package upload, and API-key
+  management. See [The Web UI]({{< ref "/platform/tutorials/02-the-web-ui" >}}).
+
+## Operations & security
+
+- **Observability** — Prometheus `/metrics`, structured logs, and optional
+  OpenTelemetry export. See
+  [Observability]({{< ref "/platform/explanation/observability" >}}) and the
+  [Metrics Catalog]({{< ref "/platform/reference/metrics-catalog" >}}).
+- **Package signing** — optional signature verification, enforced when the server
+  runs with signatures required; signing private keys are encrypted at rest
+  (AES-256-GCM). See
+  [Package Signing]({{< ref "/platform/how-to-guides/security/package-signing" >}})
+  and [Require Signed Packages]({{< ref "/platform/how-to-guides/require-signed-packages" >}}).
+- **Build sandboxing** — the compiler builds untrusted packages in an isolated
+  environment (Linux). See [Security Model]({{< ref "/platform/explanation/security-model" >}}).
+- **Horizontal scaling** — stateless schedulers coordinate through the database.
+  See [Horizontal Scaling]({{< ref "/platform/explanation/horizontal-scaling" >}}).
+
+## Tooling
+
+- **`cloacinactl`** — the operator + developer CLI (daemon, server/compiler
+  lifecycle, package, workflow, execution, tenant, key, trigger, graph). See the
+  [CLI Reference]({{< ref "/platform/reference/cli" >}}).
+- **HTTP + WebSocket API** — see the
+  [HTTP API Reference]({{< ref "/platform/reference/http-api" >}}) and
+  [WebSocket Protocol]({{< ref "/platform/reference/websocket-protocol" >}}).

--- a/docs/content/quick-start/when-to-use.md
+++ b/docs/content/quick-start/when-to-use.md
@@ -1,0 +1,89 @@
+---
+title: "When to Use Cloacina"
+description: "Where Cloacina fits, where it doesn't, and how to decide between its modes and primitives."
+weight: 2
+---
+
+# When to Use Cloacina (and When Not)
+
+Cloacina is an **embedded-first workflow orchestration engine** for Rust and
+Python. This page helps you decide whether it fits your problem before you invest
+in learning it.
+
+## Cloacina is a good fit when…
+
+- **You have multi-step work that must run reliably.** Steps depend on each other,
+  must retry on failure, and must not be silently dropped — and you want that
+  durability backed by a database you already run.
+- **You'd rather embed orchestration than operate a separate service.** Cloacina
+  runs *inside* your Rust or Python application as a library. The only external
+  dependency is a database (Postgres or SQLite) — there is no broker, queue, or
+  coordinator to stand up.
+- **You're in Rust or Python.** Both are first-class: the Python bindings
+  (`cloaca`) expose the same engine and API as the Rust crate (`cloacina`),
+  not a reduced wrapper.
+- **You want to start small and grow.** The same packaged workflow runs embedded,
+  under the local daemon, or on the multi-tenant server — without a rewrite.
+- **You're building a platform for multiple teams/tenants.** The server provides
+  schema-per-tenant isolation, API-key auth, package upload, and a web UI.
+
+## Cloacina is *not* the right tool when…
+
+- **You want a no-code / click-to-build scheduler.** Cloacina workflows are
+  authored in Rust or Python code. The [web UI]({{< ref "/platform/tutorials/02-the-web-ui" >}})
+  is for *operating and observing* — uploading packages, running workflows,
+  watching executions — not for drawing pipelines.
+- **You need multi-tenancy or horizontal scaling on SQLite.** SQLite is
+  single-process: ideal for embedding and local/dev, but multi-tenant isolation
+  and multi-replica coordination require **Postgres**. See
+  [Database Backends]({{< ref "/platform/explanation/database-backends" >}}).
+- **You need the managed multi-tenant server on Windows/macOS.** The embedded
+  library and the daemon are cross-platform; the hardened multi-tenant **server**
+  (with build sandboxing) targets **Linux**. See
+  [Security Model]({{< ref "/platform/explanation/security-model" >}}).
+- **You require exactly-once execution.** Cloacina guarantees **at-least-once**
+  with recovery; tasks and graph nodes must be idempotent under redelivery.
+- **Your tasks are synchronous and you don't want async.** Tasks and graph nodes
+  are `async`; CPU-bound or blocking work must be offloaded
+  (`tokio::task::spawn_blocking` in Rust, or a blocking node).
+
+If you simply need a standalone DAG scheduler-as-a-service with a hosted UI for
+non-developers, a dedicated orchestrator may serve you better. Cloacina's
+trade-off is the opposite: it lives in your app and your database.
+
+## Choosing a mode
+
+| If you want to… | Use | Backed by |
+|------------------|-----|-----------|
+| Run workflows inside one Rust/Python app | **Embedded library** | SQLite or Postgres |
+| Schedule packages locally, single-user | **Daemon** (`cloacinactl daemon`) | SQLite (default) |
+| Serve many tenants / a team, with an API + UI | **Server** (`cloacina-server`) | Postgres |
+| Scale the server horizontally | **Server + compiler + agent fleet** | Postgres |
+
+The embedded library and the server are **not exclusive** — you can author and
+test embedded, then deploy the same package to a server. The two deployment
+postures have deliberately different trust models (high-trust single-user vs.
+low-trust multi-tenant); see [Security Model]({{< ref "/platform/explanation/security-model" >}}).
+
+## Choosing a primitive
+
+Cloacina exposes two execution primitives:
+
+- **[Workflows]({{< ref "/workflows" >}})** — durable, database-backed DAGs where
+  the **task** is the unit of scheduling. Choose this when work must survive
+  process restarts and recover from failure (ETL, background jobs, integrations).
+- **[Computation Graphs]({{< ref "/computation-graphs" >}})** — in-process,
+  deterministic, event-driven DAGs where the **whole traversal** is the unit, with
+  in-memory channels between nodes. Choose this for low-latency, event-driven
+  processing reacting to a stream.
+
+They compose — a workflow can be triggered by a computation graph, and a workflow
+task can run one inline. See the
+[Features overview]({{< ref "/quick-start/features" >}}) for the full picture, or
+[Concepts]({{< ref "/quick-start/concepts" >}}) for the vocabulary.
+
+## Next
+
+- [Features overview]({{< ref "/quick-start/features" >}}) — everything Cloacina can do.
+- [Concepts]({{< ref "/quick-start/concepts" >}}) — the core primitives.
+- [Quick Start]({{< ref "/quick-start" >}}) — pick a starting tutorial.

--- a/docs/content/quick-start/when-to-use.md
+++ b/docs/content/quick-start/when-to-use.md
@@ -22,8 +22,11 @@ in learning it.
 - **You're in Rust or Python.** Both are first-class: the Python bindings
   (`cloaca`) expose the same engine and API as the Rust crate (`cloacina`),
   not a reduced wrapper.
-- **You want to start small and grow.** The same packaged workflow runs embedded,
-  under the local daemon, or on the multi-tenant server — without a rewrite.
+- **You want to start small and grow.** Your task and node *logic* carries across
+  all three modes — embedded, daemon, and server. A `.cloacina` package, once
+  built, runs unchanged on any of them; moving from embedded code to a deployable
+  package is a *repackaging* step (see the transition note below), not a rewrite
+  of your business logic.
 - **You're building a platform for multiple teams/tenants.** The server provides
   schema-per-tenant isolation, API-key auth, package upload, and a web UI.
 
@@ -51,6 +54,29 @@ If you simply need a standalone DAG scheduler-as-a-service with a hosted UI for
 non-developers, a dedicated orchestrator may serve you better. Cloacina's
 trade-off is the opposite: it lives in your app and your database.
 
+## How Cloacina compares
+
+If you're coming from Airflow, Temporal, or Prefect, the defining difference is
+*deployment shape*: those are standalone systems you operate alongside your
+application; Cloacina is a library that runs **inside** it. This is a genuine
+trade-off, not a strict ranking — pick the side that matches how you want to
+run things.
+
+| | **Cloacina** | **Airflow** | **Temporal** | **Prefect** |
+|---|---|---|---|---|
+| Deployment | Embedded in your app (or an optional server) | Standalone scheduler + workers + metadata DB | Standalone server cluster + workers | Control plane + agents/workers |
+| Infra dependencies | Just a database (SQLite or Postgres) | Scheduler, executor, metadata DB | Temporal service + datastore | API/cloud + worker pool |
+| Authoring | Rust or Python, in your codebase | Python DAGs | Workflow-as-code (multi-language SDKs) | Python flows |
+| Execution model | Durable DAGs (at-least-once) + in-process computation graphs | Scheduled DAGs | Durable execution / long-running workflows | Dynamic Python flows |
+| Best when | You want orchestration *in-process* with no extra service to operate | You want a dedicated scheduler with a rich authoring UI | You need long-lived, signal-driven durable executions at scale | You want flexible Python-native flows with a managed control plane |
+
+**Choose Cloacina** when you'd rather not run a separate orchestration service —
+when "a library plus the database we already have" beats "another system to
+deploy, secure, and monitor." **Choose one of the others** when a dedicated
+control plane, a hosted authoring UI for non-developers, or their specific
+execution semantics are what you're after. Cloacina deliberately does not try to
+be a hosted, click-to-build platform.
+
 ## Choosing a mode
 
 | If you want to… | Use | Backed by |
@@ -61,9 +87,27 @@ trade-off is the opposite: it lives in your app and your database.
 | Scale the server horizontally | **Server + compiler + agent fleet** | Postgres |
 
 The embedded library and the server are **not exclusive** — you can author and
-test embedded, then deploy the same package to a server. The two deployment
+test embedded, then deploy to a server. The two deployment
 postures have deliberately different trust models (high-trust single-user vs.
 low-trust multi-tenant); see [Security Model]({{< ref "/platform/explanation/security-model" >}}).
+
+### Moving from embedded to the server
+
+This is a packaging step, not a rewrite. Conceptually:
+
+- **What stays the same:** your task logic (and any computation-graph node
+  logic) — the function bodies and the dependencies between them.
+- **What changes:** the code becomes a `.cloacina` *package* with a small
+  `package.toml` and a conventional source layout. In **Python**, a packaged
+  module declares tasks with **bare `@cloaca.task` decorators** rather than the
+  `WorkflowBuilder` context manager — a builder inside a package fails to load,
+  because the package loader already supplies the workflow context.
+
+The package is portable: once built, the same artifact runs under the daemon or
+the server unchanged. For the actual procedure, see
+[Creating Your First Package]({{< ref "/platform/how-to-guides/creating-your-first-package" >}})
+and, for the Python specifics,
+[Packaging Python Workflows]({{< ref "/python/workflows/how-to-guides/packaging-python-workflows" >}}).
 
 ## Choosing a primitive
 

--- a/docs/content/workflows/_index.md
+++ b/docs/content/workflows/_index.md
@@ -8,6 +8,12 @@ weight: 10
 
 The workflow system is Cloacina's core orchestration engine. It schedules and executes directed acyclic graphs (DAGs) of tasks with automatic retry, conditional execution, cron scheduling, and persistent state.
 
+**Who this is for:** developers building durable, multi-step task pipelines that
+must survive restarts and recover from failure. **Prerequisites:** the
+[Concepts]({{< ref "/quick-start/concepts" >}}) (task, workflow, context). These
+docs are Rust-first; the same workflow surface is available in Python — see
+[Python · Workflows]({{< ref "/python/workflows" >}}).
+
 ## Run Modes
 
 ### Library (Embedded)


### PR DESCRIPTION
Full documentation overhaul (**CLOACI-I-0120**), four slices, each run through the
four Diátaxis reviewers (accuracy/completeness/clarity/diataxis-compliance) to
zero blockers/majors. Every claim and `{{< ref >}}` link verified against code.

## P0 — Orientation & onboarding (T-0682)
Landing page rewritten to lead with what-it's-for / why / **when *not* to use it**
/ ways-to-run / get-started; new `when-to-use`, `features`, and `concepts` pages;
quick-start router + README aligned.

## P1 — Correctness sweep (T-0683)
- Fixed stale claims: `execution events --follow` (it IS implemented over the WS
  substrate), the missing 5th accumulator type (`state`).
- Wrote all **7 deferred Python stub docs** (topology schema, decorator surface,
  package-a-python-CG, filter-reactor-subscriptions, env-vars, runtime-architecture,
  how-to index) — code-grounded, no more TODO placeholders.
- Replaced the stale CG-reference "Global Registry" TODO with the inventory-driven
  registration story.

## P2 — IA & usefulness (T-0684)
Audience/prerequisites on all four section landings; de-siloed Python (PyO3 layer
over the same engine, Rust↔Python cross-links); corrected the tutorial-numbering
note; reconciled the node-arg rule + Python-version drift.

## P3 — Reference gap-fill (T-0685)
Added the two missing `api-reference` index pages; documented the `CLOACINA_CORS_*`
env vars.

Notable correction: the feared "fleet/UI/SDKs documented as planned" drift was in
the *specs*, not the published docs — verified and narrowed. Deliberately scoped
out (logged in the tasks): reviewer/date metadata backfill, deeper cross-cutting
hub pages, and hand-rewriting the 249 auto-generated API docs.