### PR TITLE
release: 0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -523,7 +523,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cloacina"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "cloacina-agent"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -604,7 +604,7 @@ dependencies = [
 
 [[package]]
 name = "cloacina-api-types"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "base64",
  "serde",
@@ -615,14 +615,14 @@ dependencies = [
 
 [[package]]
 name = "cloacina-build"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "pyo3-build-config",
 ]
 
 [[package]]
 name = "cloacina-client"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "async-stream",
  "base64",
@@ -642,7 +642,7 @@ dependencies = [
 
 [[package]]
 name = "cloacina-compiler"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -672,7 +672,7 @@ dependencies = [
 
 [[package]]
 name = "cloacina-computation-graph"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "bincode",
  "once_cell",
@@ -685,7 +685,7 @@ dependencies = [
 
 [[package]]
 name = "cloacina-macros"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "once_cell",
@@ -698,7 +698,7 @@ dependencies = [
 
 [[package]]
 name = "cloacina-python"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "cloacina-server"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -767,7 +767,7 @@ dependencies = [
 
 [[package]]
 name = "cloacina-testing"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -781,7 +781,7 @@ dependencies = [
 
 [[package]]
 name = "cloacina-workflow"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -798,7 +798,7 @@ dependencies = [
 
 [[package]]
 name = "cloacina-workflow-plugin"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "cloacina-computation-graph",
  "cloacina-workflow",
@@ -812,7 +812,7 @@ dependencies = [
 
 [[package]]
 name = "cloacinactl"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["examples/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Dylan Storey <dylan.storey@gmail.com>"]
 license = "Apache-2.0"
 repository = "https://github.com/colliery-io/cloacina"
@@ -19,10 +19,10 @@ async-trait = { version = "0.1" }
 inventory = { version = "0.3" }
 once_cell = { version = "1.19.0" }
 serde_json = { version = "1.0" }
-cloacina-api-types = { version = "0.7.0", path = "crates/cloacina-api-types" }
-cloacina-client = { version = "0.7.0", path = "crates/cloacina-client" }
-cloacina-macros = { version = "0.7.0", path = "crates/cloacina-macros" }
-cloacina-workflow = { version = "0.7.0", path = "crates/cloacina-workflow" }
+cloacina-api-types = { version = "0.8.0", path = "crates/cloacina-api-types" }
+cloacina-client = { version = "0.8.0", path = "crates/cloacina-client" }
+cloacina-macros = { version = "0.8.0", path = "crates/cloacina-macros" }
+cloacina-workflow = { version = "0.8.0", path = "crates/cloacina-workflow" }
 clap = { version = "4.0", features = ["derive", "env"] }
 anyhow = { version = "1.0" }
 toml = { version = "0.8" }

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cloacina-client"
-version = "0.7.0"
+version = "0.8.0"
 description = "Python SDK for cloacina-server — typed REST client and WebSocket execution-event streams. Version-locked to the cloacina server release. (Service client; the embedded runtime is the separate `cloaca` package.)"
 readme = "README.md"
 license = "Apache-2.0"

--- a/clients/python/src/cloacina_client/__init__.py
+++ b/clients/python/src/cloacina_client/__init__.py
@@ -49,4 +49,4 @@ __all__ = [
     "models",
 ]
 
-__version__ = "0.7.0"
+__version__ = "0.8.0"

--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloacina/client",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "TypeScript SDK for cloacina-server — typed REST client and WebSocket execution-event streams. Version-locked to the cloacina server release.",
   "license": "Apache-2.0",
   "repository": {

--- a/crates/cloacina-agent/Cargo.toml
+++ b/crates/cloacina-agent/Cargo.toml
@@ -22,14 +22,14 @@ path = "src/main.rs"
 # other members; the stricter NFR-002 (truly no diesel link) is a
 # carry-forward that extracts the protocol DTOs to a no-deps `cloacina-fleet-protocol`
 # crate. See T-0632 status notes.
-cloacina = { version = "0.7.0", path = "../cloacina", default-features = false, features = ["sqlite"] }
+cloacina = { version = "0.8.0", path = "../cloacina", default-features = false, features = ["sqlite"] }
 
 # Python runtime (PyO3) so the agent can run Python-packaged workflows, not just
 # Rust cdylibs — the agent fetches a Python package's source archive and imports
 # it via this runtime. `default-features = false` (NOT extension-module) embeds
 # the interpreter into the binary; the agent image carries libpython +
 # python3-dev. (CLOACI-T-0716)
-cloacina-python = { version = "0.7.0", path = "../cloacina-python", default-features = false }
+cloacina-python = { version = "0.8.0", path = "../cloacina-python", default-features = false }
 
 # HTTP client for REST endpoints (register/heartbeat/result/ws-ticket/artifact).
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }

--- a/crates/cloacina-compiler/Cargo.toml
+++ b/crates/cloacina-compiler/Cargo.toml
@@ -24,7 +24,7 @@ postgres = ["cloacina/postgres"]
 sqlite = ["cloacina/sqlite"]
 
 [dependencies]
-cloacina = { version = "0.7.0", path = "../cloacina", default-features = false }
+cloacina = { version = "0.8.0", path = "../cloacina", default-features = false }
 clap.workspace = true
 anyhow.workspace = true
 dirs = "6"

--- a/crates/cloacina-computation-graph/Cargo.toml
+++ b/crates/cloacina-computation-graph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cloacina-computation-graph"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 description = "Core types for Cloacina computation graph plugins"
 license = "Apache-2.0"

--- a/crates/cloacina-python/Cargo.toml
+++ b/crates/cloacina-python/Cargo.toml
@@ -27,10 +27,10 @@ auth = ["cloacina/auth"]
 extension-module = ["pyo3/extension-module"]
 
 [dependencies]
-cloacina = { version = "0.7.0", path = "../cloacina", default-features = false }
-cloacina-computation-graph = { version = "0.7.0", path = "../cloacina-computation-graph" }
+cloacina = { version = "0.8.0", path = "../cloacina", default-features = false }
+cloacina-computation-graph = { version = "0.8.0", path = "../cloacina-computation-graph" }
 cloacina-workflow = { workspace = true }
-cloacina-workflow-plugin = { version = "0.7.0", path = "../cloacina-workflow-plugin" }
+cloacina-workflow-plugin = { version = "0.8.0", path = "../cloacina-workflow-plugin" }
 
 async-trait.workspace = true
 serde_json.workspace = true
@@ -50,7 +50,7 @@ url = { version = "2.5" }
 uuid = { version = "1.0", features = ["serde", "v4", "v5"] }
 
 [build-dependencies]
-cloacina-build = { version = "0.7.0", path = "../cloacina-build" }
+cloacina-build = { version = "0.8.0", path = "../cloacina-build" }
 
 [dev-dependencies]
 fidius-core = "0.2.1"

--- a/crates/cloacina-server/Cargo.toml
+++ b/crates/cloacina-server/Cargo.toml
@@ -26,14 +26,14 @@ kafka = ["cloacina/kafka"]
 telemetry = ["dep:tracing-opentelemetry", "dep:opentelemetry", "dep:opentelemetry-otlp", "dep:opentelemetry_sdk"]
 
 [dependencies]
-cloacina = { version = "0.7.0", path = "../cloacina", default-features = false }
+cloacina = { version = "0.8.0", path = "../cloacina", default-features = false }
 cloacina-api-types = { workspace = true, features = ["openapi"] }
 utoipa = { version = "5" }
 # Python runtime — server registers the impl at startup so uploaded
 # Python-language packages can be loaded by the reconciler. Compiler
 # service intentionally does not depend on this (T-0529).
-cloacina-python = { version = "0.7.0", path = "../cloacina-python", default-features = false }
-cloacina-workflow-plugin = { version = "0.7.0", path = "../cloacina-workflow-plugin" }
+cloacina-python = { version = "0.8.0", path = "../cloacina-python", default-features = false }
+cloacina-workflow-plugin = { version = "0.8.0", path = "../cloacina-workflow-plugin" }
 clap.workspace = true
 anyhow.workspace = true
 dirs = "6"
@@ -69,4 +69,4 @@ serial_test = "3"
 tempfile = "3"
 
 [build-dependencies]
-cloacina-build = { version = "0.7.0", path = "../cloacina-build" }
+cloacina-build = { version = "0.8.0", path = "../cloacina-build" }

--- a/crates/cloacina-workflow-plugin/Cargo.toml
+++ b/crates/cloacina-workflow-plugin/Cargo.toml
@@ -16,8 +16,8 @@ fidius-core = "0.2.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { workspace = true }
 inventory = "0.3"
-cloacina-computation-graph = { version = "0.7.0", path = "../cloacina-computation-graph" }
-cloacina-workflow = { version = "0.7.0", path = "../cloacina-workflow", default-features = false }
+cloacina-computation-graph = { version = "0.8.0", path = "../cloacina-computation-graph" }
+cloacina-workflow = { version = "0.8.0", path = "../cloacina-workflow", default-features = false }
 
 [dev-dependencies]
 toml = "0.8"

--- a/crates/cloacina/Cargo.toml
+++ b/crates/cloacina/Cargo.toml
@@ -35,8 +35,8 @@ serde_json.workspace = true
 cloacina-api-types = { workspace = true }
 cloacina-macros = { workspace = true, optional = true }
 cloacina-workflow = { workspace = true }
-cloacina-computation-graph = { version = "0.7.0", path = "../cloacina-computation-graph" }
-cloacina-workflow-plugin = { version = "0.7.0", path = "../cloacina-workflow-plugin" }
+cloacina-computation-graph = { version = "0.8.0", path = "../cloacina-computation-graph" }
+cloacina-workflow-plugin = { version = "0.8.0", path = "../cloacina-workflow-plugin" }
 
 # External dependencies
 chrono = { version = "0.4", features = ["serde"] }

--- a/crates/cloacinactl/Cargo.toml
+++ b/crates/cloacinactl/Cargo.toml
@@ -21,9 +21,9 @@ sqlite = ["cloacina/sqlite"]
 kafka = ["cloacina/kafka"]
 
 [dependencies]
-cloacina = { version = "0.7.0", path = "../cloacina", default-features = false }
+cloacina = { version = "0.8.0", path = "../cloacina", default-features = false }
 cloacina-client = { workspace = true }
-cloacina-workflow-plugin = { version = "0.7.0", path = "../cloacina-workflow-plugin" }
+cloacina-workflow-plugin = { version = "0.8.0", path = "../cloacina-workflow-plugin" }
 clap.workspace = true
 clap_complete = "4"
 anyhow.workspace = true

--- a/docs/static/openapi.json
+++ b/docs/static/openapi.json
@@ -11,7 +11,7 @@
       "name": "Apache-2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0"
     },
-    "version": "0.7.0"
+    "version": "0.8.0"
   },
   "paths": {
     "/health": {

--- a/ui/harness/package.json
+++ b/ui/harness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloacina/seed-harness",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "private": true,
   "type": "module",
   "description": "Cloacina UI seed/demo workload harness (CLOACI-I-0117 / T-0660). Drives a target cloacina-server — ensures a tenant, uploads fixtures, runs executions — in deterministic seed mode (for UAT) or continuous loop mode (for a live demo).",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloacina/ui",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "private": true,
   "type": "module",
   "description": "Cloacina web UI — tenant-scoped control plane (CLOACI-I-0117). React SPA over @cloacina/client.",


### PR DESCRIPTION
Minor version bump **0.7.0 → 0.8.0** across all lockstep surfaces (REQ-008): workspace + crate manifests + Cargo.lock, cloacina-computation-graph (pinned), @cloacina/client (TS), cloacina-client (Python pyproject + `__version__`), ui + ui/harness package.json, docs/static/openapi.json (matches fresh `emit-openapi`). `scripts/check_sdk_versions.py` passes.

## Headline since 0.7.0
- **Scheduler throughput rework (T-0745)** — batched per-tick state resolution + backend-aware dispatch (fire-and-forget on postgres, serial on sqlite). Fleet utilization under load ~0.3 → ~18+ tasks/s; the loop no longer stalls at high active-workflow counts.
- **Timer-driven cron (T-0743)** — ~10ms pickup (was up to 30s), change-notify, concurrent co-due processing.
- **Rust↔Python parity (T-0688)** — `@cloaca.state_accumulator` + packaged cron `@cloaca.trigger`, with demo fixtures + the synthetic-module fix.
- **Reactor-first CG view (T-0742)** — `GET /v1/health/reactors` + UI Reactors card.
- **Demo fleet concurrency** 4 → 16.

No code changes beyond version strings + Cargo.lock + the regenerated openapi version. After merge, tag `v0.8.0` to trigger `unified_release.yml` (publishes crates.io / PyPI / npm / GitHub release).