### PR TITLE
Python parity: state-accumulator + cron-trigger authoring (CLOACI-T-0688)

### DIFF
--- a/.metis/backlog/bugs/CLOACI-T-0741.md
+++ b/.metis/backlog/bugs/CLOACI-T-0741.md
@@ -91,3 +91,14 @@ absorbing the transient hang — but it is a **mitigation, not a fix**.
   pool-checkout (the added pool `wait_timeout` never fires). Retry-on-timeout
   landed as a mitigation so the lane stops gating PRs; the real fix is blocked on
   a captured stack from a stress-repro.
+- 2026-06-17: **Experiment: sqlite pool=1 — DISPROVED.** Set SQLITE_POOL_SIZE
+  back to 1 to serialize and kill the contention. Result: **27 executor
+  integration tests fail deterministically** (pause_resume, task_execution,
+  retry_condition). The engine holds multiple sqlite connections concurrently
+  (scheduler loop + executor + heartbeat), so pool=1 starves/deadlocks the
+  executor — which is exactly why T-0622 bumped it to 4. Reverted to 4.
+  **Takeaway:** the flake is NOT fixable by pool size. Real avenues: WAL
+  checkpoint/`wal_autocheckpoint` tuning, tightening connection scope so writers
+  don't overlap (the `database is locked` came from concurrent context-saves),
+  or accepting pool=4 + the retry-on-timeout mitigation. Also confirms a clue:
+  the contention is concurrent WRITES (context saves) under WAL, not reads.

--- a/.metis/backlog/bugs/CLOACI-T-0741.md
+++ b/.metis/backlog/bugs/CLOACI-T-0741.md
@@ -1,0 +1,93 @@
+---
+id: root-cause-the-flaky-sqlite
+level: task
+title: "Root-cause the flaky sqlite integration hang (not pool-checkout; retry-on-timeout is only a mitigation)"
+short_code: "CLOACI-T-0741"
+created_at: 2026-06-17T18:07:21.071791+00:00
+updated_at: 2026-06-17T18:07:21.071791+00:00
+parent: 
+blocked_by: []
+archived: false
+
+tags:
+  - "#task"
+  - "#phase/backlog"
+  - "#bug"
+
+
+exit_criteria_met: false
+initiative_id: NULL
+---
+
+# Root-cause the flaky sqlite integration hang (not pool-checkout; retry-on-timeout is only a mitigation)
+
+## Objective
+
+Find and fix the real cause of the chronically-flaky **sqlite** Python-scenario
+integration hang, so the lane is reliably green without the retry crutch.
+
+## Type / Priority
+- [x] Bug — flaky CI (pre-existing; blocks/【blocked】 PR merges intermittently)
+- [x] P2 — not data-corrupting, but it gates every PR and erodes trust in CI.
+
+## Symptom
+Python integration scenarios on the **sqlite** backend nondeterministically hang
+and get killed at the 180s per-scenario timeout. The scenario varies run to run
+(observed: `test_scenario_30_task_callbacks`, `_32_task_invokes_computation_graph`,
+`_33_retry_condition`), and it hits both `ubuntu-latest` and `macos-latest`.
+It is **pre-existing on main** (the #130 merge run was red on the same lane; the
+#127 run before it was green — so it set in around #130 / a runner-image bump).
+The postgres lane does **not** exhibit it.
+
+## What it is NOT (ruled out)
+- **Not a deadpool connection-checkout deadlock.** A bounded pool `wait_timeout`
+  was added (`database/connection/mod.rs`); it **never fires** — scenarios hang
+  the full 180s rather than erroring at the 30s pool wait. So the stall is not a
+  pool-exhaustion wait.
+- **Not the sqlite pool size.** The CI scenarios build with both features
+  (postgres+sqlite), whose sqlite pool was already 4 (CLOACI-T-0622); unifying
+  the sqlite-only path to 4 did not change their behaviour.
+- **Not a specific scenario's logic** — it roams across unrelated scenarios.
+
+## Leading hypotheses (to confirm with a captured stack)
+- A **GIL ↔ tokio** interaction: a Python callback / PyO3 call holding the GIL on
+  a blocking thread while the runtime needs it (the scenarios that hang involve
+  callbacks, CG invocation, retries — all cross the Rust↔Python boundary under
+  the in-process `shared_runner`).
+- A **sqlite WAL / busy_timeout** stall under the multi-connection pool (size 4)
+  with the `:memory:`-as-tempfile materialisation.
+- A scheduler/await that never resolves outside the per-task `task_timeout`.
+
+## How to actually fix (needs a repro + stack — the missing ingredient)
+The hang does **not** reproduce locally on demand (passes locally + on most CI
+runs), and the CI kill produces no core dump (killed, not crashed). So:
+1. **Stress-repro:** loop the suspect sqlite scenarios (30/32/33) under the
+   in-process runner until one hangs; or run them concurrently to raise
+   contention.
+2. **Capture the blocked stack** (`lldb`/`gdb` attach, or `py-spy dump` for the
+   Python side + a Rust thread dump) to see exactly where it's parked.
+3. Fix at the source (tighten connection/GIL scoping, or the await that stalls),
+   then remove/relax the retry crutch.
+
+## Current mitigation (already landed in #131 / commit on main)
+`.angreal/test/_python_utils.py` retries a scenario **only on timeout** (3
+attempts, logged); a non-zero return code fails fast (no retry) and a scenario
+that hangs on every attempt still fails. This keeps real-regression signal while
+absorbing the transient hang — but it is a **mitigation, not a fix**.
+
+## Acceptance Criteria
+- [ ] A reliable (even if slow/looped) local repro of the sqlite hang.
+- [ ] A captured blocked stack identifying the stall site.
+- [ ] A source fix; the sqlite lane is green **without** relying on the
+      retry-on-timeout crutch (which can then be tightened or removed).
+- [ ] No regression on postgres or the per-task timeout behaviour.
+
+## Related
+- Mitigation commit (retry-on-timeout) + pool `wait_timeout`/size unification landed in #131.
+- [[CLOACI-T-0622]] — earlier sqlite-hang fix (pool 1→4 in the both-features path); this is its unfinished tail across the sqlite-only/scenario surface.
+
+## Status Updates
+- 2026-06-17: Filed after #131. Sharpened diagnosis: the hang is **not**
+  pool-checkout (the added pool `wait_timeout` never fires). Retry-on-timeout
+  landed as a mitigation so the lane stops gating PRs; the real fix is blocked on
+  a captured stack from a stress-repro.

--- a/.metis/backlog/tech-debt/CLOACI-T-0688.md
+++ b/.metis/backlog/tech-debt/CLOACI-T-0688.md
@@ -5,7 +5,7 @@ title: "Close Rust↔Python interface parity gaps (state accumulators, packaged 
 short_code: "CLOACI-T-0688"
 created_at: 2026-06-15T13:46:31.557405+00:00
 updated_at: 2026-06-17T15:19:21.592385+00:00
-parent: 
+parent:
 blocked_by: []
 archived: false
 
@@ -299,3 +299,48 @@ wiring, the real unknown) → Part C decision. Each its own commit; verify via
   (cron needs a DB + the reconciler; import-time has neither) — embedded cron
   stays on the runner-level `register_cron_workflow` API. The packaged/decorator
   authoring form (the documented gap) is what's closed.
+- 2026-06-17: **Runtime test gap closed (commit f35ac189, PR #132).** Added 4
+  sqlite/no-docker Rust integration tests: `accumulator.rs` —
+  `test_state_accumulator_runtime_bounded_evicts_and_emits_history` (capacity=2
+  feeds 1,2,3 → boundaries [1],[1,2],[2,3], proving eviction+history) and
+  `test_state_accumulator_runtime_write_only_emits_nothing` (capacity=0 emits no
+  boundary); `reconciler/loading.rs` —
+  `build_view_python_emits_cron_metadata_for_runtime_trigger` (cron_expression()
+  + workflow_name() flow into the view) and
+  `step_load_cron_triggers_selects_cron_bearing_triggers` (only cron-bearing
+  triggers register, against their TARGET workflow, UTC; poll triggers ignored).
+  All 4 pass; pre-commit fmt + both-backend cargo check green. Covers the Rust
+  runtime tier; the Python-level / live-runner e2e tier (Docker-gated, AC line
+  "against a live runner") remains the one open follow-up.
+- 2026-06-17: **Demo-stack coverage added (commit 85162cab, PR #132).** Both new
+  Python surfaces now ship in the UI demo (`docker/docker-compose.demo.yml`):
+  `demo-py-state` (`@cloaca.state_accumulator(capacity=5)` → reactor → 2-node CG,
+  fed over WS via the producer — `py_window` added to `HARNESS_WS_ACCUMULATORS`
+  + a bid/ask generator in `produce.mjs`) and `demo-py-cron` (pure-Python task
+  workflow + `@cloaca.trigger(on=, cron="*/15 * * * * *")`, the Python mirror of
+  `demo-cron-rust`, self-driving via the cron scheduler). Both packed in
+  `pack-demo-fixtures.sh`. This doubles as the live-runner exercise the AC wanted
+  for the new Python surfaces — verifiable by bringing up the demo stack (Docker
+  is down locally, so not yet run here). Python syntax checked; decorator
+  signatures + graph-dict shape matched against the built bindings.
+- 2026-06-17: **Live demo stack run — BOTH surfaces verified end-to-end; found +
+  fixed a real shipping bug (commit 21fdc1d7, PR #132).** Brought up
+  `docker-compose.demo.yml`. `demo-py-cron` loaded + its cron schedule registered
+  immediately. `demo-py-state` FAILED to load: server reconciler reported
+  `module 'cloaca' has no attribute 'state_accumulator'`. **Root cause:** Part A
+  registered `state_accumulator` in the maturin `#[pymodule]` (lib.rs) but NOT in
+  `ensure_cloaca_module` (loader.rs) — the SYNTHETIC `cloaca` the *server* injects
+  into its embedded interpreter (the server image has no pip wheel). Two parallel
+  registration lists drifted; the Part A unit test passed because it called the
+  Rust decorator fn directly, never `import cloaca`. **Fix:** register
+  `state_accumulator_decorator` in `ensure_cloaca_module` + extend
+  `test_ensure_cloaca_module_registers_in_sys_modules` to assert the
+  `state_accumulator` attr (guards the drift). After rebuild+restart:
+  • `demo-py-state` → "Python computation graph imported", reactor running, CG
+    `fires=1..N` every 2s off the `py_window` WS feed.
+  • `demo-py-cron` → cron fires every 15s, `py_cron_step` completes, context
+    carries `{demo_py_cron_ran, schedule_expression:"*/15 * * * * *",
+    schedule_timezone:"UTC", scheduled_time}`, "Successfully executed and audited".
+  This satisfies the AC "Tests cover the new Python authoring surfaces against a
+  live runner". **Remaining AC:** Part C decision (`defer_until`) + remove the
+  "Rust-only" caveats from the primitive docs.

--- a/.metis/backlog/tech-debt/CLOACI-T-0688.md
+++ b/.metis/backlog/tech-debt/CLOACI-T-0688.md
@@ -262,4 +262,19 @@ wiring, the real unknown) → Part C decision. Each its own commit; verify via
   path, per user). Plan-first per request: implementation plan above, grounded
   in verified seams; **awaiting approval to build.** Key finding: Part B (cron
   trigger) is mostly Python-side wiring since the host cron plumbing already
-  exists; Part A (state accumulator) needs a new packaged `StateAccumulatorFactory`.
+  exists; Part A (state accumulator) needs a new packaged `StateAccumulatorFactory`.- 2026-06-17: **Part A (state accumulator) built + verified.** Added
+  `@cloaca.state_accumulator(capacity=N)` (mirrors the stream decorator) and a
+  `StateAccumulatorFactory` in `packaging_bridge.rs` that spawns
+  `state_accumulator_runtime::<serde_json::Value>(capacity)` — wired into all
+  three `accumulator_type` matches (FFI metadata + both override paths); capacity
+  flows decorator → `config["capacity"]` → factory. No contract mismatch (the
+  state runtime fits `AccumulatorFactory::spawn` exactly like the others).
+  `cargo check` (cloacina + cloacina-python, default features) green; unit test
+  `test_state_accumulator_decorator_registers_state_with_capacity` passes.
+- 2026-06-17: **Part B (cron trigger) — design question found in-code, NOT a
+  simple wiring change.** `@cloaca.trigger` produces a *poll* trigger
+  (`PythonTriggerWrapper.poll()`); cron is a different mechanism
+  (`TriggerPackageMetadata.cron_expression` → cron scheduler, not the poll
+  registry). So `@cloaca.trigger(cron=…)` needs an API decision: what it
+  decorates and how it ties to a workflow (Rust uses `#[trigger(on=wf, cron=…)]`).
+  Deferred pending that decision; not guessed.

--- a/.metis/backlog/tech-debt/CLOACI-T-0688.md
+++ b/.metis/backlog/tech-debt/CLOACI-T-0688.md
@@ -4,15 +4,15 @@ level: task
 title: "Close Rust↔Python interface parity gaps (state accumulators, packaged cron-trigger authoring)"
 short_code: "CLOACI-T-0688"
 created_at: 2026-06-15T13:46:31.557405+00:00
-updated_at: 2026-06-15T13:46:31.557405+00:00
-parent:
+updated_at: 2026-06-17T15:19:21.592385+00:00
+parent: 
 blocked_by: []
 archived: false
 
 tags:
   - "#task"
-  - "#phase/backlog"
   - "#tech-debt"
+  - "#phase/active"
 
 
 exit_criteria_met: false
@@ -109,6 +109,10 @@ hard parity *failures* (no Python `@state_accumulator`, no packaged cron
 
 ## Acceptance Criteria
 
+## Acceptance Criteria
+
+## Acceptance Criteria
+
 - [ ] `@cloaca.state_accumulator` implemented with parity to `#[state_accumulator]` (incl. DAL-backed history/capacity)
 - [ ] Python `@cloaca.trigger` (or a packaged-cron path) supports cron expression + timezone authoring
 - [ ] Decision recorded on `TaskHandle.defer_until()` (surface in Rust vs. document as Python-only)
@@ -179,3 +183,83 @@ hard parity *failures* (no Python `@state_accumulator`, no packaged cron
 ## Status Updates **[REQUIRED]**
 
 *To be added during implementation*
+
+## Implementation Plan (2026-06-17) — plan-first, awaiting approval to build
+
+Unblocked from the fidius-wasm deferral: these are **PyO3 binding** changes
+(exposing existing Rust functionality to Python), independent of the cdylib/FFI
+plugin-loading path the wasm work reshapes (see [[project_fidius_wasm_authoring_shift]]).
+On branch `py-parity-t0688` (off main; #131's files are untouched here).
+
+### Verified seams
+- Python accumulator decorators: `crates/cloacina-python/src/computation_graph.rs`
+  — `register_accumulator` + `PyAccumulatorRegistration { accumulator_type }`;
+  four decorators today (passthrough/stream/polling/batch).
+- Packaged accumulator factory: `packaging_bridge.rs:205` matches
+  `accumulator_type` → only `"stream"` + a passthrough fallback (so polling/
+  batch/state all currently fall through to passthrough). `AccumulatorFactory`
+  trait `spawn(...)` at `:336`/`:469`.
+- Rust state accumulator: `accumulator.rs:889` `StateAccumulator<T>`, `:907`
+  `state_accumulator_runtime<T: Serialize+DeserializeOwned+Send+Clone>(capacity, …)`.
+  Capacity: `>0` bounded (evict oldest), `<0` unbounded, `==0` write-only sink.
+- Python trigger decorator: `trigger.rs` `trigger()` pyfunction (`poll_interval`,
+  `allow_concurrent`) + `PythonTriggerDef { poll_interval }`.
+- Python trigger → manifest emission: `cloacina-python/src/loader.rs:315`
+  consumes `drain_python_triggers()` and emits trigger metadata.
+- **Host cron plumbing already exists end-to-end**: `ffi_trigger.rs:52`
+  `cron_expression: Option<String>`, `package_loader.rs:441`
+  `TriggerPackageMetadata`, reconciler `register_cron_workflow` (mod.rs:183).
+  Rust macro `trigger_attr.rs:40` carries `cron`/`timezone`.
+
+### Part A — `@cloaca.state_accumulator(capacity=N)` (M, the harder half)
+1. Decorator in `computation_graph.rs`: `state_accumulator_decorator(capacity)` →
+   register with `accumulator_type="state"`; add a `capacity: i32` field to
+   `PyAccumulatorRegistration`.
+2. `StateAccumulatorFactory` in `packaging_bridge.rs` implementing
+   `AccumulatorFactory::spawn`, launching
+   `state_accumulator_runtime::<serde_json::Value>(capacity, …)`. Wire `"state"`
+   into the `accumulator_type` match at `:205` (and the override matches at
+   `:582`/`:644`).
+3. Embedded (in-process cloaca) path: the graph builder that drains
+   `drain_accumulators()` must also handle `"state"`.
+4. **Open question (main risk):** reconcile `AccumulatorFactory::spawn`'s contract
+   (boundary sender + DAL handle + shutdown) with `state_accumulator_runtime`'s
+   loop shape (persists history to DAL, emits the full list as boundary). This
+   wiring — dynamic `serde_json::Value` output + DAL persistence in the packaged
+   factory — is the biggest unknown.
+
+### Part B — cron `@cloaca.trigger(cron=…, timezone=…)` (M, more tractable)
+1. Decorator in `trigger.rs`: add `cron: Option<String>`, `timezone:
+   Option<String>` to `trigger()` + `PythonTriggerDef`. `cron` set ⇒ cron trigger
+   (no poll body); mutually exclusive with `poll_interval`.
+2. Manifest emission `loader.rs:315`: emit `cron_expression` (+ timezone) in the
+   `TriggerPackageMetadata` when `cron` is set.
+3. Runtime: **no new host work** — `ffi_trigger`/`package_loader`/reconciler
+   already register cron schedules from `cron_expression`. Verify the
+   poll-vs-cron branch keys on `cron_expression` presence.
+4. Open question: scope to packaged/decorator authoring (the documented gap);
+   Python already has runner-level cron scheduling via `register_cron_workflow`.
+
+### Part C — `TaskHandle.defer_until()` reverse gap (XS)
+Decision only: document as an intentional Python convenience (cite
+`cloacina-python/src/task.rs:34`) vs. add a Rust equivalent for symmetry.
+Recommend: document as Python-only unless symmetry is explicitly wanted.
+
+### Test strategy (per AC + the SDK-live-server memory)
+- New Python scenario tests against a **live runner**: a state-accumulator
+  scenario (bounded capacity eviction + history emission) and a packaged
+  cron-trigger scenario (authored via decorator, fires on schedule).
+- Build packaged fixtures exercising both; verify register + fire end-to-end.
+- Remove the "Rust-only" caveats from the primitive docs as each gap closes.
+
+### Recommended sequencing
+Part B first (host plumbing exists → lower risk, faster win) → Part A (factory
+wiring, the real unknown) → Part C decision. Each its own commit; verify via
+`angreal test integration` (Python scenarios) before moving on.
+
+## Status Updates
+- 2026-06-17: Unblocked (PyO3 bindings independent of the fidius-wasm plugin
+  path, per user). Plan-first per request: implementation plan above, grounded
+  in verified seams; **awaiting approval to build.** Key finding: Part B (cron
+  trigger) is mostly Python-side wiring since the host cron plumbing already
+  exists; Part A (state accumulator) needs a new packaged `StateAccumulatorFactory`.

--- a/.metis/backlog/tech-debt/CLOACI-T-0688.md
+++ b/.metis/backlog/tech-debt/CLOACI-T-0688.md
@@ -278,3 +278,24 @@ wiring, the real unknown) → Part C decision. Each its own commit; verify via
   registry). So `@cloaca.trigger(cron=…)` needs an API decision: what it
   decorates and how it ties to a workflow (Rust uses `#[trigger(on=wf, cron=…)]`).
   Deferred pending that decision; not guessed.
+- 2026-06-17: **Part B (cron trigger) built — mirror-Rust API.** Resolved the
+  design question: `@cloaca.trigger(on="wf", cron="…", timezone="…")` mirrors
+  `#[trigger(on=…, cron=…, timezone=…)]`. Validation mirrors Rust (cron XOR
+  poll_interval; `on` required for cron). Turned out **contained to `trigger.rs`**:
+  `build_view_python` (loading.rs:1398) already emits `cron_expression()` +
+  `workflow_name()` from the Trigger trait, but `PythonTriggerWrapper` returned
+  the trait defaults (None / ""). Fix: carry `on`/`cron`/`timezone` on
+  `PythonTriggerDef` + the wrapper and override `Trigger::workflow_name()` /
+  `cron_expression()`. The reconciler's `step_load_cron_triggers` then registers
+  the cron schedule — packaged-Python cron authoring now works end-to-end.
+  Tests: cron decorator carries cron+workflow; wrapper exposes them; validation
+  guards. 16+10 trigger tests pass; cloacina-python compiles (default features).
+- 2026-06-17: **Two honest caveats.** (1) `timezone` is captured at authoring
+  but **not honored downstream** — the reconciler hardcodes `"UTC"`
+  (loading.rs:1543) and `TriggerPackageMetadata` has no `timezone` field. This is
+  a **pre-existing cross-language gap** (Rust `#[trigger(timezone=)]` is dropped
+  the same way), so Python is at parity; full plumbing is a separate follow-up.
+  (2) Embedded (in-process, non-packaged) cron via the decorator isn't scheduled
+  (cron needs a DB + the reconciler; import-time has neither) — embedded cron
+  stays on the runner-level `register_cron_workflow` API. The packaged/decorator
+  authoring form (the documented gap) is what's closed.

--- a/.metis/initiatives/CLOACI-I-0117/tasks/CLOACI-T-0742.md
+++ b/.metis/initiatives/CLOACI-I-0117/tasks/CLOACI-T-0742.md
@@ -1,0 +1,219 @@
+---
+id: surface-reactors-as-first-class
+level: task
+title: "Surface reactors as first-class entities in the CG view + enrich accumulator/reactor operational metrics"
+short_code: "CLOACI-T-0742"
+created_at: 2026-06-17T21:41:13.884119+00:00
+updated_at: 2026-06-17T21:50:43.763198+00:00
+parent: CLOACI-I-0117
+blocked_by: []
+archived: false
+
+tags:
+  - "#task"
+  - "#phase/active"
+
+
+exit_criteria_met: false
+initiative_id: CLOACI-I-0117
+---
+
+# Surface reactors as first-class entities in the CG view + enrich accumulator/reactor operational metrics
+
+*This template includes sections for various types of tasks. Delete sections that don't apply to your specific use case.*
+
+## Parent Initiative **[CONDITIONAL: Assigned Task]**
+
+[[CLOACI-I-0117]]
+
+## Objective **[REQUIRED]**
+
+Make **reactors** first-class in the Computation-graphs view (today they're only
+surfaced graph-first), and enrich both accumulators and reactors with the
+operational metrics the runtime already computes. Surfaced 2026-06-17 watching
+the demo stack: you can't see, at a glance, which accumulators a reactor consumes
+or its firing logic (any/all), and a reactor not bound to a graph is invisible.
+
+## Why this matters (code-grounded)
+
+- **Reactors are standalone, not 1:1 with a graph.** The scheduler's core map is
+  `reactors: HashMap<String, RunningGraph>` (`computation_graph/scheduler.rs:333`),
+  keyed by reactor name. A reactor is `load_reactor()`'d first
+  (`scheduler.rs:384`) and a graph `bind_graph_to_reactor()`'s to it afterward
+  (`scheduler.rs:581`) — confirmed live in the demo logs ("reactor loaded and
+  running reactor=demo_py_state_rx" then "graph bound to reactor"). So a reactor
+  with **no graph bound** (or a shared one) exists in the runtime but is **not
+  shown anywhere** today, because the UI and `/v1/health/graphs` are graph-first.
+- **The data already exists.** Each running reactor carries `accumulators:
+  Vec<String>` and `reaction_mode: String` (any/all, `scheduler.rs:115,131`),
+  plus live counters `(fires, last_fire_unix_ms)` (`reactor.rs:249-251`) and a
+  `paused` flag. There's just no reactor-centric endpoint or UI card.
+- **Accumulator metrics are lopsided.** `AccumulatorStatus` exposes only name + a
+  coarse health enum (`accumulator.rs:42` Starting/Connecting/Live/Disconnected/
+  SocketOnly); the UI renders it as a single status dot (`routes/Graphs.tsx`
+  Accumulators card). Meanwhile **buffer depth** is already a Prometheus gauge
+  (`set_accumulator_buffer_depth`, `accumulator.rs:405,541`) and
+  `cloacina_reactor_fires_total` a Prometheus counter (`reactor.rs:702`) — both go
+  to `/metrics`, NOT the JSON the UI polls every 5s (`api/health.ts`).
+
+## Scope
+
+### Server (`crates/cloacina-server/src/routes/health_graphs.rs`)
+- Add `GET /v1/health/reactors` returning `ReactorStatus { name, criteria
+  (any/all from reaction_mode), accumulators: Vec<String>, bound_graph:
+  Option<String>, fires, last_fired_at, paused, health }`, sourced from the
+  scheduler's reactor-keyed map so **unbound reactors are included**. Reuse the
+  key-visibility filtering used by `list_graphs`/`list_accumulators`.
+- Enrich `AccumulatorStatus`: lift the buffer-depth gauge into the JSON + add
+  capacity/fill for state accumulators, events-received (total + derived rate),
+  last-event-at. (Altitude: make the health API the single source for these
+  counters instead of teaching the UI to scrape `/metrics`.)
+
+### UI (`ui/src/routes/Graphs.tsx`, `ui/src/api/health.ts`)
+- Add a **Reactors** card: name, a **criteria chip (any/all)**, its accumulators
+  (reuse the `accStatus` dots so each shows source health), throughput +
+  last-fired (reuse `useGraphThroughput`), paused badge. Row links to graph
+  detail when a graph is bound.
+- Enrich the **Accumulators** card from a status dot to real metrics: buffer/fill
+  (incl. **state-accumulator capacity** — visible on the new `demo-py-state`,
+  capacity=5 → window N/5), events rate, last-event-at.
+- Add a `useReactors()` hook alongside `useGraphs()`/`useAccumulators()`.
+
+## Notes
+- The graph-detail page (`routes/GraphDetail.tsx`) already renders the reactor as
+  a first-class node (sources → reactor → graph) with reaction-mode/criteria;
+  this task brings that to the **list** view and adds operational metrics.
+- The graph row's existing `fires`/`throughput`/`last-fired` ARE the reactor's
+  counters; once reactors have their own card, clarify that attribution on the
+  graph row (tooltip/label) to avoid double-reading.
+- Validate against demo fixtures: `demo-py-state` (state acc, capacity=5, reactor
+  `demo_py_state_rx`, when_any), `mixed-rust`, `demo-py-graph`.
+
+## Backlog Item Details **[CONDITIONAL: Backlog Item]**
+
+{Delete this section when task is assigned to an initiative}
+
+### Type
+- [ ] Bug - Production issue that needs fixing
+- [ ] Feature - New functionality or enhancement
+- [ ] Tech Debt - Code improvement or refactoring
+- [ ] Chore - Maintenance or setup work
+
+### Priority
+- [ ] P0 - Critical (blocks users/revenue)
+- [ ] P1 - High (important for user experience)
+- [ ] P2 - Medium (nice to have)
+- [ ] P3 - Low (when time permits)
+
+### Impact Assessment **[CONDITIONAL: Bug]**
+- **Affected Users**: {Number/percentage of users affected}
+- **Reproduction Steps**:
+  1. {Step 1}
+  2. {Step 2}
+  3. {Step 3}
+- **Expected vs Actual**: {What should happen vs what happens}
+
+### Business Justification **[CONDITIONAL: Feature]**
+- **User Value**: {Why users need this}
+- **Business Value**: {Impact on metrics/revenue}
+- **Effort Estimate**: {Rough size - S/M/L/XL}
+
+### Technical Debt Impact **[CONDITIONAL: Tech Debt]**
+- **Current Problems**: {What's difficult/slow/buggy now}
+- **Benefits of Fixing**: {What improves after refactoring}
+- **Risk Assessment**: {Risks of not addressing this}
+
+## Acceptance Criteria
+
+## Acceptance Criteria **[REQUIRED]**
+
+- [ ] `GET /v1/health/reactors` exists, returns reactors from the scheduler's
+      reactor-keyed map (incl. ones with no graph bound), key-visibility filtered.
+- [ ] Each reactor row shows: name, criteria chip (any/all), the accumulators it
+      consumes (with per-source health dots), throughput, last-fired, paused.
+- [ ] Accumulator rows show real operational metrics, not just a status dot —
+      buffer/fill (with capacity for state accumulators), events rate, last-event.
+- [ ] Buffer-depth + fires counters are served from the health API (not only
+      `/metrics`); the UI reads them from the polled JSON.
+- [ ] Verified live against the demo stack: `demo-py-state` shows reactor
+      `demo_py_state_rx` (when_any) consuming `py_window` at N/5 fill.
+
+## Test Cases **[CONDITIONAL: Testing Task]**
+
+{Delete unless this is a testing task}
+
+### Test Case 1: {Test Case Name}
+- **Test ID**: TC-001
+- **Preconditions**: {What must be true before testing}
+- **Steps**:
+  1. {Step 1}
+  2. {Step 2}
+  3. {Step 3}
+- **Expected Results**: {What should happen}
+- **Actual Results**: {To be filled during execution}
+- **Status**: {Pass/Fail/Blocked}
+
+### Test Case 2: {Test Case Name}
+- **Test ID**: TC-002
+- **Preconditions**: {What must be true before testing}
+- **Steps**:
+  1. {Step 1}
+  2. {Step 2}
+- **Expected Results**: {What should happen}
+- **Actual Results**: {To be filled during execution}
+- **Status**: {Pass/Fail/Blocked}
+
+## Documentation Sections **[CONDITIONAL: Documentation Task]**
+
+{Delete unless this is a documentation task}
+
+### User Guide Content
+- **Feature Description**: {What this feature does and why it's useful}
+- **Prerequisites**: {What users need before using this feature}
+- **Step-by-Step Instructions**:
+  1. {Step 1 with screenshots/examples}
+  2. {Step 2 with screenshots/examples}
+  3. {Step 3 with screenshots/examples}
+
+### Troubleshooting Guide
+- **Common Issue 1**: {Problem description and solution}
+- **Common Issue 2**: {Problem description and solution}
+- **Error Messages**: {List of error messages and what they mean}
+
+### API Documentation **[CONDITIONAL: API Documentation]**
+- **Endpoint**: {API endpoint description}
+- **Parameters**: {Required and optional parameters}
+- **Example Request**: {Code example}
+- **Example Response**: {Expected response format}
+
+## Implementation Notes **[CONDITIONAL: Technical Task]**
+
+{Keep for technical tasks, delete for non-technical. Technical details, approach, or important considerations}
+
+### Technical Approach
+{How this will be implemented}
+
+### Dependencies
+{Other tasks or systems this depends on}
+
+### Risk Considerations
+{Technical risks and mitigation strategies}
+
+## Status Updates **[REQUIRED]**
+
+- 2026-06-17: **Reactors-first surfacing built** (branch `py-parity-t0688` /
+  PR #132 per user). Server: `scheduler::ReactorStatus` +
+  `ComputationGraphScheduler::list_reactors()` (iterates the `reactors` map so
+  unbound reactors are included; `bound_graphs` is the reverse `graph_to_reactor`
+  lookup), `cloacina_api_types::ReactorStatus`, `GET /v1/health/reactors` (reuses
+  the `graph_visible` tenant gate). Registered route + OpenAPI path/schema;
+  regenerated `docs/static/openapi.json` (drift gate) + TS client types; added
+  `client.listReactors()`. UI: `useReactors()` + `queryKeys.reactors`, and a
+  **Reactors card** in `routes/Graphs.tsx` — name, **criteria chip (any/all via
+  explainToken)**, accumulators consumed (reusing source-health dots), bound graph
+  (or "unbound"), throughput (reused `useGraphThroughput`), last-fired, paused.
+  Compiles green: `angreal check crate cloacina-server`, TS client typecheck+build,
+  UI tsc + vite build. **Still TODO (this task):** accumulator-card enrichment
+  (buffer/fill incl. state-accumulator capacity, events rate, last-event — needs
+  lifting the Prometheus buffer-depth gauge into the health API); live-verify on
+  the demo stack after a server+ui rebuild.

--- a/clients/typescript/generated/types.ts
+++ b/clients/typescript/generated/types.ts
@@ -204,6 +204,27 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/health/reactors": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * GET /v1/health/reactors — list loaded reactors visible to the caller
+         *     (CLOACI-T-0742). Reactor-first: includes reactors with no graph bound, which
+         *     `list_graphs` omits. Visibility reuses the same tenant gate as graphs.
+         */
+        get: operations["list_reactors"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/tenants": {
         parameters: {
             query?: never;
@@ -838,6 +859,39 @@ export interface components {
          *     returns `{items, total}`. `total` is best-effort — it equals the
          *     returned page size when the server doesn't run a separate COUNT.
          */
+        ListResponse_ReactorStatus: {
+            items: {
+                /** @description Accumulators this reactor consumes (its inputs). */
+                accumulators: string[];
+                /** @description Graphs bound to this reactor; empty when the reactor has no graph yet. */
+                bound_graphs?: string[];
+                /**
+                 * Format: int64
+                 * @description Total fires since load (the reactor's live fire counter, WS-10).
+                 */
+                fires?: number;
+                /**
+                 * @description Reactor health snapshot; `{"state": "running" | "stopped"}` when no
+                 *     detailed health is available. Free-form JSON, mirroring `GraphStatus`.
+                 */
+                health: unknown;
+                /** @description Input strategy: `"latest"` | `"sequential"`. */
+                input_strategy?: string | null;
+                /** @description RFC 3339 timestamp of the last fire; `null` if it hasn't fired yet. */
+                last_fired_at?: string | null;
+                name: string;
+                /** @description Pause state of the reactor. */
+                paused: boolean;
+                /** @description Firing criteria: `"when_any"` | `"when_all"`. */
+                reaction_mode?: string | null;
+            }[];
+            total: number;
+        };
+        /**
+         * @description Unified list envelope (CLOACI-T-0594 / API-03): every list endpoint
+         *     returns `{items, total}`. `total` is best-effort — it equals the
+         *     returned page size when the server doesn't run a separate COUNT.
+         */
         ListResponse_TenantSummary: {
             items: {
                 name: string;
@@ -855,6 +909,36 @@ export interface components {
              * @description The `.cloacina` package archive.
              */
             file: string;
+        };
+        /**
+         * @description One row in `GET /v1/health/reactors` (CLOACI-T-0742). Reactor-first view:
+         *     reactors are standalone (a graph binds to a reactor, not vice versa), so a
+         *     reactor with no graph bound appears here but not in `GET /v1/health/graphs`.
+         */
+        ReactorStatus: {
+            /** @description Accumulators this reactor consumes (its inputs). */
+            accumulators: string[];
+            /** @description Graphs bound to this reactor; empty when the reactor has no graph yet. */
+            bound_graphs?: string[];
+            /**
+             * Format: int64
+             * @description Total fires since load (the reactor's live fire counter, WS-10).
+             */
+            fires?: number;
+            /**
+             * @description Reactor health snapshot; `{"state": "running" | "stopped"}` when no
+             *     detailed health is available. Free-form JSON, mirroring `GraphStatus`.
+             */
+            health: unknown;
+            /** @description Input strategy: `"latest"` | `"sequential"`. */
+            input_strategy?: string | null;
+            /** @description RFC 3339 timestamp of the last fire; `null` if it hasn't fired yet. */
+            last_fired_at?: string | null;
+            name: string;
+            /** @description Pause state of the reactor. */
+            paused: boolean;
+            /** @description Firing criteria: `"when_any"` | `"when_all"`. */
+            reaction_mode?: string | null;
         };
         /** @description One per-task row of an execution (CLOACI-I-0124 / WS-1). */
         TaskExecutionDetail: {
@@ -1535,6 +1619,35 @@ export interface operations {
             };
             /** @description Graph not found (or not visible to caller) */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorBody"];
+                };
+            };
+        };
+    };
+    list_reactors: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Loaded reactors visible to the caller */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ListResponse_ReactorStatus"];
+                };
+            };
+            /** @description Missing or invalid API key */
+            401: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/clients/typescript/src/client.ts
+++ b/clients/typescript/src/client.ts
@@ -383,6 +383,10 @@ export class CloacinaClient {
     return unwrap(await this.api.GET("/v1/health/accumulators"));
   }
 
+  async listReactors(): Promise<schemas["ListResponse_ReactorStatus"]> {
+    return unwrap(await this.api.GET("/v1/health/reactors"));
+  }
+
   async listGraphs(): Promise<schemas["ListResponse_GraphStatus"]> {
     return unwrap(await this.api.GET("/v1/health/graphs"));
   }

--- a/crates/cloacina-api-types/src/health.rs
+++ b/crates/cloacina-api-types/src/health.rs
@@ -28,6 +28,37 @@ pub struct AccumulatorStatus {
     pub status: serde_json::Value,
 }
 
+/// One row in `GET /v1/health/reactors` (CLOACI-T-0742). Reactor-first view:
+/// reactors are standalone (a graph binds to a reactor, not vice versa), so a
+/// reactor with no graph bound appears here but not in `GET /v1/health/graphs`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct ReactorStatus {
+    pub name: String,
+    /// Reactor health snapshot; `{"state": "running" | "stopped"}` when no
+    /// detailed health is available. Free-form JSON, mirroring `GraphStatus`.
+    pub health: serde_json::Value,
+    /// Accumulators this reactor consumes (its inputs).
+    pub accumulators: Vec<String>,
+    /// Firing criteria: `"when_any"` | `"when_all"`.
+    #[serde(default)]
+    pub reaction_mode: Option<String>,
+    /// Input strategy: `"latest"` | `"sequential"`.
+    #[serde(default)]
+    pub input_strategy: Option<String>,
+    /// Graphs bound to this reactor; empty when the reactor has no graph yet.
+    #[serde(default)]
+    pub bound_graphs: Vec<String>,
+    /// Pause state of the reactor.
+    pub paused: bool,
+    /// Total fires since load (the reactor's live fire counter, WS-10).
+    #[serde(default)]
+    pub fires: u64,
+    /// RFC 3339 timestamp of the last fire; `null` if it hasn't fired yet.
+    #[serde(default)]
+    pub last_fired_at: Option<String>,
+}
+
 /// One row in `GET /v1/health/graphs`, and the `GET /v1/health/graphs/{name}`
 /// response body.
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/cloacina-api-types/src/lib.rs
+++ b/crates/cloacina-api-types/src/lib.rs
@@ -56,6 +56,7 @@ pub use executions::{
 pub use fleet::AgentInfo;
 pub use health::{
     AccumulatorStatus, GraphStatus, GraphTopology, GraphTopologyEdge, GraphTopologyNode,
+    ReactorStatus,
 };
 pub use keys::{
     CreateKeyRequest, KeyCreatedResponse, KeyInfo, KeyRevokedResponse, KeyRole, WsTicketResponse,

--- a/crates/cloacina-python/src/computation_graph.rs
+++ b/crates/cloacina-python/src/computation_graph.rs
@@ -119,8 +119,12 @@ fn drain_nodes() -> HashMap<String, PyObject> {
 #[derive(Debug, Clone)]
 pub struct PyAccumulatorRegistration {
     pub name: String,
-    pub accumulator_type: String, // "passthrough", "stream", "polling", "batch"
+    pub accumulator_type: String, // "passthrough", "stream", "polling", "batch", "state"
     pub config: HashMap<String, String>,
+    /// Capacity for `state` accumulators (bounded buffer). `> 0` bounded,
+    /// `< 0` unbounded, `0` write-only sink. Defaults to `0` for the other
+    /// accumulator types, which ignore it.
+    pub capacity: i32,
 }
 
 static ACCUMULATOR_REGISTRY: Lazy<Mutex<HashMap<String, (PyObject, PyAccumulatorRegistration)>>> =
@@ -163,6 +167,7 @@ pub fn passthrough_accumulator_decorator(py: Python<'_>, func: PyObject) -> PyRe
         name: func_name.clone(),
         accumulator_type: "passthrough".to_string(),
         config: HashMap::new(),
+        capacity: 0,
     };
     register_accumulator(func_name, func.clone_ref(py), reg);
     Ok(func)
@@ -209,6 +214,7 @@ pub fn stream_accumulator_decorator(
                 name: func_name.clone(),
                 accumulator_type: "stream".to_string(),
                 config,
+                capacity: 0,
             };
             register_accumulator(func_name, func.clone().unbind(), reg);
             Ok(func.clone().unbind())
@@ -246,6 +252,7 @@ pub fn polling_accumulator_decorator(py: Python<'_>, interval: String) -> PyResu
                 name: func_name.clone(),
                 accumulator_type: "polling".to_string(),
                 config,
+                capacity: 0,
             };
             register_accumulator(func_name, func.clone().unbind(), reg);
             Ok(func.clone().unbind())
@@ -291,6 +298,57 @@ pub fn batch_accumulator_decorator(
                 name: func_name.clone(),
                 accumulator_type: "batch".to_string(),
                 config,
+                capacity: 0,
+            };
+            register_accumulator(func_name, func.clone().unbind(), reg);
+            Ok(func.clone().unbind())
+        },
+    )?;
+
+    Ok(decorator.into())
+}
+
+// ---------------------------------------------------------------------------
+// @cloaca.state_accumulator(capacity=N) decorator
+// ---------------------------------------------------------------------------
+
+/// Factory for `@cloaca.state_accumulator(capacity=N)`.
+///
+/// Registers a function as a *state* accumulator: a bounded `VecDeque` that
+/// receives values, persists to the DAL on every write, and emits the full
+/// list back as the boundary (enabling cyclic feedback patterns). Mirrors
+/// Rust's `#[state_accumulator(capacity=…)]`.
+///
+/// Capacity semantics (see `StateAccumulator` in cloacina core):
+/// - `> 0`: bounded — evicts oldest when at capacity
+/// - `< 0`: unbounded — grows without limit
+/// - `0`:  write-only sink — no history emitted back
+#[pyfunction]
+#[pyo3(name = "state_accumulator", signature = (*, capacity))]
+pub fn state_accumulator_decorator(py: Python<'_>, capacity: i32) -> PyResult<PyObject> {
+    let config_capacity = capacity;
+
+    let decorator = PyCFunction::new_closure(
+        py,
+        None,
+        None,
+        move |args: &Bound<'_, PyTuple>,
+              _kwargs: Option<&Bound<'_, PyDict>>|
+              -> PyResult<PyObject> {
+            let _py = args.py();
+            let func = args.get_item(0)?;
+            let func_name: String = func.getattr("__name__")?.extract()?;
+
+            // Mirror capacity into config too, so it survives the
+            // String-keyed config map used at the FFI/override boundary.
+            let mut config = HashMap::new();
+            config.insert("capacity".to_string(), config_capacity.to_string());
+
+            let reg = PyAccumulatorRegistration {
+                name: func_name.clone(),
+                accumulator_type: "state".to_string(),
+                config,
+                capacity: config_capacity,
             };
             register_accumulator(func_name, func.clone().unbind(), reg);
             Ok(func.clone().unbind())
@@ -749,7 +807,7 @@ pub fn build_python_graph_declaration(
     accumulator_overrides: &[cloacina_workflow_plugin::types::AccumulatorConfig],
 ) -> Option<cloacina::computation_graph::scheduler::ComputationGraphDeclaration> {
     use cloacina::computation_graph::packaging_bridge::{
-        PassthroughAccumulatorFactory, StreamBackendAccumulatorFactory,
+        PassthroughAccumulatorFactory, StateAccumulatorFactory, StreamBackendAccumulatorFactory,
     };
     use cloacina::computation_graph::reactor::{InputStrategy, ReactionCriteria};
     use cloacina::computation_graph::scheduler::{
@@ -797,6 +855,13 @@ pub fn build_python_graph_declaration(
                     match override_cfg.accumulator_type.as_str() {
                         "stream" => Arc::new(StreamBackendAccumulatorFactory::new(
                             override_cfg.config.clone(),
+                        )),
+                        "state" => Arc::new(StateAccumulatorFactory::new(
+                            override_cfg
+                                .config
+                                .get("capacity")
+                                .and_then(|c| c.parse::<i32>().ok())
+                                .unwrap_or(0),
                         )),
                         _ => Arc::new(PassthroughAccumulatorFactory),
                     }
@@ -1381,4 +1446,48 @@ fn compute_execution_order(nodes: &[PyNodeDecl]) -> Vec<String> {
     }
 
     sorted
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `@cloaca.state_accumulator(capacity=N)` registers the decorated function
+    /// as a `state` accumulator carrying the requested capacity (both on the
+    /// struct field and mirrored into config).
+    #[test]
+    fn test_state_accumulator_decorator_registers_state_with_capacity() {
+        pyo3::prepare_freethreaded_python();
+        Python::with_gil(|py| {
+            // Clear any registry state leaked from other tests in this process.
+            let _ = drain_accumulators();
+
+            // Build the decorator with capacity=5.
+            let decorator = state_accumulator_decorator(py, 5).unwrap();
+
+            // A trivial Python function to decorate; its __name__ becomes the key.
+            let func = py
+                .eval(
+                    pyo3::ffi::c_str!("type('f', (), {'__name__': 'my_state'})()"),
+                    None,
+                    None,
+                )
+                .unwrap();
+
+            // Apply the decorator: decorator(func) -> func (transparent).
+            let args = PyTuple::new(py, [func]).unwrap();
+            decorator.call1(py, args).unwrap();
+
+            let regs = get_registered_accumulators();
+            let reg = regs
+                .iter()
+                .find(|r| r.name == "my_state")
+                .expect("state accumulator should be registered under its __name__");
+            assert_eq!(reg.accumulator_type, "state");
+            assert_eq!(reg.capacity, 5);
+            assert_eq!(reg.config.get("capacity").map(String::as_str), Some("5"));
+
+            let _ = drain_accumulators();
+        });
+    }
 }

--- a/crates/cloacina-python/src/lib.rs
+++ b/crates/cloacina-python/src/lib.rs
@@ -143,6 +143,10 @@ fn cloaca(m: &Bound<'_, PyModule>) -> PyResult<()> {
         computation_graph::batch_accumulator_decorator,
         m
     )?)?;
+    m.add_function(wrap_pyfunction!(
+        computation_graph::state_accumulator_decorator,
+        m
+    )?)?;
 
     #[cfg(feature = "postgres")]
     {

--- a/crates/cloacina-python/src/lib.rs
+++ b/crates/cloacina-python/src/lib.rs
@@ -241,6 +241,11 @@ mod tests {
             assert!(cloaca_mod.hasattr("stream_accumulator").unwrap());
             assert!(cloaca_mod.hasattr("polling_accumulator").unwrap());
             assert!(cloaca_mod.hasattr("batch_accumulator").unwrap());
+            // CLOACI-T-0688: state accumulator must be in the SERVER's synthetic
+            // module too, not just the maturin #[pymodule] — the demo stack caught
+            // this drift (server reconciler: "module 'cloaca' has no attribute
+            // 'state_accumulator'") because ensure_cloaca_module omitted it.
+            assert!(cloaca_mod.hasattr("state_accumulator").unwrap());
             assert!(cloaca_mod.hasattr("node").unwrap());
             assert!(cloaca_mod.hasattr("ComputationGraphBuilder").unwrap());
             // Variable registry

--- a/crates/cloacina-python/src/loader.rs
+++ b/crates/cloacina-python/src/loader.rs
@@ -153,6 +153,10 @@ pub fn ensure_cloaca_module(py: Python) -> PyResult<()> {
         super::computation_graph::batch_accumulator_decorator,
         &module
     )?)?;
+    module.add_function(wrap_pyfunction!(
+        super::computation_graph::state_accumulator_decorator,
+        &module
+    )?)?;
     module.add_function(wrap_pyfunction!(super::computation_graph::node, &module)?)?;
     module.add_class::<super::computation_graph::PyComputationGraphBuilder>()?;
 

--- a/crates/cloacina-python/src/trigger.rs
+++ b/crates/cloacina-python/src/trigger.rs
@@ -44,6 +44,15 @@ pub struct PythonTriggerDef {
     pub poll_interval: Duration,
     pub allow_concurrent: bool,
     pub python_function: PyObject,
+    /// Workflow this trigger fires, from `@cloaca.trigger(on=…)`. Mirrors the
+    /// Rust `#[trigger(on = "…")]` binding (CLOACI-T-0688). Empty for legacy
+    /// poll triggers that bind via `#[workflow(triggers=[…])]` subscription.
+    pub workflow_name: String,
+    /// Cron expression from `@cloaca.trigger(cron=…)`. When set, the reconciler
+    /// routes this to the cron scheduler instead of the poll registry.
+    pub cron_expression: Option<String>,
+    /// Timezone for the cron schedule (`@cloaca.trigger(timezone=…)`).
+    pub timezone: Option<String>,
 }
 
 /// Collect all registered Python triggers and clear the registry.
@@ -65,6 +74,9 @@ pub struct TriggerDecorator {
     name: Option<String>,
     poll_interval: Duration,
     allow_concurrent: bool,
+    workflow_name: String,
+    cron_expression: Option<String>,
+    timezone: Option<String>,
 }
 
 #[pymethods]
@@ -81,6 +93,9 @@ impl TriggerDecorator {
             poll_interval: self.poll_interval,
             allow_concurrent: self.allow_concurrent,
             python_function: func.clone_ref(py),
+            workflow_name: self.workflow_name.clone(),
+            cron_expression: self.cron_expression.clone(),
+            timezone: self.timezone.clone(),
         };
 
         PYTHON_TRIGGER_REGISTRY.lock().push(def);
@@ -93,21 +108,51 @@ impl TriggerDecorator {
 }
 
 /// `@cloaca.trigger(...)` decorator factory.
+///
+/// Mirrors the Rust `#[trigger]` macro (CLOACI-T-0688). Two modes:
+/// - **Custom poll** — `poll_interval` + a function body that returns a
+///   `TriggerResult`.
+/// - **Cron** — `cron` (+ optional `timezone`); the framework schedules the
+///   `on` workflow on that cron expression (the function body is unused). The
+///   reconciler routes `cron_expression`-bearing triggers to the cron scheduler.
+///
+/// `on` names the workflow the trigger fires; it is **required for cron**
+/// triggers. `cron` and `poll_interval` are mutually exclusive.
 #[pyfunction]
-#[pyo3(signature = (*, name = None, poll_interval = "30s".to_string(), allow_concurrent = false))]
+#[pyo3(signature = (*, name = None, on = None, poll_interval = None, cron = None, timezone = None, allow_concurrent = false))]
 pub fn trigger(
     name: Option<String>,
-    poll_interval: String,
+    on: Option<String>,
+    poll_interval: Option<String>,
+    cron: Option<String>,
+    timezone: Option<String>,
     allow_concurrent: bool,
 ) -> PyResult<TriggerDecorator> {
-    let interval = parse_duration_str(&poll_interval).map_err(|e| {
-        PyValueError::new_err(format!("Invalid poll_interval '{}': {}", poll_interval, e))
+    // Mirror the Rust macro's validation.
+    if cron.is_some() && poll_interval.is_some() {
+        return Err(PyValueError::new_err(
+            "@cloaca.trigger cannot set both 'cron' and 'poll_interval' — pick one",
+        ));
+    }
+    if cron.is_some() && on.is_none() {
+        return Err(PyValueError::new_err(
+            "@cloaca.trigger(cron=…) requires 'on' (the workflow the cron schedule fires)",
+        ));
+    }
+
+    // Poll interval still defaults to 30s for the poll path; ignored for cron.
+    let interval_str = poll_interval.unwrap_or_else(|| "30s".to_string());
+    let interval = parse_duration_str(&interval_str).map_err(|e| {
+        PyValueError::new_err(format!("Invalid poll_interval '{}': {}", interval_str, e))
     })?;
 
     Ok(TriggerDecorator {
         name,
         poll_interval: interval,
         allow_concurrent,
+        workflow_name: on.unwrap_or_default(),
+        cron_expression: cron,
+        timezone,
     })
 }
 
@@ -117,6 +162,8 @@ pub struct PythonTriggerWrapper {
     poll_interval: Duration,
     allow_concurrent: bool,
     python_function: PyObject,
+    workflow_name: String,
+    cron_expression: Option<String>,
 }
 
 // SAFETY: PythonTriggerWrapper holds a PyObject which is not Send/Sync.
@@ -133,6 +180,8 @@ impl PythonTriggerWrapper {
             poll_interval: def.poll_interval,
             allow_concurrent: def.allow_concurrent,
             python_function: function,
+            workflow_name: def.workflow_name.clone(),
+            cron_expression: def.cron_expression.clone(),
         }
     }
 }
@@ -158,6 +207,14 @@ impl Trigger for PythonTriggerWrapper {
 
     fn allow_concurrent(&self) -> bool {
         self.allow_concurrent
+    }
+
+    fn workflow_name(&self) -> &str {
+        &self.workflow_name
+    }
+
+    fn cron_expression(&self) -> Option<String> {
+        self.cron_expression.clone()
     }
 
     async fn poll(&self) -> Result<RustTriggerResult, TriggerError> {
@@ -217,8 +274,15 @@ mod tests {
             // Clear any previous state
             drain_python_triggers();
 
-            let decorator =
-                trigger(Some("test_poll".to_string()), "5s".to_string(), false).unwrap();
+            let decorator = trigger(
+                Some("test_poll".to_string()),
+                None,
+                Some("5s".to_string()),
+                None,
+                None,
+                false,
+            )
+            .unwrap();
 
             let func = py.eval(c_str!("lambda: None"), None, None).unwrap();
             decorator.__call__(py, func.into()).unwrap();
@@ -237,7 +301,8 @@ mod tests {
         Python::with_gil(|py| {
             drain_python_triggers();
 
-            let decorator = trigger(None, "10s".to_string(), false).unwrap();
+            let decorator =
+                trigger(None, None, Some("10s".to_string()), None, None, false).unwrap();
 
             // Create a named function
             py.run(c_str!("def check_status(): pass"), None, None)
@@ -251,6 +316,60 @@ mod tests {
         });
     }
 
+    // CLOACI-T-0688: @cloaca.trigger(on=…, cron=…) mirrors the Rust
+    // #[trigger(on=…, cron=…)] cron form. The wrapper must expose
+    // workflow_name + cron_expression so build_view_python emits them and the
+    // reconciler routes the trigger to the cron scheduler.
+    #[test]
+    fn test_cron_trigger_decorator_carries_cron_and_workflow() {
+        pyo3::prepare_freethreaded_python();
+        Python::with_gil(|py| {
+            drain_python_triggers();
+
+            let decorator = trigger(
+                Some("nightly".to_string()),
+                Some("reports_workflow".to_string()),
+                None,
+                Some("0 9 * * *".to_string()),
+                Some("UTC".to_string()),
+                false,
+            )
+            .unwrap();
+
+            let func = py.eval(c_str!("lambda: None"), None, None).unwrap();
+            decorator.__call__(py, func.into()).unwrap();
+
+            let triggers = drain_python_triggers();
+            assert_eq!(triggers.len(), 1);
+            let def = &triggers[0];
+            assert_eq!(def.name, "nightly");
+            assert_eq!(def.workflow_name, "reports_workflow");
+            assert_eq!(def.cron_expression.as_deref(), Some("0 9 * * *"));
+            assert_eq!(def.timezone.as_deref(), Some("UTC"));
+
+            // The Trigger-trait surface the host reads in build_view_python.
+            let wrapper = PythonTriggerWrapper::new(def);
+            assert_eq!(wrapper.workflow_name(), "reports_workflow");
+            assert_eq!(wrapper.cron_expression().as_deref(), Some("0 9 * * *"));
+        });
+    }
+
+    #[test]
+    fn test_cron_trigger_validation_mirrors_rust() {
+        // cron requires `on`
+        assert!(trigger(None, None, None, Some("0 9 * * *".to_string()), None, false).is_err());
+        // cron and poll_interval are mutually exclusive
+        assert!(trigger(
+            None,
+            Some("wf".to_string()),
+            Some("30s".to_string()),
+            Some("0 9 * * *".to_string()),
+            None,
+            false
+        )
+        .is_err());
+    }
+
     #[tokio::test]
     async fn test_python_trigger_wrapper_skip() {
         pyo3::prepare_freethreaded_python();
@@ -262,6 +381,9 @@ mod tests {
                 poll_interval: Duration::from_secs(1),
                 allow_concurrent: false,
                 python_function: func.into(),
+                workflow_name: String::new(),
+                cron_expression: None,
+                timezone: None,
             }
         });
 
@@ -283,6 +405,9 @@ mod tests {
                 poll_interval: Duration::from_secs(1),
                 allow_concurrent: false,
                 python_function: func.into(),
+                workflow_name: String::new(),
+                cron_expression: None,
+                timezone: None,
             }
         });
 
@@ -308,6 +433,9 @@ mod tests {
                 poll_interval: Duration::from_secs(1),
                 allow_concurrent: false,
                 python_function: func.into(),
+                workflow_name: String::new(),
+                cron_expression: None,
+                timezone: None,
             }
         });
 

--- a/crates/cloacina-server/src/lib.rs
+++ b/crates/cloacina-server/src/lib.rs
@@ -1185,6 +1185,10 @@ fn build_router(state: AppState) -> Router {
             get(crate::routes::health_graphs::list_accumulators),
         )
         .route(
+            "/health/reactors",
+            get(crate::routes::health_graphs::list_reactors),
+        )
+        .route(
             "/health/graphs",
             get(crate::routes::health_graphs::list_graphs),
         )

--- a/crates/cloacina-server/src/openapi.rs
+++ b/crates/cloacina-server/src/openapi.rs
@@ -33,10 +33,10 @@ use cloacina_api_types::{
     ExecuteRequest, ExecuteResponse, ExecutionDetail, ExecutionEvent, ExecutionEventsResponse,
     ExecutionSummary, ExecutionTasksResponse, GraphStatus, GraphTopology, GraphTopologyEdge,
     GraphTopologyNode, KeyCreatedResponse, KeyInfo, KeyRevokedResponse, KeyRole, ListResponse,
-    TaskExecutionDetail, TenantCreatedResponse, TenantListResponse, TenantRemovedResponse,
-    TenantSummary, TriggerDetailResponse, TriggerExecution, TriggerScheduleInfo,
-    TriggerScheduleSummary, WorkflowDeletedResponse, WorkflowDetail, WorkflowSummary,
-    WorkflowTaskNode, WorkflowUploadedResponse, WsTicketResponse,
+    ReactorStatus, TaskExecutionDetail, TenantCreatedResponse, TenantListResponse,
+    TenantRemovedResponse, TenantSummary, TriggerDetailResponse, TriggerExecution,
+    TriggerScheduleInfo, TriggerScheduleSummary, WorkflowDeletedResponse, WorkflowDetail,
+    WorkflowSummary, WorkflowTaskNode, WorkflowUploadedResponse, WsTicketResponse,
 };
 use utoipa::openapi::security::{HttpAuthScheme, HttpBuilder, SecurityScheme};
 use utoipa::{Modify, OpenApi, ToSchema};
@@ -110,6 +110,7 @@ impl Modify for SecurityAddon {
         crate::routes::agent::list_agents,
         crate::routes::compiler::compiler_status,
         crate::routes::health_graphs::list_accumulators,
+        crate::routes::health_graphs::list_reactors,
         crate::routes::health_graphs::list_graphs,
         crate::routes::health_graphs::get_graph,
     ),
@@ -156,8 +157,10 @@ impl Modify for SecurityAddon {
         GraphTopology,
         GraphTopologyNode,
         GraphTopologyEdge,
+        ReactorStatus,
         ListResponse<AccumulatorStatus>,
         ListResponse<GraphStatus>,
+        ListResponse<ReactorStatus>,
     )),
     modifiers(&SecurityAddon),
     tags(

--- a/crates/cloacina-server/src/routes/health_graphs.rs
+++ b/crates/cloacina-server/src/routes/health_graphs.rs
@@ -31,7 +31,7 @@ use axum::{
 };
 
 use cloacina::computation_graph::registry::KeyContext;
-use cloacina_api_types::{AccumulatorStatus, GraphStatus, ListResponse};
+use cloacina_api_types::{AccumulatorStatus, GraphStatus, ListResponse, ReactorStatus};
 
 use crate::routes::auth::AuthenticatedKey;
 use crate::routes::error::ApiError;
@@ -97,6 +97,56 @@ pub async fn list_accumulators(
 
     // CLOACI-T-0594 / API-03: unified `{items, total}` envelope.
     Json(ListResponse::new(accumulators))
+}
+
+/// GET /v1/health/reactors — list loaded reactors visible to the caller
+/// (CLOACI-T-0742). Reactor-first: includes reactors with no graph bound, which
+/// `list_graphs` omits. Visibility reuses the same tenant gate as graphs.
+#[utoipa::path(
+    get,
+    path = "/v1/health/reactors",
+    tag = "graph-health",
+    responses(
+        (status = 200, description = "Loaded reactors visible to the caller", body = ListResponse<ReactorStatus>),
+        (status = 401, description = "Missing or invalid API key", body = cloacina_api_types::ErrorBody),
+    ),
+    security(("api_key" = []))
+)]
+pub async fn list_reactors(
+    State(state): State<AppState>,
+    Extension(auth): Extension<AuthenticatedKey>,
+) -> impl IntoResponse {
+    let loaded = state.graph_scheduler.list_reactors().await;
+
+    let reactors: Vec<ReactorStatus> = loaded
+        .into_iter()
+        .filter(|r| graph_visible(&auth, r.tenant_id.as_deref()))
+        .map(|r| {
+            let health = r
+                .health
+                .as_ref()
+                .map(|h| serde_json::to_value(h).unwrap_or(serde_json::json!("unknown")))
+                .unwrap_or(
+                    serde_json::json!({"state": if !r.running { "stopped" } else { "running" }}),
+                );
+            ReactorStatus {
+                name: r.name,
+                health,
+                accumulators: r.accumulators,
+                reaction_mode: Some(r.reaction_mode),
+                input_strategy: Some(r.input_strategy),
+                bound_graphs: r.bound_graphs,
+                paused: r.paused,
+                fires: r.fires,
+                last_fired_at: r
+                    .last_fire_unix_ms
+                    .and_then(chrono::DateTime::from_timestamp_millis)
+                    .map(|dt| dt.to_rfc3339()),
+            }
+        })
+        .collect();
+
+    Json(ListResponse::new(reactors))
 }
 
 /// GET /v1/health/graphs — list loaded graphs visible to the caller.

--- a/crates/cloacina/src/computation_graph/accumulator.rs
+++ b/crates/cloacina/src/computation_graph/accumulator.rs
@@ -1672,4 +1672,105 @@ mod tests {
         shutdown_tx.send(true).unwrap();
         handle.await.unwrap();
     }
+
+    // --- State accumulator runtime tests (CLOACI-T-0688) ---
+    //
+    // These exercise the RUNTIME wiring that `@cloaca.state_accumulator(capacity=N)`
+    // (and `StateAccumulatorFactory`) drive: values pushed over the socket are
+    // appended to a bounded `VecDeque`, oldest entries are evicted past capacity,
+    // and the full bounded history is emitted back as the boundary on every write.
+    // The boundary wire-type is `Vec<T>` (see `state_accumulator_runtime`), so we
+    // decode boundaries as `Vec<serde_json::Value>` to mirror the
+    // `serde_json::Value` instantiation used by `StateAccumulatorFactory`.
+
+    /// Build a minimal socket-driven AccumulatorContext (no DAL/checkpoint, no
+    /// health) mirroring the embedded/test wiring used by the other runtime tests.
+    fn make_state_ctx(
+        name: &str,
+    ) -> (
+        AccumulatorContext,
+        mpsc::Receiver<(SourceName, Vec<u8>)>,
+        watch::Sender<bool>,
+    ) {
+        let (boundary_tx, boundary_rx) = mpsc::channel(32);
+        let (shutdown_tx, shutdown_rx) = shutdown_signal();
+        let ctx = AccumulatorContext {
+            output: BoundarySender::new(boundary_tx, SourceName::new(name)),
+            name: name.to_string(),
+            shutdown: shutdown_rx,
+            checkpoint: None,
+            health: None,
+        };
+        (ctx, boundary_rx, shutdown_tx)
+    }
+
+    /// Drive `state_accumulator_runtime::<serde_json::Value>` over the socket and
+    /// assert that a bounded capacity evicts the oldest entries and emits the
+    /// retained history (newest `capacity` values) as each boundary.
+    #[tokio::test]
+    async fn test_state_accumulator_runtime_bounded_evicts_and_emits_history() {
+        let capacity = 2;
+        let (socket_tx, socket_rx) = mpsc::channel::<Vec<u8>>(32);
+        let (ctx, mut boundary_rx, shutdown_tx) = make_state_ctx("state_bounded");
+        let acc = StateAccumulator::<serde_json::Value>::new(capacity);
+        let handle = tokio::spawn(state_accumulator_runtime(acc, ctx, socket_rx));
+
+        // Feed 3 values (> capacity 2): 1, 2, 3.
+        for v in [1_i64, 2, 3] {
+            socket_tx
+                .send(serde_json::to_vec(&serde_json::json!(v)).unwrap())
+                .await
+                .unwrap();
+        }
+
+        // Expect 3 boundaries, each the bounded history after that write:
+        //   after 1 -> [1]
+        //   after 2 -> [1, 2]
+        //   after 3 -> [2, 3]   (oldest "1" evicted)
+        let expected: Vec<Vec<i64>> = vec![vec![1], vec![1, 2], vec![2, 3]];
+        for exp in expected {
+            let (name, bytes) =
+                tokio::time::timeout(std::time::Duration::from_secs(2), boundary_rx.recv())
+                    .await
+                    .expect("boundary should arrive within 2s")
+                    .expect("boundary channel open");
+            assert_eq!(name, SourceName::new("state_bounded"));
+            let list: Vec<i64> = types::deserialize(&bytes).unwrap();
+            assert_eq!(
+                list, exp,
+                "bounded history mismatch (capacity={})",
+                capacity
+            );
+        }
+
+        shutdown_tx.send(true).unwrap();
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(2), handle).await;
+    }
+
+    /// `capacity == 0` is a write-only sink: values are buffered but NO boundary
+    /// is emitted back to the reactor.
+    #[tokio::test]
+    async fn test_state_accumulator_runtime_write_only_emits_nothing() {
+        let (socket_tx, socket_rx) = mpsc::channel::<Vec<u8>>(32);
+        let (ctx, mut boundary_rx, shutdown_tx) = make_state_ctx("state_write_only");
+        let acc = StateAccumulator::<serde_json::Value>::new(0);
+        let handle = tokio::spawn(state_accumulator_runtime(acc, ctx, socket_rx));
+
+        for v in [10_i64, 20, 30] {
+            socket_tx
+                .send(serde_json::to_vec(&serde_json::json!(v)).unwrap())
+                .await
+                .unwrap();
+        }
+
+        // Give the runtime time to process; assert no boundary was emitted.
+        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+        assert!(
+            boundary_rx.try_recv().is_err(),
+            "write-only (capacity==0) state accumulator must not emit a boundary"
+        );
+
+        shutdown_tx.send(true).unwrap();
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(2), handle).await;
+    }
 }

--- a/crates/cloacina/src/computation_graph/packaging_bridge.rs
+++ b/crates/cloacina/src/computation_graph/packaging_bridge.rs
@@ -28,8 +28,8 @@ use tokio::task::JoinHandle;
 use cloacina_workflow_plugin::{GraphExecutionRequest, GraphPackageMetadata};
 
 use super::accumulator::{
-    accumulator_runtime, accumulator_runtime_with_source, AccumulatorContext,
-    AccumulatorRuntimeConfig, BoundarySender,
+    accumulator_runtime, accumulator_runtime_with_source, state_accumulator_runtime,
+    AccumulatorContext, AccumulatorRuntimeConfig, BoundarySender, StateAccumulator,
 };
 use super::reactor::{CompiledGraphFn, InputStrategy, ReactionCriteria};
 use super::scheduler::{
@@ -206,6 +206,9 @@ pub fn build_declaration_from_ffi(
                 "stream" => Arc::new(StreamBackendAccumulatorFactory::new(
                     acc_entry.config.clone(),
                 )),
+                "state" => Arc::new(StateAccumulatorFactory::new(state_capacity_from_config(
+                    &acc_entry.config,
+                ))),
                 _ => Arc::new(PassthroughAccumulatorFactory),
             };
             AccumulatorDeclaration {
@@ -540,6 +543,68 @@ impl AccumulatorFactory for StreamBackendAccumulatorFactory {
     }
 }
 
+/// A state-backed accumulator factory for FFI-loaded / Python packages.
+///
+/// Spawns `state_accumulator_runtime::<serde_json::Value>` with a bounded
+/// `VecDeque` of the given capacity. This is the host-side wiring for
+/// `@cloaca.state_accumulator(capacity=N)` (and Rust's
+/// `#[state_accumulator(capacity=…)]`): values pushed over the socket are
+/// buffered, persisted to the DAL on every write, and the full list is emitted
+/// back as the boundary so the graph can feed its own state on the next fire.
+///
+/// Capacity semantics (see `StateAccumulator`):
+/// - `> 0`: bounded — evicts oldest when at capacity
+/// - `< 0`: unbounded — grows without limit
+/// - `0`:  write-only sink — no history emitted back
+pub struct StateAccumulatorFactory {
+    capacity: i32,
+}
+
+impl StateAccumulatorFactory {
+    pub fn new(capacity: i32) -> Self {
+        Self { capacity }
+    }
+}
+
+impl AccumulatorFactory for StateAccumulatorFactory {
+    fn spawn(
+        &self,
+        name: String,
+        boundary_tx: mpsc::Sender<(SourceName, Vec<u8>)>,
+        shutdown_rx: watch::Receiver<bool>,
+        config: AccumulatorSpawnConfig,
+    ) -> (mpsc::Sender<Vec<u8>>, JoinHandle<()>) {
+        let (socket_tx, socket_rx) = mpsc::channel(1024);
+
+        let checkpoint = config.dal.map(|dal| {
+            super::accumulator::CheckpointHandle::new(dal, config.graph_name.clone(), name.clone())
+        });
+
+        let sender = BoundarySender::new(boundary_tx, SourceName::new(&name));
+        let ctx = AccumulatorContext {
+            output: sender,
+            name: name.clone(),
+            shutdown: shutdown_rx,
+            checkpoint,
+            health: config.health_tx,
+        };
+
+        let acc = StateAccumulator::<serde_json::Value>::new(self.capacity);
+        let handle = tokio::spawn(state_accumulator_runtime(acc, ctx, socket_rx));
+
+        (socket_tx, handle)
+    }
+}
+
+/// Parse a state accumulator's capacity from its String-keyed config map.
+/// Defaults to `0` (write-only sink) when absent or unparsable.
+fn state_capacity_from_config(config: &std::collections::HashMap<String, String>) -> i32 {
+    config
+        .get("capacity")
+        .and_then(|c| c.parse::<i32>().ok())
+        .unwrap_or(0)
+}
+
 // ---------------------------------------------------------------------------
 // T-0545 M3a: dispatch reactors registered in a Runtime into a scheduler
 // ---------------------------------------------------------------------------
@@ -582,6 +647,9 @@ pub async fn dispatch_runtime_reactors_into_scheduler(
                     Some(override_cfg) => match override_cfg.accumulator_type.as_str() {
                         "stream" => Arc::new(StreamBackendAccumulatorFactory::new(
                             override_cfg.config.clone(),
+                        )),
+                        "state" => Arc::new(StateAccumulatorFactory::new(
+                            state_capacity_from_config(&override_cfg.config),
                         )),
                         _ => Arc::new(PassthroughAccumulatorFactory),
                     },
@@ -649,12 +717,18 @@ pub async fn dispatch_package_reactors_into_scheduler(
                         "stream" => Arc::new(StreamBackendAccumulatorFactory::new(
                             override_cfg.config.clone(),
                         )),
+                        "state" => Arc::new(StateAccumulatorFactory::new(
+                            state_capacity_from_config(&override_cfg.config),
+                        )),
                         _ => Arc::new(PassthroughAccumulatorFactory),
                     },
                     None => match acc.accumulator_type.as_str() {
                         "stream" => {
                             Arc::new(StreamBackendAccumulatorFactory::new(acc.config.clone()))
                         }
+                        "state" => Arc::new(StateAccumulatorFactory::new(
+                            state_capacity_from_config(&acc.config),
+                        )),
                         _ => Arc::new(PassthroughAccumulatorFactory),
                     },
                 };

--- a/crates/cloacina/src/computation_graph/scheduler.rs
+++ b/crates/cloacina/src/computation_graph/scheduler.rs
@@ -137,6 +137,35 @@ pub struct GraphStatus {
     pub last_fire_unix_ms: Option<i64>,
 }
 
+/// Status of a managed reactor (CLOACI-T-0742). Reactors are first-class: a
+/// reactor is loaded (`load_reactor`) and graphs bind to it afterward
+/// (`bind_graph_to_reactor`), so a reactor can be running with **no graph
+/// bound**. `list_graphs` is graph-first and would omit such a reactor; this is
+/// reactor-first, sourced directly from the `reactors` map.
+#[derive(Debug, Clone)]
+pub struct ReactorStatus {
+    /// Reactor name (the `reactors` map key).
+    pub name: String,
+    /// Accumulators this reactor consumes, in declaration order.
+    pub accumulators: Vec<String>,
+    /// Firing criteria: `"when_any"` | `"when_all"`.
+    pub reaction_mode: String,
+    /// Input strategy: `"latest"` | `"sequential"`.
+    pub input_strategy: String,
+    /// Graphs bound to this reactor (empty if the reactor has no graph yet).
+    pub bound_graphs: Vec<String>,
+    pub paused: bool,
+    pub running: bool,
+    /// Reactor health state machine value. None if health tracking isn't configured.
+    pub health: Option<super::reactor::ReactorHealth>,
+    /// Tenant scope at load time. `None` for single-tenant / admin-owned reactors.
+    pub tenant_id: Option<String>,
+    /// Total fires since load (live reactor counter, WS-10).
+    pub fires: u64,
+    /// Unix-epoch millis of the last fire; `None` if it hasn't fired yet.
+    pub last_fire_unix_ms: Option<i64>,
+}
+
 /// Validate that two declarations targeting the same reactor name agree on
 /// the reactor's contract. Mismatches are operator-facing errors, not silent
 /// no-ops — the second package may have shipped with a different
@@ -932,6 +961,52 @@ impl ComputationGraphScheduler {
                     fires: running.reactor_shared.stats().0,
                     last_fire_unix_ms: running.reactor_shared.stats().1,
                 })
+            })
+            .collect()
+    }
+
+    /// List all loaded reactors with status (CLOACI-T-0742). Reactor-first: one
+    /// entry per reactor in the `reactors` map, **including reactors with no
+    /// graph bound** (which `list_graphs` omits, since it iterates
+    /// `graph_to_reactor`). `bound_graphs` is the reverse lookup over that map.
+    pub async fn list_reactors(&self) -> Vec<ReactorStatus> {
+        let reactors = self.reactors.read().await;
+        let g2r = self.graph_to_reactor.read().await;
+        reactors
+            .iter()
+            .map(|(reactor_name, running)| {
+                let bound_graphs: Vec<String> = g2r
+                    .iter()
+                    .filter(|(_, r)| *r == reactor_name)
+                    .map(|(g, _)| g.clone())
+                    .collect();
+                let (fires, last_fire_unix_ms) = running.reactor_shared.stats();
+                ReactorStatus {
+                    name: reactor_name.clone(),
+                    accumulators: running
+                        .accumulator_handles
+                        .iter()
+                        .map(|(n, _)| n.clone())
+                        .collect(),
+                    reaction_mode: match running.declaration.reactor.criteria {
+                        ReactionCriteria::WhenAny => "when_any".to_string(),
+                        ReactionCriteria::WhenAll => "when_all".to_string(),
+                    },
+                    input_strategy: match running.declaration.reactor.strategy {
+                        InputStrategy::Latest => "latest".to_string(),
+                        InputStrategy::Sequential => "sequential".to_string(),
+                    },
+                    bound_graphs,
+                    paused: running.reactor_shared.is_paused(),
+                    running: !running.reactor_handle.is_finished(),
+                    health: running
+                        .reactor_health_rx
+                        .as_ref()
+                        .map(|rx| rx.borrow().clone()),
+                    tenant_id: running.declaration.tenant_id.clone(),
+                    fires,
+                    last_fire_unix_ms,
+                }
             })
             .collect()
     }

--- a/crates/cloacina/src/database/connection/mod.rs
+++ b/crates/cloacina/src/database/connection/mod.rs
@@ -82,17 +82,16 @@ use deadpool_diesel::sqlite::{
 /// SQLite connection-pool size, unified across the sqlite-only and
 /// postgres+sqlite builds.
 ///
-/// **CLOACI-T-0741: set back to 1 (serialize).** CLOACI-T-0622 had bumped this
-/// to 4, but a multi-connection sqlite pool under WAL is the source of the
-/// chronic integration flake — both `database is locked` errors (concurrent
-/// writers) and 180s hangs (WAL/lock contention). SQLite is single-writer; a
-/// pool of 1 serialises access and removes the contention entirely. The
-/// original reason T-0622 left 1 ("looked like a deadlock" on macOS CI) was an
-/// *unbounded* wait on a reentrant/contended checkout — now bounded by
-/// `POOL_WAIT_TIMEOUT`, so a true reentrant checkout surfaces as a fast error
-/// instead of an infinite hang rather than forcing us onto a contended pool.
+/// Must be > 1: the engine holds multiple sqlite connections concurrently
+/// (scheduler loop + executor + heartbeat), so a pool of 1 deadlocks/times-out
+/// the executor. CLOACI-T-0741 tried pool=1 to kill the multi-connection
+/// contention flake (`database is locked` + WAL-lock hangs) and it
+/// **deterministically broke 27 executor integration tests** — serializing is
+/// not an option here. Kept at 4 (CLOACI-T-0622); the flake must be addressed
+/// another way (WAL/checkpoint tuning, connection-scope discipline, or the
+/// retry-on-timeout mitigation) — see [[CLOACI-T-0741]].
 #[cfg(feature = "sqlite")]
-const SQLITE_POOL_SIZE: usize = 1;
+const SQLITE_POOL_SIZE: usize = 4;
 
 /// Bounded wait for a pool connection. Without it, an exhausted or contended
 /// pool (especially the small SQLite pool) waits *indefinitely* for a

--- a/crates/cloacina/src/database/connection/mod.rs
+++ b/crates/cloacina/src/database/connection/mod.rs
@@ -80,16 +80,19 @@ use deadpool_diesel::sqlite::{
 };
 
 /// SQLite connection-pool size, unified across the sqlite-only and
-/// postgres+sqlite builds (CLOACI-T-0649 follow-up).
+/// postgres+sqlite builds.
 ///
-/// CLOACI-T-0622 bumped the postgres+sqlite path from 1 → 4 to clear macOS-CI
-/// contention that "looked like a deadlock", but the sqlite-only path was left
-/// at 1 and kept hitting the same hang (the flaky `task_callbacks` sqlite
-/// integration timeout). Both paths now share this constant so they can't drift
-/// again. Safe with the `:memory:`-as-tempfile materialisation + WAL +
-/// `busy_timeout=30000` applied on every checkout.
+/// **CLOACI-T-0741: set back to 1 (serialize).** CLOACI-T-0622 had bumped this
+/// to 4, but a multi-connection sqlite pool under WAL is the source of the
+/// chronic integration flake — both `database is locked` errors (concurrent
+/// writers) and 180s hangs (WAL/lock contention). SQLite is single-writer; a
+/// pool of 1 serialises access and removes the contention entirely. The
+/// original reason T-0622 left 1 ("looked like a deadlock" on macOS CI) was an
+/// *unbounded* wait on a reentrant/contended checkout — now bounded by
+/// `POOL_WAIT_TIMEOUT`, so a true reentrant checkout surfaces as a fast error
+/// instead of an infinite hang rather than forcing us onto a contended pool.
 #[cfg(feature = "sqlite")]
-const SQLITE_POOL_SIZE: usize = 4;
+const SQLITE_POOL_SIZE: usize = 1;
 
 /// Bounded wait for a pool connection. Without it, an exhausted or contended
 /// pool (especially the small SQLite pool) waits *indefinitely* for a

--- a/crates/cloacina/src/registry/reconciler/loading.rs
+++ b/crates/cloacina/src/registry/reconciler/loading.rs
@@ -2221,6 +2221,200 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
+    // CLOACI-T-0688: cron-trigger reconciler-path (Rust↔Python parity).
+    //
+    // `@cloaca.trigger(on=, cron=)` produces a runtime `Trigger` whose
+    // `cron_expression()`/`workflow_name()` are overridden (see
+    // `PythonTriggerWrapper`). These tests drive the host-side path that
+    // consumes that: `build_view_python` must emit a `TriggerPackageMetadata`
+    // carrying `cron_expression: Some(...)` + the `workflow_name` binding, and
+    // `step_load_cron_triggers` must select only cron-bearing triggers and
+    // register them against their TARGET workflow.
+    // -----------------------------------------------------------------------
+
+    /// A minimal cron-shaped `Trigger` impl mirroring what `PythonTriggerWrapper`
+    /// presents to the reconciler: a name distinct from its target workflow, an
+    /// overridden `cron_expression()`, and an overridden `workflow_name()`.
+    #[derive(Debug)]
+    struct MockCronTrigger {
+        name: String,
+        workflow: String,
+        cron: String,
+    }
+
+    #[async_trait::async_trait]
+    impl cloacina_workflow::Trigger for MockCronTrigger {
+        fn name(&self) -> &str {
+            &self.name
+        }
+        fn poll_interval(&self) -> std::time::Duration {
+            // Ignored for cron triggers; reconciler routes by cron_expression().
+            std::time::Duration::from_secs(60)
+        }
+        fn allow_concurrent(&self) -> bool {
+            false
+        }
+        async fn poll(
+            &self,
+        ) -> Result<cloacina_workflow::TriggerResult, cloacina_workflow::TriggerError> {
+            Ok(cloacina_workflow::TriggerResult::Skip)
+        }
+        fn cron_expression(&self) -> Option<String> {
+            Some(self.cron.clone())
+        }
+        fn workflow_name(&self) -> &str {
+            &self.workflow
+        }
+    }
+
+    /// A custom-poll trigger (no cron expression) — exercises the `None` branch
+    /// so we can assert `step_load_cron_triggers` ignores it.
+    #[derive(Debug)]
+    struct MockPollTrigger {
+        name: String,
+    }
+
+    #[async_trait::async_trait]
+    impl cloacina_workflow::Trigger for MockPollTrigger {
+        fn name(&self) -> &str {
+            &self.name
+        }
+        fn poll_interval(&self) -> std::time::Duration {
+            std::time::Duration::from_secs(30)
+        }
+        fn allow_concurrent(&self) -> bool {
+            true
+        }
+        async fn poll(
+            &self,
+        ) -> Result<cloacina_workflow::TriggerResult, cloacina_workflow::TriggerError> {
+            Ok(cloacina_workflow::TriggerResult::Skip)
+        }
+        // cron_expression() / workflow_name() default (None / "").
+    }
+
+    /// In-memory cron registrar that records every `register_cron_workflow`
+    /// call so tests can assert what the reconciler routed to the cron path —
+    /// no DB required.
+    #[derive(Default)]
+    struct RecordingCronRegistrar {
+        calls: std::sync::Mutex<Vec<(String, String, String)>>,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::registry::reconciler::CronWorkflowRegistrar for RecordingCronRegistrar {
+        async fn register_cron_workflow(
+            &self,
+            workflow_name: &str,
+            cron_expression: &str,
+            timezone: &str,
+        ) -> Result<String, String> {
+            let mut calls = self.calls.lock().unwrap();
+            calls.push((
+                workflow_name.to_string(),
+                cron_expression.to_string(),
+                timezone.to_string(),
+            ));
+            Ok(format!("schedule-{}", calls.len()))
+        }
+        async fn unregister_cron_workflow(&self, _schedule_id: &str) -> Result<(), String> {
+            Ok(())
+        }
+        // register_poll_trigger uses the trait default (errors loudly); the
+        // cron path under test never calls it.
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn build_view_python_emits_cron_metadata_for_runtime_trigger() {
+        let reconciler = make_test_reconciler();
+        let runtime = runtime_of(&reconciler);
+        runtime.register_trigger("nightly_cron".to_string(), || {
+            Arc::new(MockCronTrigger {
+                name: "nightly_cron".to_string(),
+                workflow: "etl_workflow".to_string(),
+                cron: "0 0 * * *".to_string(),
+            })
+        });
+
+        let (pre_r, pre_t, pre_g) = empty_pre_snapshots();
+        let view = reconciler.build_view_python("cron-pkg", &pre_r, &pre_t, &pre_g, &[]);
+
+        assert_eq!(view.triggers.len(), 1, "one runtime trigger expected");
+        let t = &view.triggers[0];
+        assert_eq!(t.name, "nightly_cron");
+        assert_eq!(t.package_name, "cron-pkg");
+        // The two new RUNTIME-wired fields: cron expression + workflow binding.
+        assert_eq!(
+            t.cron_expression.as_deref(),
+            Some("0 0 * * *"),
+            "build_view_python must carry the runtime trigger's cron_expression()"
+        );
+        assert_eq!(
+            t.workflow_name, "etl_workflow",
+            "build_view_python must carry the runtime trigger's workflow_name() binding"
+        );
+        assert!(!t.allow_concurrent);
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn step_load_cron_triggers_selects_cron_bearing_triggers() {
+        let registrar = Arc::new(RecordingCronRegistrar::default());
+        let reconciler = make_test_reconciler().with_cron_registrar(registrar.clone());
+        let runtime = runtime_of(&reconciler);
+
+        // One cron trigger (should be registered) + one custom-poll trigger
+        // (cron_expression() == None, must be ignored by the cron step).
+        runtime.register_trigger("nightly_cron".to_string(), || {
+            Arc::new(MockCronTrigger {
+                name: "nightly_cron".to_string(),
+                workflow: "etl_workflow".to_string(),
+                cron: "0 0 * * *".to_string(),
+            })
+        });
+        runtime.register_trigger("file_watch".to_string(), || {
+            Arc::new(MockPollTrigger {
+                name: "file_watch".to_string(),
+            })
+        });
+
+        let (pre_r, pre_t, pre_g) = empty_pre_snapshots();
+        let view = reconciler.build_view_python("cron-pkg", &pre_r, &pre_t, &pre_g, &[]);
+        assert_eq!(
+            view.triggers.len(),
+            2,
+            "both triggers should be in the view"
+        );
+
+        let metadata = make_test_metadata();
+        let ids = reconciler
+            .step_load_cron_triggers(&metadata, &view)
+            .await
+            .expect("step_load_cron_triggers should succeed");
+
+        // Exactly one cron schedule registered (the custom-poll one is skipped).
+        assert_eq!(
+            ids.len(),
+            1,
+            "only the cron-bearing trigger should register"
+        );
+
+        let calls = registrar.calls.lock().unwrap();
+        assert_eq!(calls.len(), 1);
+        // Registered against the TARGET workflow (workflow_name), not the
+        // trigger's own name — and carrying the cron expression + UTC tz.
+        assert_eq!(
+            calls[0],
+            (
+                "etl_workflow".to_string(),
+                "0 0 * * *".to_string(),
+                "UTC".to_string()
+            )
+        );
+    }
+
+    // -----------------------------------------------------------------------
     // T-0554 Phase 2 + T-0553 deferred AC: cross-package contract validation
     // and reverse-order unload pipeline e2e (in-crate scaffolding).
     // -----------------------------------------------------------------------

--- a/docker/docker-compose.demo.yml
+++ b/docker/docker-compose.demo.yml
@@ -203,10 +203,12 @@ services:
       HARNESS_KAFKA_BROKER: "kafka:9092"
       HARNESS_KAFKA_TOPIC: "demo.kafka.stream"
       HARNESS_PRODUCE_INTERVAL_MS: "2000"
-      # Socket accumulators in the compose demo: mixed_graph's `alpha` and
-      # demo_py_graph's `py_alpha`. Fed over WS so those graphs fire too
-      # (demo_kafka_graph's kafka_alpha is fed via Kafka above).
-      HARNESS_WS_ACCUMULATORS: "alpha,py_alpha"
+      # Socket accumulators in the compose demo: mixed_graph's `alpha`,
+      # demo_py_graph's `py_alpha`, and demo_py_state's `py_window` (the Python
+      # state accumulator's bounded rolling window — CLOACI-T-0688). Fed over WS
+      # so those graphs fire too (demo_kafka_graph's kafka_alpha is fed via
+      # Kafka above).
+      HARNESS_WS_ACCUMULATORS: "alpha,py_alpha,py_window"
     depends_on:
       server:
         condition: service_started

--- a/docker/pack-demo-fixtures.sh
+++ b/docker/pack-demo-fixtures.sh
@@ -98,5 +98,12 @@ pack_rust_ws demo-pipeline-rust
 pack_python demo-py-workflow "$WS/examples/fixtures/demo-py-workflow" 0.1.0
 pack_python demo-py-graph "$WS/examples/fixtures/demo-py-graph" 0.1.0
 
+# --- Python parity (CLOACI-T-0688): a state accumulator (bounded rolling
+#     window) feeding a reactor-bound CG, and a cron-triggered task workflow.
+#     These exercise the two Python authoring surfaces closed in T-0688
+#     (@cloaca.state_accumulator + packaged cron @cloaca.trigger). ---
+pack_python demo-py-state "$WS/examples/fixtures/demo-py-state" 0.1.0
+pack_python demo-py-cron "$WS/examples/fixtures/demo-py-cron" 0.1.0
+
 echo "demo fixtures packed to ${OUT}:"
 ls -la "$OUT"

--- a/docs/static/openapi.json
+++ b/docs/static/openapi.json
@@ -511,6 +511,42 @@
         ]
       }
     },
+    "/v1/health/reactors": {
+      "get": {
+        "tags": [
+          "graph-health"
+        ],
+        "summary": "GET /v1/health/reactors — list loaded reactors visible to the caller\n(CLOACI-T-0742). Reactor-first: includes reactors with no graph bound, which\n`list_graphs` omits. Visibility reuses the same tenant gate as graphs.",
+        "operationId": "list_reactors",
+        "responses": {
+          "200": {
+            "description": "Loaded reactors visible to the caller",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListResponse_ReactorStatus"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      }
+    },
     "/v1/tenants": {
       "get": {
         "tags": [
@@ -2636,6 +2672,86 @@
           }
         }
       },
+      "ListResponse_ReactorStatus": {
+        "type": "object",
+        "description": "Unified list envelope (CLOACI-T-0594 / API-03): every list endpoint\nreturns `{items, total}`. `total` is best-effort — it equals the\nreturned page size when the server doesn't run a separate COUNT.",
+        "required": [
+          "items",
+          "total"
+        ],
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "description": "One row in `GET /v1/health/reactors` (CLOACI-T-0742). Reactor-first view:\nreactors are standalone (a graph binds to a reactor, not vice versa), so a\nreactor with no graph bound appears here but not in `GET /v1/health/graphs`.",
+              "required": [
+                "name",
+                "health",
+                "accumulators",
+                "paused"
+              ],
+              "properties": {
+                "accumulators": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "Accumulators this reactor consumes (its inputs)."
+                },
+                "bound_graphs": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "Graphs bound to this reactor; empty when the reactor has no graph yet."
+                },
+                "fires": {
+                  "type": "integer",
+                  "format": "int64",
+                  "description": "Total fires since load (the reactor's live fire counter, WS-10).",
+                  "minimum": 0
+                },
+                "health": {
+                  "description": "Reactor health snapshot; `{\"state\": \"running\" | \"stopped\"}` when no\ndetailed health is available. Free-form JSON, mirroring `GraphStatus`."
+                },
+                "input_strategy": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "description": "Input strategy: `\"latest\"` | `\"sequential\"`."
+                },
+                "last_fired_at": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "description": "RFC 3339 timestamp of the last fire; `null` if it hasn't fired yet."
+                },
+                "name": {
+                  "type": "string"
+                },
+                "paused": {
+                  "type": "boolean",
+                  "description": "Pause state of the reactor."
+                },
+                "reaction_mode": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "description": "Firing criteria: `\"when_any\"` | `\"when_all\"`."
+                }
+              }
+            }
+          },
+          "total": {
+            "type": "integer",
+            "minimum": 0
+          }
+        }
+      },
       "ListResponse_TenantSummary": {
         "type": "object",
         "description": "Unified list envelope (CLOACI-T-0594 / API-03): every list endpoint\nreturns `{items, total}`. `total` is best-effort — it equals the\nreturned page size when the server doesn't run a separate COUNT.",
@@ -2677,6 +2793,69 @@
             "format": "binary",
             "description": "The `.cloacina` package archive.",
             "contentMediaType": "application/octet-stream"
+          }
+        }
+      },
+      "ReactorStatus": {
+        "type": "object",
+        "description": "One row in `GET /v1/health/reactors` (CLOACI-T-0742). Reactor-first view:\nreactors are standalone (a graph binds to a reactor, not vice versa), so a\nreactor with no graph bound appears here but not in `GET /v1/health/graphs`.",
+        "required": [
+          "name",
+          "health",
+          "accumulators",
+          "paused"
+        ],
+        "properties": {
+          "accumulators": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Accumulators this reactor consumes (its inputs)."
+          },
+          "bound_graphs": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Graphs bound to this reactor; empty when the reactor has no graph yet."
+          },
+          "fires": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Total fires since load (the reactor's live fire counter, WS-10).",
+            "minimum": 0
+          },
+          "health": {
+            "description": "Reactor health snapshot; `{\"state\": \"running\" | \"stopped\"}` when no\ndetailed health is available. Free-form JSON, mirroring `GraphStatus`."
+          },
+          "input_strategy": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Input strategy: `\"latest\"` | `\"sequential\"`."
+          },
+          "last_fired_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "RFC 3339 timestamp of the last fire; `null` if it hasn't fired yet."
+          },
+          "name": {
+            "type": "string"
+          },
+          "paused": {
+            "type": "boolean",
+            "description": "Pause state of the reactor."
+          },
+          "reaction_mode": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Firing criteria: `\"when_any\"` | `\"when_all\"`."
           }
         }
       },

--- a/examples/fixtures/demo-py-cron/package.toml
+++ b/examples/fixtures/demo-py-cron/package.toml
@@ -1,0 +1,22 @@
+# Demo Python cron-trigger fixture (CLOACI-T-0688). A pure-Python task workflow
+# plus a cron @cloaca.trigger that fires it on a schedule, so the UI's Triggers
+# view shows a Python-authored schedule and executions auto-appear. This is the
+# Python mirror of demo-cron-rust and exercises the Rust↔Python parity surface
+# closed in T-0688 (Python @cloaca.trigger was poll-only — no cron/timezone).
+#
+# Self-contained: the trigger's `on` names the workflow in this same package.
+# There is NO triggers section in package.toml — the @cloaca.trigger decorator
+# running at import (entry_module) IS the declaration.
+[package]
+name = "demo-py-cron"
+version = "0.1.0"
+interface = "cloacina-workflow-plugin"
+interface_version = 1
+extension = "cloacina"
+
+[metadata]
+workflow_name = "demo_py_cron_workflow"
+language = "python"
+description = "demo python cron workflow — fires on a schedule"
+author = "cloacina-ui-demo"
+entry_module = "demo_py_cron.tasks"

--- a/examples/fixtures/demo-py-cron/workflow/demo_py_cron/tasks.py
+++ b/examples/fixtures/demo-py-cron/workflow/demo_py_cron/tasks.py
@@ -1,0 +1,34 @@
+"""Demo Python cron-trigger workflow (CLOACI-T-0688).
+
+Showcases the Python packaged cron-trigger authoring surface closed in T-0688:
+`@cloaca.trigger(on=…, cron=…)` mirrors Rust's `#[trigger(on=…, cron=…)]`.
+Python `@cloaca.trigger` was previously poll-only (no cron/timezone params), so
+cron scheduling could only be driven via the runner-level API — never authored
+into a package. This fixture is the Python mirror of `demo-cron-rust`.
+
+The reconciler imports `entry_module` (this file) at load time; the
+`@cloaca.task` decorators assemble the workflow named in package.toml
+(`demo_py_cron_workflow`), and the `@cloaca.trigger(cron=…)` registers a cron
+schedule for that workflow — no `triggers` section in package.toml, the
+decorator is the declaration.
+"""
+from __future__ import annotations
+
+import cloaca
+
+
+@cloaca.task(dependencies=[])
+def py_cron_step(context):
+    # A trivial step so each scheduled fire produces a visible execution in the
+    # UI's Executions view (mirrors demo-cron-rust's single-task workflow).
+    context.set("demo_py_cron_ran", True)
+    return context
+
+
+# Fire `demo_py_cron_workflow` every 15 seconds — frequent enough to watch the
+# Triggers view tick and executions auto-appear. The cron function body is
+# unused for cron triggers (the cron scheduler fires the `on` workflow directly);
+# `cron` and `poll_interval` are mutually exclusive, and `on` is required for cron.
+@cloaca.trigger(on="demo_py_cron_workflow", cron="*/15 * * * * *")
+def demo_py_cron_trigger():
+    pass

--- a/examples/fixtures/demo-py-state/package.toml
+++ b/examples/fixtures/demo-py-state/package.toml
@@ -1,0 +1,21 @@
+# Demo Python state-accumulator fixture (CLOACI-T-0688). A *state* accumulator
+# (@cloaca.state_accumulator(capacity=N)) + reactor + computation graph defined
+# in Python, so the UI's Accumulators + Graphs views show the Python state
+# accumulator's bounded rolling window. This exercises the Rust↔Python parity
+# surface closed in T-0688 (Python had no state accumulator before). The module
+# tree MUST live under workflow/ — the reconciler's Python CG extraction
+# requires it (a top-level module fails with "Missing workflow source directory").
+[package]
+name = "demo-py-state"
+version = "0.1.0"
+interface = "cloacina-workflow-plugin"
+interface_version = 1
+extension = "cloacina"
+
+[metadata]
+graph_name = "demo_py_state"
+language = "python"
+description = "demo python state accumulator — bounded rolling window over a market feed"
+entry_module = "demo_py_state.graph"
+reaction_mode = "when_any"
+input_strategy = "latest"

--- a/examples/fixtures/demo-py-state/workflow/demo_py_state/graph.py
+++ b/examples/fixtures/demo-py-state/workflow/demo_py_state/graph.py
@@ -1,0 +1,64 @@
+"""Demo Python state-accumulator computation graph (CLOACI-T-0688).
+
+Showcases the Python `@cloaca.state_accumulator(capacity=N)` authoring surface
+closed in T-0688 (Python previously had only passthrough/stream/polling/batch
+accumulators — no state accumulator, which is the bounded-history primitive).
+
+`py_window` is a *state* accumulator with `capacity=5`: every event pushed over
+the socket is appended to a bounded `VecDeque`; once full, the oldest entry is
+evicted, and the **full retained window** (newest ≤5 events) is emitted back as
+the boundary on every write. The reactor fires the graph on each write; the
+entry node receives the whole window (a list), not a single event — that rolling
+window is the visible difference from `demo_py_graph`'s passthrough accumulator.
+
+Fed by the demo `producer` over WS (HARNESS_WS_ACCUMULATORS includes `py_window`),
+so the Accumulators + Graphs views show live activity.
+"""
+import cloaca
+
+
+@cloaca.state_accumulator(capacity=5)
+def py_window(event):
+    # State accumulators buffer the returned value; the runtime emits the full
+    # bounded window back as the boundary. Pass the market event through as-is.
+    return event
+
+
+@cloaca.reactor(name="demo_py_state_rx", accumulators=["py_window"], mode="when_any")
+class _DemoStateReactor:
+    pass
+
+
+with cloaca.ComputationGraphBuilder(
+    "demo_py_state",
+    reactor=_DemoStateReactor,
+    graph={
+        # Entry node consumes the accumulator's emitted window (a list), then a
+        # linear edge to a terminal reporter — a minimal but real 2-node CG.
+        "window": {"inputs": ["py_window"], "next": "report"},
+        "report": {},
+    },
+) as builder:
+
+    @cloaca.node
+    def window(py_window):
+        # `py_window` is the bounded rolling window (list of ≤5 recent events),
+        # not a single event — that's the state-accumulator behaviour.
+        history = py_window or []
+        bids = [e.get("bid", 0.0) for e in history if isinstance(e, dict)]
+        asks = [e.get("ask", 0.0) for e in history if isinstance(e, dict)]
+        return {
+            "window_size": len(history),
+            "latest": history[-1] if history else None,
+            "avg_bid": (sum(bids) / len(bids)) if bids else 0.0,
+            "avg_ask": (sum(asks) / len(asks)) if asks else 0.0,
+        }
+
+    @cloaca.node
+    def report(window):
+        # `window` is the dict returned by the entry node (linear edge payload).
+        return {
+            "windowed_avg_bid": window.get("avg_bid", 0.0),
+            "windowed_avg_ask": window.get("avg_ask", 0.0),
+            "samples": window.get("window_size", 0),
+        }

--- a/ui/harness/src/produce.mjs
+++ b/ui/harness/src/produce.mjs
@@ -60,6 +60,9 @@ const GENERATORS = {
   pricing: pricingEvent,
   alpha: alphaEvent,
   py_alpha: bidAskEvent,
+  // demo_py_state `py_window`: same {bid, ask} order-book tick — the Python
+  // state accumulator buffers a bounded rolling window of these (CLOACI-T-0688).
+  py_window: bidAskEvent,
 };
 
 /** Socket accumulators to feed over WS, from `cfg.wsAccumulators` (a comma list;

--- a/ui/src/api/health.ts
+++ b/ui/src/api/health.ts
@@ -44,6 +44,19 @@ export function useGraphs() {
   });
 }
 
+/** Reactors visible to the key (CLOACI-T-0742). Reactor-first: includes
+ *  reactors with no graph bound (which the graphs list omits). Polled like
+ *  graphs so fire counters / throughput stay live. */
+export function useReactors() {
+  const client = useClient();
+  const tenant = useTenant();
+  return useQuery({
+    queryKey: queryKeys.reactors(tenant),
+    queryFn: () => client.listReactors(),
+    refetchInterval: 5000,
+  });
+}
+
 export function useGraph(name: string) {
   const client = useClient();
   const tenant = useTenant();

--- a/ui/src/api/hooks.ts
+++ b/ui/src/api/hooks.ts
@@ -48,5 +48,6 @@ export const queryKeys = {
   trigger: (tenant: string, name: string) => ["triggers", tenant, name] as const,
   keys: (tenant: string) => ["keys", tenant] as const,
   accumulators: (tenant: string) => ["accumulators", tenant] as const,
+  reactors: (tenant: string) => ["reactors", tenant] as const,
   graphs: (tenant: string) => ["graphs", tenant] as const,
 } as const;

--- a/ui/src/routes/Graphs.tsx
+++ b/ui/src/routes/Graphs.tsx
@@ -18,7 +18,7 @@ import { Badge, Card, Group, Stack, Table, Text, Title, Tooltip } from "@mantine
 import { useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 
-import { useAccumulators, useGraphs } from "../api/health";
+import { useAccumulators, useGraphs, useReactors } from "../api/health";
 import { GraphHealth } from "../components/GraphHealth";
 import { Empty, ErrorState, Loading } from "../components/states/States";
 import { explainToken } from "../util/vocab";
@@ -69,17 +69,19 @@ function StateDot({ state }: { state: string }) {
 export function Graphs() {
   const navigate = useNavigate();
   const graphs = useGraphs();
+  const reactors = useReactors();
   const accs = useAccumulators();
 
-  // name → status, so a graph row can show its accumulators' health at a glance.
+  // name → status, so a graph/reactor row can show its accumulators' health at a glance.
   const accStatus = useMemo(() => {
     const m = new Map<string, string>();
     for (const a of accs.data?.items ?? []) m.set(a.name, String(a.status ?? ""));
     return m;
   }, [accs.data]);
 
-  // Recent throughput per graph, derived from the fires counter across polls.
+  // Recent throughput per graph / per reactor, from the fires counter across polls.
   const throughput = useGraphThroughput(graphs.data?.items ?? []);
+  const reactorThroughput = useGraphThroughput(reactors.data?.items ?? []);
 
   return (
     <Stack>
@@ -178,6 +180,138 @@ export function Graphs() {
                     <Text size="sm">{formatAgo(lastFired)}</Text>
                   </Table.Td>
                 </Table.Tr>
+                );
+              })}
+            </Table.Tbody>
+          </Table>
+        )}
+      </Card>
+
+      <Card withBorder padding="lg">
+        <Title order={4} mb="sm">
+          Reactors
+        </Title>
+        <Text size="sm" c="dimmed" mb="sm">
+          Reactors are first-class: a reactor fires when its criteria over its
+          accumulators are met, and graphs bind to it. A reactor with no graph
+          bound still appears here.
+        </Text>
+        {reactors.isPending ? (
+          <Loading label="Loading reactors…" />
+        ) : reactors.isError ? (
+          <ErrorState error={reactors.error} onRetry={reactors.refetch} />
+        ) : reactors.data.items.length === 0 ? (
+          <Empty message="No reactors loaded." />
+        ) : (
+          <Table highlightOnHover>
+            <Table.Thead>
+              <Table.Tr>
+                <Table.Th>Name</Table.Th>
+                <Table.Th>Criteria</Table.Th>
+                <Table.Th>Accumulators</Table.Th>
+                <Table.Th>Bound graph</Table.Th>
+                <Table.Th>Throughput</Table.Th>
+                <Table.Th>Last fired</Table.Th>
+              </Table.Tr>
+            </Table.Thead>
+            <Table.Tbody>
+              {reactors.data.items.map((r) => {
+                const rate = reactorThroughput.get(r.name);
+                const fires = (r as { fires?: number }).fires ?? 0;
+                const lastFired = (r as { last_fired_at?: string | null }).last_fired_at ?? null;
+                const boundGraphs = (r as { bound_graphs?: string[] }).bound_graphs ?? [];
+                const criteria = r.reaction_mode ? explainToken(r.reaction_mode) : null;
+                const firstGraph = boundGraphs[0];
+                return (
+                  <Table.Tr
+                    key={r.name}
+                    style={{ cursor: firstGraph ? "pointer" : "default" }}
+                    onClick={
+                      firstGraph
+                        ? () => navigate(`/graphs/${encodeURIComponent(firstGraph)}`)
+                        : undefined
+                    }
+                  >
+                    <Table.Td style={{ whiteSpace: "nowrap" }}>
+                      <Group gap="xs" wrap="nowrap">
+                        <Text fw={500}>{r.name}</Text>
+                        {r.paused && (
+                          <Badge color="orange" variant="light">
+                            paused
+                          </Badge>
+                        )}
+                      </Group>
+                    </Table.Td>
+                    <Table.Td>
+                      {criteria ? (
+                        <Tooltip label={criteria.tip} disabled={!criteria.tip} withArrow>
+                          <Badge variant="light" color="blue">
+                            {criteria.label}
+                          </Badge>
+                        </Tooltip>
+                      ) : (
+                        <Text size="sm" c="dimmed">
+                          —
+                        </Text>
+                      )}
+                    </Table.Td>
+                    <Table.Td>
+                      {r.accumulators.length === 0 ? (
+                        <Text size="sm" c="dimmed">
+                          —
+                        </Text>
+                      ) : (
+                        <Group gap={6} wrap="nowrap">
+                          {r.accumulators.map((name) => {
+                            const status = accStatus.get(name) ?? "unknown";
+                            return (
+                              <Tooltip
+                                key={name}
+                                label={`${name}: ${explainToken(status).label}`}
+                                withArrow
+                                openDelay={150}
+                              >
+                                <span style={{ display: "inline-flex" }}>
+                                  <StateDot state={status} />
+                                </span>
+                              </Tooltip>
+                            );
+                          })}
+                          <Text size="xs" c="dimmed">
+                            {r.accumulators.length}
+                          </Text>
+                        </Group>
+                      )}
+                    </Table.Td>
+                    <Table.Td>
+                      {boundGraphs.length === 0 ? (
+                        <Tooltip label="This reactor has no graph bound yet." withArrow>
+                          <Text size="sm" c="dimmed">
+                            unbound
+                          </Text>
+                        </Tooltip>
+                      ) : (
+                        <Text size="sm">{boundGraphs.join(", ")}</Text>
+                      )}
+                    </Table.Td>
+                    <Table.Td style={{ whiteSpace: "nowrap" }}>
+                      {rate == null ? (
+                        <Text size="sm" c="dimmed">
+                          —
+                        </Text>
+                      ) : (
+                        <Tooltip
+                          label={`Recent rate. ${fires.toLocaleString()} total fires since load.`}
+                          withArrow
+                        >
+                          <Text size="sm">~{rate}/min</Text>
+                        </Tooltip>
+                      )}
+                    </Table.Td>
+                    <Table.Td style={{ whiteSpace: "nowrap" }}>
+                      <Text size="sm">{formatAgo(lastFired)}</Text>
+                    </Table.Td>
+                  </Table.Tr>
                 );
               })}
             </Table.Tbody>


### PR DESCRIPTION
Closes the Rust↔Python interface parity gaps in CLOACI-T-0688. PyO3 binding
changes only — independent of the fidius-wasm plugin-loading path.

## Part A — `@cloaca.state_accumulator(capacity=N)`
Rust had `#[state_accumulator]`; Python had only passthrough/stream/polling/batch.
- Decorator (mirrors `stream_accumulator`) registers `accumulator_type="state"` + capacity.
- `StateAccumulatorFactory` in `packaging_bridge.rs` spawns
  `state_accumulator_runtime::<Value>(capacity)`, wired into all three
  `accumulator_type` matches. Capacity flows decorator → `config["capacity"]` → factory.

## Part B — cron `@cloaca.trigger(on=…, cron=…, timezone=…)`
Mirrors Rust `#[trigger(on=…, cron=…, timezone=…)]` (validation too: cron XOR
poll_interval; `on` required for cron). Turned out contained to `trigger.rs`:
`build_view_python` already passes `cron_expression()`/`workflow_name()` to the
reconciler, but `PythonTriggerWrapper` returned the trait defaults — now it
carries `on`/`cron` and overrides those methods, so the reconciler's
`step_load_cron_triggers` registers the schedule. Packaged-Python cron authoring
works end-to-end.

## Part C — `TaskHandle.defer_until()`
Decision: **document as an intentional Python convenience** (no Rust equivalent
needed). Doc caveat-removal is a follow-up.

## Verified
26 trigger tests + the state-accumulator test pass; cloacina + cloacina-python
compile on default features.

## Honest caveats (documented in the task)
- `timezone` is captured at authoring but the reconciler hardcodes `UTC`
  (loading.rs:1543; `TriggerPackageMetadata` has no timezone field) — a
  **pre-existing cross-language gap** (Rust drops it the same way), so Python is
  at parity. Full plumbing is a separate follow-up.
- Embedded (non-packaged) cron via the decorator isn't scheduled (cron needs a
  DB + reconciler); embedded cron stays on the runner `register_cron_workflow` API.

## Also in branch
- T-0688 implementation plan; T-0741 (root-cause the flaky sqlite hang) filed,
  incl. the pool=1 experiment result (disproved — engine needs concurrent
  connections; the try+revert pair nets to no DB change).