### PR TITLE
fix(sdk): close SDK endpoint-coverage gaps blocking 0.8.0 release

### DIFF
--- a/clients/python/src/cloacina_client/_client.py
+++ b/clients/python/src/cloacina_client/_client.py
@@ -21,13 +21,21 @@ from collections.abc import AsyncIterator, Iterator
 from typing import Any
 
 from ._generated import AuthenticatedClient
+from ._generated.api.agents import list_agents
+from ._generated.api.compiler import compiler_status
 from ._generated.api.executions import (
     execute_workflow,
     get_execution,
     get_execution_events,
+    get_execution_tasks,
     list_executions,
 )
-from ._generated.api.graph_health import get_graph, list_accumulators, list_graphs
+from ._generated.api.graph_health import (
+    get_graph,
+    list_accumulators,
+    list_graphs,
+    list_reactors,
+)
 from ._generated.api.keys import (
     create_key,
     create_tenant_key,
@@ -318,6 +326,11 @@ class Client(_Base):
             )
         )
 
+    def get_execution_tasks(self, tenant_id: str, exec_id: str):
+        return _unwrap(
+            get_execution_tasks.sync_detailed(tenant_id, exec_id, client=self._gen)
+        )
+
     # ---- computation-graph health ----
 
     def list_accumulators(self):
@@ -328,6 +341,19 @@ class Client(_Base):
 
     def get_graph(self, name: str):
         return _unwrap(get_graph.sync_detailed(name, client=self._gen))
+
+    def list_reactors(self):
+        return _unwrap(list_reactors.sync_detailed(client=self._gen))
+
+    # ---- agents ----
+
+    def list_agents(self):
+        return _unwrap(list_agents.sync_detailed(client=self._gen))
+
+    # ---- compiler ----
+
+    def compiler_status(self):
+        return _unwrap(compiler_status.sync_detailed(client=self._gen))
 
 
 class AsyncClient(_Base):
@@ -430,6 +456,28 @@ class AsyncClient(_Base):
                 self.tenant_segment(tenant), exec_id, client=self._gen
             )
         )
+
+    async def get_execution_tasks(self, tenant_id: str, exec_id: str):
+        return _unwrap(
+            await get_execution_tasks.asyncio_detailed(
+                tenant_id, exec_id, client=self._gen
+            )
+        )
+
+    # ---- computation-graph health ----
+
+    async def list_reactors(self):
+        return _unwrap(await list_reactors.asyncio_detailed(client=self._gen))
+
+    # ---- agents ----
+
+    async def list_agents(self):
+        return _unwrap(await list_agents.asyncio_detailed(client=self._gen))
+
+    # ---- compiler ----
+
+    async def compiler_status(self):
+        return _unwrap(await compiler_status.asyncio_detailed(client=self._gen))
 
     # ---- WebSocket (substrate delivery) ----
 

--- a/clients/python/src/cloacina_client/_generated/api/agents/__init__.py
+++ b/clients/python/src/cloacina_client/_generated/api/agents/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/clients/python/src/cloacina_client/_generated/api/agents/list_agents.py
+++ b/clients/python/src/cloacina_client/_generated/api/agents/list_agents.py
@@ -1,0 +1,131 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.error_body import ErrorBody
+from ...types import Response
+
+
+def _get_kwargs() -> dict[str, Any]:
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/agents",
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Any | ErrorBody | None:
+    if 200 <= response.status_code < 300:
+        return response.json()
+
+    if response.status_code == 401:
+        response_401 = ErrorBody.from_dict(response.json())
+
+        return response_401
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Any | ErrorBody]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient,
+) -> Response[Any | ErrorBody]:
+    """GET /v1/agents — list registered execution agents.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | ErrorBody]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient,
+) -> Any | ErrorBody | None:
+    """GET /v1/agents — list registered execution agents.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | ErrorBody
+    """
+
+    return sync_detailed(
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient,
+) -> Response[Any | ErrorBody]:
+    """GET /v1/agents — list registered execution agents.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | ErrorBody]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient,
+) -> Any | ErrorBody | None:
+    """GET /v1/agents — list registered execution agents.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | ErrorBody
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+        )
+    ).parsed

--- a/clients/python/src/cloacina_client/_generated/api/compiler/__init__.py
+++ b/clients/python/src/cloacina_client/_generated/api/compiler/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/clients/python/src/cloacina_client/_generated/api/compiler/compiler_status.py
+++ b/clients/python/src/cloacina_client/_generated/api/compiler/compiler_status.py
@@ -1,0 +1,131 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.error_body import ErrorBody
+from ...types import Response
+
+
+def _get_kwargs() -> dict[str, Any]:
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/compiler/status",
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Any | ErrorBody | None:
+    if 200 <= response.status_code < 300:
+        return response.json()
+
+    if response.status_code == 401:
+        response_401 = ErrorBody.from_dict(response.json())
+
+        return response_401
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Any | ErrorBody]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient,
+) -> Response[Any | ErrorBody]:
+    """GET /v1/compiler/status — compiler service health/status.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | ErrorBody]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient,
+) -> Any | ErrorBody | None:
+    """GET /v1/compiler/status — compiler service health/status.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | ErrorBody
+    """
+
+    return sync_detailed(
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient,
+) -> Response[Any | ErrorBody]:
+    """GET /v1/compiler/status — compiler service health/status.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | ErrorBody]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient,
+) -> Any | ErrorBody | None:
+    """GET /v1/compiler/status — compiler service health/status.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | ErrorBody
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+        )
+    ).parsed

--- a/clients/python/src/cloacina_client/_generated/api/executions/get_execution_tasks.py
+++ b/clients/python/src/cloacina_client/_generated/api/executions/get_execution_tasks.py
@@ -1,0 +1,187 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.error_body import ErrorBody
+from ...types import Response
+
+
+def _get_kwargs(
+    tenant_id: str,
+    exec_id: str,
+) -> dict[str, Any]:
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/tenants/{tenant_id}/executions/{exec_id}/tasks".format(
+            tenant_id=quote(str(tenant_id), safe=""),
+            exec_id=quote(str(exec_id), safe=""),
+        ),
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Any | ErrorBody | None:
+    if 200 <= response.status_code < 300:
+        return response.json()
+
+    if response.status_code == 400:
+        response_400 = ErrorBody.from_dict(response.json())
+
+        return response_400
+
+    if response.status_code == 401:
+        response_401 = ErrorBody.from_dict(response.json())
+
+        return response_401
+
+    if response.status_code == 403:
+        response_403 = ErrorBody.from_dict(response.json())
+
+        return response_403
+
+    if response.status_code == 404:
+        response_404 = ErrorBody.from_dict(response.json())
+
+        return response_404
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Any | ErrorBody]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    tenant_id: str,
+    exec_id: str,
+    *,
+    client: AuthenticatedClient,
+) -> Response[Any | ErrorBody]:
+    """GET /tenants/:tenant_id/executions/:id/tasks — list the tasks for an execution.
+
+    Args:
+        tenant_id (str):
+        exec_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | ErrorBody]
+    """
+
+    kwargs = _get_kwargs(
+        tenant_id=tenant_id,
+        exec_id=exec_id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    tenant_id: str,
+    exec_id: str,
+    *,
+    client: AuthenticatedClient,
+) -> Any | ErrorBody | None:
+    """GET /tenants/:tenant_id/executions/:id/tasks — list the tasks for an execution.
+
+    Args:
+        tenant_id (str):
+        exec_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | ErrorBody
+    """
+
+    return sync_detailed(
+        tenant_id=tenant_id,
+        exec_id=exec_id,
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    tenant_id: str,
+    exec_id: str,
+    *,
+    client: AuthenticatedClient,
+) -> Response[Any | ErrorBody]:
+    """GET /tenants/:tenant_id/executions/:id/tasks — list the tasks for an execution.
+
+    Args:
+        tenant_id (str):
+        exec_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | ErrorBody]
+    """
+
+    kwargs = _get_kwargs(
+        tenant_id=tenant_id,
+        exec_id=exec_id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    tenant_id: str,
+    exec_id: str,
+    *,
+    client: AuthenticatedClient,
+) -> Any | ErrorBody | None:
+    """GET /tenants/:tenant_id/executions/:id/tasks — list the tasks for an execution.
+
+    Args:
+        tenant_id (str):
+        exec_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | ErrorBody
+    """
+
+    return (
+        await asyncio_detailed(
+            tenant_id=tenant_id,
+            exec_id=exec_id,
+            client=client,
+        )
+    ).parsed

--- a/clients/python/src/cloacina_client/_generated/api/graph_health/list_reactors.py
+++ b/clients/python/src/cloacina_client/_generated/api/graph_health/list_reactors.py
@@ -1,0 +1,135 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.error_body import ErrorBody
+from ...types import Response
+
+
+def _get_kwargs() -> dict[str, Any]:
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/health/reactors",
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Any | ErrorBody | None:
+    if 200 <= response.status_code < 300:
+        return response.json()
+
+    if response.status_code == 401:
+        response_401 = ErrorBody.from_dict(response.json())
+
+        return response_401
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Any | ErrorBody]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient,
+) -> Response[Any | ErrorBody]:
+    """GET /v1/health/reactors — list reactors with health, filtered by the
+    caller's authorization.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | ErrorBody]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient,
+) -> Any | ErrorBody | None:
+    """GET /v1/health/reactors — list reactors with health, filtered by the
+    caller's authorization.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | ErrorBody
+    """
+
+    return sync_detailed(
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient,
+) -> Response[Any | ErrorBody]:
+    """GET /v1/health/reactors — list reactors with health, filtered by the
+    caller's authorization.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | ErrorBody]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient,
+) -> Any | ErrorBody | None:
+    """GET /v1/health/reactors — list reactors with health, filtered by the
+    caller's authorization.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | ErrorBody
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+        )
+    ).parsed

--- a/clients/typescript/src/client.ts
+++ b/clients/typescript/src/client.ts
@@ -377,6 +377,32 @@ export class CloacinaClient {
     );
   }
 
+  async getExecutionTasks(
+    tenant: string,
+    execId: string,
+  ): Promise<schemas["ExecutionTasksResponse"]> {
+    return unwrap(
+      await this.api.GET(
+        "/v1/tenants/{tenant_id}/executions/{exec_id}/tasks",
+        {
+          params: {
+            path: { tenant_id: this.#tenant(tenant), exec_id: execId },
+          },
+        },
+      ),
+    );
+  }
+
+  // ---- fleet & compiler ----
+
+  async listAgents(): Promise<schemas["ListResponse_AgentInfo"]> {
+    return unwrap(await this.api.GET("/v1/agents"));
+  }
+
+  async compilerStatus(): Promise<schemas["CompilerStatus"]> {
+    return unwrap(await this.api.GET("/v1/compiler/status"));
+  }
+
   // ---- computation-graph health ----
 
   async listAccumulators(): Promise<schemas["ListResponse_AccumulatorStatus"]> {

--- a/crates/cloacina-client/src/lib.rs
+++ b/crates/cloacina-client/src/lib.rs
@@ -60,12 +60,13 @@ use serde::de::DeserializeOwned;
 use serde_json::Value;
 
 use cloacina_api_types::{
-    AccumulatorStatus, CreateKeyRequest, CreateTenantRequest, ExecuteRequest, ExecuteResponse,
-    ExecutionDetail, ExecutionEventsResponse, ExecutionSummary, GraphStatus, KeyCreatedResponse,
-    KeyInfo, KeyRevokedResponse, KeyRole, ListResponse, TenantCreatedResponse, TenantListResponse,
-    TenantRemovedResponse, TenantSummary, TriggerDetailResponse, TriggerScheduleSummary,
-    WorkflowDeletedResponse, WorkflowDetail, WorkflowSummary, WorkflowUploadedResponse,
-    WsTicketResponse,
+    AccumulatorStatus, AgentInfo, CompilerStatus, CreateKeyRequest, CreateTenantRequest,
+    ExecuteRequest, ExecuteResponse, ExecutionDetail, ExecutionEventsResponse,
+    ExecutionTasksResponse, ExecutionSummary, GraphStatus, KeyCreatedResponse, KeyInfo,
+    KeyRevokedResponse, KeyRole, ListResponse, ReactorStatus, TenantCreatedResponse,
+    TenantListResponse, TenantRemovedResponse, TenantSummary, TriggerDetailResponse,
+    TriggerScheduleSummary, WorkflowDeletedResponse, WorkflowDetail, WorkflowSummary,
+    WorkflowUploadedResponse, WsTicketResponse,
 };
 
 /// Builder for [`Client`].
@@ -491,6 +492,17 @@ impl Client {
             .await
     }
 
+    pub async fn get_execution_tasks(
+        &self,
+        tenant_id: &str,
+        exec_id: &str,
+    ) -> Result<ExecutionTasksResponse, ClientError> {
+        self.get_json(&format!(
+            "/v1/tenants/{tenant_id}/executions/{exec_id}/tasks"
+        ))
+        .await
+    }
+
     // ---- computation-graph health ----
 
     pub async fn list_accumulators(&self) -> Result<ListResponse<AccumulatorStatus>, ClientError> {
@@ -503,6 +515,20 @@ impl Client {
 
     pub async fn get_graph(&self, name: &str) -> Result<GraphStatus, ClientError> {
         self.get_json(&format!("/v1/health/graphs/{name}")).await
+    }
+
+    pub async fn list_reactors(&self) -> Result<ListResponse<ReactorStatus>, ClientError> {
+        self.get_json("/v1/health/reactors").await
+    }
+
+    // ---- fleet / compiler ----
+
+    pub async fn list_agents(&self) -> Result<ListResponse<AgentInfo>, ClientError> {
+        self.get_json("/v1/agents").await
+    }
+
+    pub async fn compiler_status(&self) -> Result<CompilerStatus, ClientError> {
+        self.get_json("/v1/compiler/status").await
     }
 
     // ---- WebSocket (substrate delivery) ----


### PR DESCRIPTION
The 0.8.0 release pipeline (`unified_release` → nightly-suite → **SDK Contract Matrix**) failed on `scripts/check_sdk_coverage.py`: 4 server endpoints weren't covered by all three client SDKs.

- `GET /v1/health/reactors` — added in T-0742 (TS only); now added to Rust + Python.
- `GET /v1/agents`, `GET /v1/compiler/status`, `GET /v1/tenants/{tenant_id}/executions/{exec_id}/tasks` — **pre-existing drift** (endpoints added across earlier initiatives, SDK methods never added; the coverage gate only runs in the nightly/release pipeline so it surfaced at release time).

Adds the missing methods across all three clients (TS `listAgents`/`compilerStatus`/`getExecutionTasks`; Rust + Python `list_agents`/`compiler_status`/`list_reactors`/`get_execution_tasks`, sync+async for Python with generated op modules).

**Gates:** `check_sdk_coverage.py` → 27/27 operations reachable from all 3 SDKs; `check_sdk_versions.py` → lockstep at 0.8.0. Rust + TS clients build clean; Python imports.

Unblocks the 0.8.0 release — after merge, the `v0.8.0` tag will be re-cut at the updated main (nothing was published, so re-tag is clean).