### PR TITLE
chore(helm): fix Chart.yaml org URLs colliery-software -> colliery-io

### DIFF
--- a/charts/cloacina-server/Chart.yaml
+++ b/charts/cloacina-server/Chart.yaml
@@ -17,11 +17,11 @@ appVersion: "0.6.1"
 
 home: https://cloacina.dev
 sources:
-  - https://github.com/colliery-software/cloacina
+  - https://github.com/colliery-io/cloacina
 
 maintainers:
   - name: Colliery Software
-    url: https://github.com/colliery-software
+    url: https://github.com/colliery-io
 
 keywords:
   - workflow


### PR DESCRIPTION
The Helm chart's `home`/`sources`/maintainer URLs pointed at `github.com/colliery-software`, but the repository and the chart's OCI publish target are `colliery-io` (`.github/workflows/unified_release.yml` pushes to `ghcr.io/<owner>/charts/cloacina-server` where owner = `colliery-io`).

Surfaced by the operator-docs QA harness (Q03): the docs correctly say `colliery-io`; this was the metadata that disagreed. Metadata-only, no chart behavior change.

Squash-merge.