### PR TITLE
fix(release): SDK auth-surface coverage + Connect label collision — unblock v0.9.0

### DIFF
--- a/clients/python/src/cloacina_client/_client.py
+++ b/clients/python/src/cloacina_client/_client.py
@@ -21,6 +21,16 @@ from collections.abc import AsyncIterator, Iterator
 from typing import Any
 
 from ._generated import AuthenticatedClient
+from ._generated.api.auth import (
+    create_account,
+    disable_account,
+    list_accounts,
+    local_login,
+    logout,
+    refresh,
+    reset_password,
+    whoami,
+)
 from ._generated.api.fleet import list_agents
 from ._generated.api.compiler import compiler_status
 from ._generated.api.executions import (
@@ -47,7 +57,9 @@ from ._generated.api.keys import (
     create_tenant_key,
     create_ws_ticket,
     list_keys,
+    list_tenant_keys,
     revoke_key,
+    revoke_tenant_key,
 )
 from ._generated.api.operational import health, ready
 from ._generated.api.tenants import create_tenant, list_tenants, remove_tenant
@@ -69,12 +81,15 @@ from ._generated.api.workflows import (
     upload_workflow,
 )
 from ._generated.models import (
+    CreateAccountRequest,
     CreateKeyRequest,
     CreateTenantRequest,
     ErrorBody,
     ExecuteRequest,
     KeyRole,
+    LocalLoginRequest,
     PackageUploadForm,
+    ResetPasswordRequest,
 )
 from ._generated.types import UNSET, File, Response, Unset
 
@@ -187,8 +202,77 @@ class Client(_Base):
             )
         )
 
+    def list_tenant_keys(self, tenant: str | None = None):
+        """List the connected tenant's own keys (tenant-admin, CLOACI-T-0784)."""
+        return _unwrap(
+            list_tenant_keys.sync_detailed(self.tenant_segment(tenant), client=self._gen)
+        )
+
+    def revoke_tenant_key(self, key_id: str, tenant: str | None = None):
+        """Revoke one of the connected tenant's own keys (tenant-admin, CLOACI-T-0784)."""
+        return _unwrap(
+            revoke_tenant_key.sync_detailed(
+                self.tenant_segment(tenant), key_id, client=self._gen
+            )
+        )
+
     def create_ws_ticket(self):
         return _unwrap(create_ws_ticket.sync_detailed(client=self._gen))
+
+    # ---- session / local auth (CLOACI-T-0794/0796/0803) ----
+
+    def local_login(self, username: str, password: str, tenant: str | None = None):
+        """Username/password login — returns a minted bearer key."""
+        body = LocalLoginRequest(
+            username=username,
+            password=password,
+            tenant=tenant if tenant is not None else UNSET,
+        )
+        return _unwrap(local_login.sync_detailed(client=self._gen, body=body))
+
+    def refresh(self):
+        """Silently re-mint the current short-TTL key before it expires."""
+        return _unwrap(refresh.sync_detailed(client=self._gen))
+
+    def logout(self):
+        """Revoke the current key + forget any refresh session."""
+        return _unwrap(logout.sync_detailed(client=self._gen))
+
+    def whoami(self):
+        """The current key's tenant + role + admin flag."""
+        return _unwrap(whoami.sync_detailed(client=self._gen))
+
+    # ---- local accounts: tenant-admin management (CLOACI-T-0797) ----
+
+    def list_accounts(self, tenant: str | None = None):
+        return _unwrap(
+            list_accounts.sync_detailed(self.tenant_segment(tenant), client=self._gen)
+        )
+
+    def create_account(
+        self, username: str, password: str, role: str = "read", tenant: str | None = None
+    ):
+        body = CreateAccountRequest(username=username, password=password, role=role)
+        return _unwrap(
+            create_account.sync_detailed(
+                self.tenant_segment(tenant), client=self._gen, body=body
+            )
+        )
+
+    def disable_account(self, account_id: str, tenant: str | None = None):
+        return _unwrap(
+            disable_account.sync_detailed(
+                self.tenant_segment(tenant), account_id, client=self._gen
+            )
+        )
+
+    def reset_password(self, account_id: str, password: str, tenant: str | None = None):
+        body = ResetPasswordRequest(password=password)
+        return _unwrap(
+            reset_password.sync_detailed(
+                self.tenant_segment(tenant), account_id, client=self._gen, body=body
+            )
+        )
 
     # ---- tenants ----
 

--- a/clients/python/src/cloacina_client/_generated/api/auth/__init__.py
+++ b/clients/python/src/cloacina_client/_generated/api/auth/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/clients/python/src/cloacina_client/_generated/api/auth/create_account.py
+++ b/clients/python/src/cloacina_client/_generated/api/auth/create_account.py
@@ -1,0 +1,192 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.account_info import AccountInfo
+from ...models.create_account_request import CreateAccountRequest
+from ...models.error_body import ErrorBody
+from ...types import Response
+
+
+def _get_kwargs(
+    tenant_id: str,
+    *,
+    body: CreateAccountRequest,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/v1/tenants/{tenant_id}/accounts".format(
+            tenant_id=quote(str(tenant_id), safe=""),
+        ),
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> AccountInfo | ErrorBody | None:
+    if response.status_code == 201:
+        response_201 = AccountInfo.from_dict(response.json())
+
+        return response_201
+
+    if response.status_code == 401:
+        response_401 = ErrorBody.from_dict(response.json())
+
+        return response_401
+
+    if response.status_code == 403:
+        response_403 = ErrorBody.from_dict(response.json())
+
+        return response_403
+
+    if response.status_code == 500:
+        response_500 = ErrorBody.from_dict(response.json())
+
+        return response_500
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[AccountInfo | ErrorBody]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    tenant_id: str,
+    *,
+    client: AuthenticatedClient,
+    body: CreateAccountRequest,
+) -> Response[AccountInfo | ErrorBody]:
+    """`POST /v1/tenants/{tenant_id}/accounts` — create a tenant local account.
+
+    Args:
+        tenant_id (str):
+        body (CreateAccountRequest): Create a local account in a tenant.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[AccountInfo | ErrorBody]
+    """
+
+    kwargs = _get_kwargs(
+        tenant_id=tenant_id,
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    tenant_id: str,
+    *,
+    client: AuthenticatedClient,
+    body: CreateAccountRequest,
+) -> AccountInfo | ErrorBody | None:
+    """`POST /v1/tenants/{tenant_id}/accounts` — create a tenant local account.
+
+    Args:
+        tenant_id (str):
+        body (CreateAccountRequest): Create a local account in a tenant.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        AccountInfo | ErrorBody
+    """
+
+    return sync_detailed(
+        tenant_id=tenant_id,
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    tenant_id: str,
+    *,
+    client: AuthenticatedClient,
+    body: CreateAccountRequest,
+) -> Response[AccountInfo | ErrorBody]:
+    """`POST /v1/tenants/{tenant_id}/accounts` — create a tenant local account.
+
+    Args:
+        tenant_id (str):
+        body (CreateAccountRequest): Create a local account in a tenant.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[AccountInfo | ErrorBody]
+    """
+
+    kwargs = _get_kwargs(
+        tenant_id=tenant_id,
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    tenant_id: str,
+    *,
+    client: AuthenticatedClient,
+    body: CreateAccountRequest,
+) -> AccountInfo | ErrorBody | None:
+    """`POST /v1/tenants/{tenant_id}/accounts` — create a tenant local account.
+
+    Args:
+        tenant_id (str):
+        body (CreateAccountRequest): Create a local account in a tenant.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        AccountInfo | ErrorBody
+    """
+
+    return (
+        await asyncio_detailed(
+            tenant_id=tenant_id,
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/clients/python/src/cloacina_client/_generated/api/auth/disable_account.py
+++ b/clients/python/src/cloacina_client/_generated/api/auth/disable_account.py
@@ -1,0 +1,193 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.account_action_response import AccountActionResponse
+from ...models.error_body import ErrorBody
+from ...types import Response
+
+
+def _get_kwargs(
+    tenant_id: str,
+    account_id: str,
+) -> dict[str, Any]:
+
+    _kwargs: dict[str, Any] = {
+        "method": "delete",
+        "url": "/v1/tenants/{tenant_id}/accounts/{account_id}".format(
+            tenant_id=quote(str(tenant_id), safe=""),
+            account_id=quote(str(account_id), safe=""),
+        ),
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> AccountActionResponse | ErrorBody | None:
+    if response.status_code == 200:
+        response_200 = AccountActionResponse.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 400:
+        response_400 = ErrorBody.from_dict(response.json())
+
+        return response_400
+
+    if response.status_code == 403:
+        response_403 = ErrorBody.from_dict(response.json())
+
+        return response_403
+
+    if response.status_code == 404:
+        response_404 = ErrorBody.from_dict(response.json())
+
+        return response_404
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[AccountActionResponse | ErrorBody]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    tenant_id: str,
+    account_id: str,
+    *,
+    client: AuthenticatedClient,
+) -> Response[AccountActionResponse | ErrorBody]:
+    """`DELETE /v1/tenants/{tenant_id}/accounts/{account_id}` — disable an account.
+    Disable (not hard-delete) preserves history; already-minted keys lapse at
+    their TTL (deprovisioning latency bounded by the short TTL).
+
+    Args:
+        tenant_id (str):
+        account_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[AccountActionResponse | ErrorBody]
+    """
+
+    kwargs = _get_kwargs(
+        tenant_id=tenant_id,
+        account_id=account_id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    tenant_id: str,
+    account_id: str,
+    *,
+    client: AuthenticatedClient,
+) -> AccountActionResponse | ErrorBody | None:
+    """`DELETE /v1/tenants/{tenant_id}/accounts/{account_id}` — disable an account.
+    Disable (not hard-delete) preserves history; already-minted keys lapse at
+    their TTL (deprovisioning latency bounded by the short TTL).
+
+    Args:
+        tenant_id (str):
+        account_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        AccountActionResponse | ErrorBody
+    """
+
+    return sync_detailed(
+        tenant_id=tenant_id,
+        account_id=account_id,
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    tenant_id: str,
+    account_id: str,
+    *,
+    client: AuthenticatedClient,
+) -> Response[AccountActionResponse | ErrorBody]:
+    """`DELETE /v1/tenants/{tenant_id}/accounts/{account_id}` — disable an account.
+    Disable (not hard-delete) preserves history; already-minted keys lapse at
+    their TTL (deprovisioning latency bounded by the short TTL).
+
+    Args:
+        tenant_id (str):
+        account_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[AccountActionResponse | ErrorBody]
+    """
+
+    kwargs = _get_kwargs(
+        tenant_id=tenant_id,
+        account_id=account_id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    tenant_id: str,
+    account_id: str,
+    *,
+    client: AuthenticatedClient,
+) -> AccountActionResponse | ErrorBody | None:
+    """`DELETE /v1/tenants/{tenant_id}/accounts/{account_id}` — disable an account.
+    Disable (not hard-delete) preserves history; already-minted keys lapse at
+    their TTL (deprovisioning latency bounded by the short TTL).
+
+    Args:
+        tenant_id (str):
+        account_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        AccountActionResponse | ErrorBody
+    """
+
+    return (
+        await asyncio_detailed(
+            tenant_id=tenant_id,
+            account_id=account_id,
+            client=client,
+        )
+    ).parsed

--- a/clients/python/src/cloacina_client/_generated/api/auth/list_accounts.py
+++ b/clients/python/src/cloacina_client/_generated/api/auth/list_accounts.py
@@ -1,0 +1,171 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.error_body import ErrorBody
+from ...models.list_response_account_info import ListResponseAccountInfo
+from ...types import Response
+
+
+def _get_kwargs(
+    tenant_id: str,
+) -> dict[str, Any]:
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/tenants/{tenant_id}/accounts".format(
+            tenant_id=quote(str(tenant_id), safe=""),
+        ),
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> ErrorBody | ListResponseAccountInfo | None:
+    if response.status_code == 200:
+        response_200 = ListResponseAccountInfo.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 401:
+        response_401 = ErrorBody.from_dict(response.json())
+
+        return response_401
+
+    if response.status_code == 403:
+        response_403 = ErrorBody.from_dict(response.json())
+
+        return response_403
+
+    if response.status_code == 500:
+        response_500 = ErrorBody.from_dict(response.json())
+
+        return response_500
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[ErrorBody | ListResponseAccountInfo]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    tenant_id: str,
+    *,
+    client: AuthenticatedClient,
+) -> Response[ErrorBody | ListResponseAccountInfo]:
+    """`GET /v1/tenants/{tenant_id}/accounts` — list a tenant's local accounts.
+
+    Args:
+        tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[ErrorBody | ListResponseAccountInfo]
+    """
+
+    kwargs = _get_kwargs(
+        tenant_id=tenant_id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    tenant_id: str,
+    *,
+    client: AuthenticatedClient,
+) -> ErrorBody | ListResponseAccountInfo | None:
+    """`GET /v1/tenants/{tenant_id}/accounts` — list a tenant's local accounts.
+
+    Args:
+        tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        ErrorBody | ListResponseAccountInfo
+    """
+
+    return sync_detailed(
+        tenant_id=tenant_id,
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    tenant_id: str,
+    *,
+    client: AuthenticatedClient,
+) -> Response[ErrorBody | ListResponseAccountInfo]:
+    """`GET /v1/tenants/{tenant_id}/accounts` — list a tenant's local accounts.
+
+    Args:
+        tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[ErrorBody | ListResponseAccountInfo]
+    """
+
+    kwargs = _get_kwargs(
+        tenant_id=tenant_id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    tenant_id: str,
+    *,
+    client: AuthenticatedClient,
+) -> ErrorBody | ListResponseAccountInfo | None:
+    """`GET /v1/tenants/{tenant_id}/accounts` — list a tenant's local accounts.
+
+    Args:
+        tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        ErrorBody | ListResponseAccountInfo
+    """
+
+    return (
+        await asyncio_detailed(
+            tenant_id=tenant_id,
+            client=client,
+        )
+    ).parsed

--- a/clients/python/src/cloacina_client/_generated/api/auth/local_login.py
+++ b/clients/python/src/cloacina_client/_generated/api/auth/local_login.py
@@ -1,0 +1,179 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.error_body import ErrorBody
+from ...models.local_login_request import LocalLoginRequest
+from ...models.local_login_response import LocalLoginResponse
+from ...types import Response
+
+
+def _get_kwargs(
+    *,
+    body: LocalLoginRequest,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/v1/auth/local/login",
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> ErrorBody | LocalLoginResponse | None:
+    if response.status_code == 200:
+        response_200 = LocalLoginResponse.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 401:
+        response_401 = ErrorBody.from_dict(response.json())
+
+        return response_401
+
+    if response.status_code == 500:
+        response_500 = ErrorBody.from_dict(response.json())
+
+        return response_500
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[ErrorBody | LocalLoginResponse]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    body: LocalLoginRequest,
+) -> Response[ErrorBody | LocalLoginResponse]:
+    """`POST /v1/auth/local/login` — verify a password, mint a short-TTL key.
+
+    Args:
+        body (LocalLoginRequest): A local-login attempt. `tenant` selects which tenant's account
+            namespace to
+            authenticate against (`None` = a global account).
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[ErrorBody | LocalLoginResponse]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+    body: LocalLoginRequest,
+) -> ErrorBody | LocalLoginResponse | None:
+    """`POST /v1/auth/local/login` — verify a password, mint a short-TTL key.
+
+    Args:
+        body (LocalLoginRequest): A local-login attempt. `tenant` selects which tenant's account
+            namespace to
+            authenticate against (`None` = a global account).
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        ErrorBody | LocalLoginResponse
+    """
+
+    return sync_detailed(
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    body: LocalLoginRequest,
+) -> Response[ErrorBody | LocalLoginResponse]:
+    """`POST /v1/auth/local/login` — verify a password, mint a short-TTL key.
+
+    Args:
+        body (LocalLoginRequest): A local-login attempt. `tenant` selects which tenant's account
+            namespace to
+            authenticate against (`None` = a global account).
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[ErrorBody | LocalLoginResponse]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+    body: LocalLoginRequest,
+) -> ErrorBody | LocalLoginResponse | None:
+    """`POST /v1/auth/local/login` — verify a password, mint a short-TTL key.
+
+    Args:
+        body (LocalLoginRequest): A local-login attempt. `tenant` selects which tenant's account
+            namespace to
+            authenticate against (`None` = a global account).
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        ErrorBody | LocalLoginResponse
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/clients/python/src/cloacina_client/_generated/api/auth/logout.py
+++ b/clients/python/src/cloacina_client/_generated/api/auth/logout.py
@@ -1,0 +1,134 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.error_body import ErrorBody
+from ...models.logout_response import LogoutResponse
+from ...types import Response
+
+
+def _get_kwargs() -> dict[str, Any]:
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/v1/auth/logout",
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> ErrorBody | LogoutResponse | None:
+    if response.status_code == 200:
+        response_200 = LogoutResponse.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 401:
+        response_401 = ErrorBody.from_dict(response.json())
+
+        return response_401
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[ErrorBody | LogoutResponse]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient,
+) -> Response[ErrorBody | LogoutResponse]:
+    """`POST /v1/auth/logout` — revoke the caller's key + forget refresh state.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[ErrorBody | LogoutResponse]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient,
+) -> ErrorBody | LogoutResponse | None:
+    """`POST /v1/auth/logout` — revoke the caller's key + forget refresh state.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        ErrorBody | LogoutResponse
+    """
+
+    return sync_detailed(
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient,
+) -> Response[ErrorBody | LogoutResponse]:
+    """`POST /v1/auth/logout` — revoke the caller's key + forget refresh state.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[ErrorBody | LogoutResponse]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient,
+) -> ErrorBody | LogoutResponse | None:
+    """`POST /v1/auth/logout` — revoke the caller's key + forget refresh state.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        ErrorBody | LogoutResponse
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+        )
+    ).parsed

--- a/clients/python/src/cloacina_client/_generated/api/auth/refresh.py
+++ b/clients/python/src/cloacina_client/_generated/api/auth/refresh.py
@@ -1,0 +1,144 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.error_body import ErrorBody
+from ...models.local_login_response import LocalLoginResponse
+from ...types import Response
+
+
+def _get_kwargs() -> dict[str, Any]:
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/v1/auth/refresh",
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> ErrorBody | LocalLoginResponse | None:
+    if response.status_code == 200:
+        response_200 = LocalLoginResponse.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 400:
+        response_400 = ErrorBody.from_dict(response.json())
+
+        return response_400
+
+    if response.status_code == 401:
+        response_401 = ErrorBody.from_dict(response.json())
+
+        return response_401
+
+    if response.status_code == 501:
+        response_501 = ErrorBody.from_dict(response.json())
+
+        return response_501
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[ErrorBody | LocalLoginResponse]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient,
+) -> Response[ErrorBody | LocalLoginResponse]:
+    """`POST /v1/auth/refresh` — silently re-mint the caller's short-TTL key.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[ErrorBody | LocalLoginResponse]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient,
+) -> ErrorBody | LocalLoginResponse | None:
+    """`POST /v1/auth/refresh` — silently re-mint the caller's short-TTL key.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        ErrorBody | LocalLoginResponse
+    """
+
+    return sync_detailed(
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient,
+) -> Response[ErrorBody | LocalLoginResponse]:
+    """`POST /v1/auth/refresh` — silently re-mint the caller's short-TTL key.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[ErrorBody | LocalLoginResponse]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient,
+) -> ErrorBody | LocalLoginResponse | None:
+    """`POST /v1/auth/refresh` — silently re-mint the caller's short-TTL key.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        ErrorBody | LocalLoginResponse
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+        )
+    ).parsed

--- a/clients/python/src/cloacina_client/_generated/api/auth/reset_password.py
+++ b/clients/python/src/cloacina_client/_generated/api/auth/reset_password.py
@@ -1,0 +1,206 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.account_action_response import AccountActionResponse
+from ...models.error_body import ErrorBody
+from ...models.reset_password_request import ResetPasswordRequest
+from ...types import Response
+
+
+def _get_kwargs(
+    tenant_id: str,
+    account_id: str,
+    *,
+    body: ResetPasswordRequest,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/v1/tenants/{tenant_id}/accounts/{account_id}/password".format(
+            tenant_id=quote(str(tenant_id), safe=""),
+            account_id=quote(str(account_id), safe=""),
+        ),
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> AccountActionResponse | ErrorBody | None:
+    if response.status_code == 200:
+        response_200 = AccountActionResponse.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 400:
+        response_400 = ErrorBody.from_dict(response.json())
+
+        return response_400
+
+    if response.status_code == 403:
+        response_403 = ErrorBody.from_dict(response.json())
+
+        return response_403
+
+    if response.status_code == 404:
+        response_404 = ErrorBody.from_dict(response.json())
+
+        return response_404
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[AccountActionResponse | ErrorBody]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    tenant_id: str,
+    account_id: str,
+    *,
+    client: AuthenticatedClient,
+    body: ResetPasswordRequest,
+) -> Response[AccountActionResponse | ErrorBody]:
+    """`POST /v1/tenants/{tenant_id}/accounts/{account_id}/password` — admin reset.
+
+    Args:
+        tenant_id (str):
+        account_id (str):
+        body (ResetPasswordRequest): Reset a local account's password (admin-reset-only, OQ-12).
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[AccountActionResponse | ErrorBody]
+    """
+
+    kwargs = _get_kwargs(
+        tenant_id=tenant_id,
+        account_id=account_id,
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    tenant_id: str,
+    account_id: str,
+    *,
+    client: AuthenticatedClient,
+    body: ResetPasswordRequest,
+) -> AccountActionResponse | ErrorBody | None:
+    """`POST /v1/tenants/{tenant_id}/accounts/{account_id}/password` — admin reset.
+
+    Args:
+        tenant_id (str):
+        account_id (str):
+        body (ResetPasswordRequest): Reset a local account's password (admin-reset-only, OQ-12).
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        AccountActionResponse | ErrorBody
+    """
+
+    return sync_detailed(
+        tenant_id=tenant_id,
+        account_id=account_id,
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    tenant_id: str,
+    account_id: str,
+    *,
+    client: AuthenticatedClient,
+    body: ResetPasswordRequest,
+) -> Response[AccountActionResponse | ErrorBody]:
+    """`POST /v1/tenants/{tenant_id}/accounts/{account_id}/password` — admin reset.
+
+    Args:
+        tenant_id (str):
+        account_id (str):
+        body (ResetPasswordRequest): Reset a local account's password (admin-reset-only, OQ-12).
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[AccountActionResponse | ErrorBody]
+    """
+
+    kwargs = _get_kwargs(
+        tenant_id=tenant_id,
+        account_id=account_id,
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    tenant_id: str,
+    account_id: str,
+    *,
+    client: AuthenticatedClient,
+    body: ResetPasswordRequest,
+) -> AccountActionResponse | ErrorBody | None:
+    """`POST /v1/tenants/{tenant_id}/accounts/{account_id}/password` — admin reset.
+
+    Args:
+        tenant_id (str):
+        account_id (str):
+        body (ResetPasswordRequest): Reset a local account's password (admin-reset-only, OQ-12).
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        AccountActionResponse | ErrorBody
+    """
+
+    return (
+        await asyncio_detailed(
+            tenant_id=tenant_id,
+            account_id=account_id,
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/clients/python/src/cloacina_client/_generated/api/auth/whoami.py
+++ b/clients/python/src/cloacina_client/_generated/api/auth/whoami.py
@@ -1,0 +1,138 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.error_body import ErrorBody
+from ...models.whoami_response import WhoamiResponse
+from ...types import Response
+
+
+def _get_kwargs() -> dict[str, Any]:
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/auth/whoami",
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> ErrorBody | WhoamiResponse | None:
+    if response.status_code == 200:
+        response_200 = WhoamiResponse.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 401:
+        response_401 = ErrorBody.from_dict(response.json())
+
+        return response_401
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[ErrorBody | WhoamiResponse]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient,
+) -> Response[ErrorBody | WhoamiResponse]:
+    """`GET /v1/auth/whoami` — return the caller's tenant, role, and admin flag.
+    Any authenticated key (read level); reads only the request's `AuthenticatedKey`.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[ErrorBody | WhoamiResponse]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient,
+) -> ErrorBody | WhoamiResponse | None:
+    """`GET /v1/auth/whoami` — return the caller's tenant, role, and admin flag.
+    Any authenticated key (read level); reads only the request's `AuthenticatedKey`.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        ErrorBody | WhoamiResponse
+    """
+
+    return sync_detailed(
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient,
+) -> Response[ErrorBody | WhoamiResponse]:
+    """`GET /v1/auth/whoami` — return the caller's tenant, role, and admin flag.
+    Any authenticated key (read level); reads only the request's `AuthenticatedKey`.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[ErrorBody | WhoamiResponse]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient,
+) -> ErrorBody | WhoamiResponse | None:
+    """`GET /v1/auth/whoami` — return the caller's tenant, role, and admin flag.
+    Any authenticated key (read level); reads only the request's `AuthenticatedKey`.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        ErrorBody | WhoamiResponse
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+        )
+    ).parsed

--- a/clients/python/src/cloacina_client/_generated/api/keys/list_tenant_keys.py
+++ b/clients/python/src/cloacina_client/_generated/api/keys/list_tenant_keys.py
@@ -1,0 +1,179 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.error_body import ErrorBody
+from ...models.list_response_key_info import ListResponseKeyInfo
+from ...types import Response
+
+
+def _get_kwargs(
+    tenant_id: str,
+) -> dict[str, Any]:
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/tenants/{tenant_id}/keys".format(
+            tenant_id=quote(str(tenant_id), safe=""),
+        ),
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> ErrorBody | ListResponseKeyInfo | None:
+    if response.status_code == 200:
+        response_200 = ListResponseKeyInfo.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 401:
+        response_401 = ErrorBody.from_dict(response.json())
+
+        return response_401
+
+    if response.status_code == 403:
+        response_403 = ErrorBody.from_dict(response.json())
+
+        return response_403
+
+    if response.status_code == 500:
+        response_500 = ErrorBody.from_dict(response.json())
+
+        return response_500
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[ErrorBody | ListResponseKeyInfo]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    tenant_id: str,
+    *,
+    client: AuthenticatedClient,
+) -> Response[ErrorBody | ListResponseKeyInfo]:
+    """GET /tenants/:tenant_id/keys — list keys scoped to one tenant (CLOACI-T-0784).
+    Tenant-admin self-service; authZ (`TenantParam + Admin`) is enforced by the
+    route-table middleware, so the caller is already confined to `tenant_id`.
+
+    Args:
+        tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[ErrorBody | ListResponseKeyInfo]
+    """
+
+    kwargs = _get_kwargs(
+        tenant_id=tenant_id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    tenant_id: str,
+    *,
+    client: AuthenticatedClient,
+) -> ErrorBody | ListResponseKeyInfo | None:
+    """GET /tenants/:tenant_id/keys — list keys scoped to one tenant (CLOACI-T-0784).
+    Tenant-admin self-service; authZ (`TenantParam + Admin`) is enforced by the
+    route-table middleware, so the caller is already confined to `tenant_id`.
+
+    Args:
+        tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        ErrorBody | ListResponseKeyInfo
+    """
+
+    return sync_detailed(
+        tenant_id=tenant_id,
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    tenant_id: str,
+    *,
+    client: AuthenticatedClient,
+) -> Response[ErrorBody | ListResponseKeyInfo]:
+    """GET /tenants/:tenant_id/keys — list keys scoped to one tenant (CLOACI-T-0784).
+    Tenant-admin self-service; authZ (`TenantParam + Admin`) is enforced by the
+    route-table middleware, so the caller is already confined to `tenant_id`.
+
+    Args:
+        tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[ErrorBody | ListResponseKeyInfo]
+    """
+
+    kwargs = _get_kwargs(
+        tenant_id=tenant_id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    tenant_id: str,
+    *,
+    client: AuthenticatedClient,
+) -> ErrorBody | ListResponseKeyInfo | None:
+    """GET /tenants/:tenant_id/keys — list keys scoped to one tenant (CLOACI-T-0784).
+    Tenant-admin self-service; authZ (`TenantParam + Admin`) is enforced by the
+    route-table middleware, so the caller is already confined to `tenant_id`.
+
+    Args:
+        tenant_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        ErrorBody | ListResponseKeyInfo
+    """
+
+    return (
+        await asyncio_detailed(
+            tenant_id=tenant_id,
+            client=client,
+        )
+    ).parsed

--- a/clients/python/src/cloacina_client/_generated/api/keys/revoke_tenant_key.py
+++ b/clients/python/src/cloacina_client/_generated/api/keys/revoke_tenant_key.py
@@ -1,0 +1,206 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.error_body import ErrorBody
+from ...models.key_revoked_response import KeyRevokedResponse
+from ...types import Response
+
+
+def _get_kwargs(
+    tenant_id: str,
+    key_id: str,
+) -> dict[str, Any]:
+
+    _kwargs: dict[str, Any] = {
+        "method": "delete",
+        "url": "/v1/tenants/{tenant_id}/keys/{key_id}".format(
+            tenant_id=quote(str(tenant_id), safe=""),
+            key_id=quote(str(key_id), safe=""),
+        ),
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> ErrorBody | KeyRevokedResponse | None:
+    if response.status_code == 200:
+        response_200 = KeyRevokedResponse.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 400:
+        response_400 = ErrorBody.from_dict(response.json())
+
+        return response_400
+
+    if response.status_code == 401:
+        response_401 = ErrorBody.from_dict(response.json())
+
+        return response_401
+
+    if response.status_code == 403:
+        response_403 = ErrorBody.from_dict(response.json())
+
+        return response_403
+
+    if response.status_code == 404:
+        response_404 = ErrorBody.from_dict(response.json())
+
+        return response_404
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[ErrorBody | KeyRevokedResponse]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    tenant_id: str,
+    key_id: str,
+    *,
+    client: AuthenticatedClient,
+) -> Response[ErrorBody | KeyRevokedResponse]:
+    """DELETE /tenants/:tenant_id/keys/:key_id — revoke a key owned by one tenant
+    (CLOACI-T-0784). The middleware confines the caller to `tenant_id`; this
+    handler additionally verifies the target key belongs to that tenant before
+    revoking. A cross-tenant or unknown id is reported as not-found (never
+    revoked) so a tenant-admin can't probe or touch another tenant's keys.
+
+    Args:
+        tenant_id (str):
+        key_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[ErrorBody | KeyRevokedResponse]
+    """
+
+    kwargs = _get_kwargs(
+        tenant_id=tenant_id,
+        key_id=key_id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    tenant_id: str,
+    key_id: str,
+    *,
+    client: AuthenticatedClient,
+) -> ErrorBody | KeyRevokedResponse | None:
+    """DELETE /tenants/:tenant_id/keys/:key_id — revoke a key owned by one tenant
+    (CLOACI-T-0784). The middleware confines the caller to `tenant_id`; this
+    handler additionally verifies the target key belongs to that tenant before
+    revoking. A cross-tenant or unknown id is reported as not-found (never
+    revoked) so a tenant-admin can't probe or touch another tenant's keys.
+
+    Args:
+        tenant_id (str):
+        key_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        ErrorBody | KeyRevokedResponse
+    """
+
+    return sync_detailed(
+        tenant_id=tenant_id,
+        key_id=key_id,
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    tenant_id: str,
+    key_id: str,
+    *,
+    client: AuthenticatedClient,
+) -> Response[ErrorBody | KeyRevokedResponse]:
+    """DELETE /tenants/:tenant_id/keys/:key_id — revoke a key owned by one tenant
+    (CLOACI-T-0784). The middleware confines the caller to `tenant_id`; this
+    handler additionally verifies the target key belongs to that tenant before
+    revoking. A cross-tenant or unknown id is reported as not-found (never
+    revoked) so a tenant-admin can't probe or touch another tenant's keys.
+
+    Args:
+        tenant_id (str):
+        key_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[ErrorBody | KeyRevokedResponse]
+    """
+
+    kwargs = _get_kwargs(
+        tenant_id=tenant_id,
+        key_id=key_id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    tenant_id: str,
+    key_id: str,
+    *,
+    client: AuthenticatedClient,
+) -> ErrorBody | KeyRevokedResponse | None:
+    """DELETE /tenants/:tenant_id/keys/:key_id — revoke a key owned by one tenant
+    (CLOACI-T-0784). The middleware confines the caller to `tenant_id`; this
+    handler additionally verifies the target key belongs to that tenant before
+    revoking. A cross-tenant or unknown id is reported as not-found (never
+    revoked) so a tenant-admin can't probe or touch another tenant's keys.
+
+    Args:
+        tenant_id (str):
+        key_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        ErrorBody | KeyRevokedResponse
+    """
+
+    return (
+        await asyncio_detailed(
+            tenant_id=tenant_id,
+            key_id=key_id,
+            client=client,
+        )
+    ).parsed

--- a/clients/python/src/cloacina_client/_generated/models/__init__.py
+++ b/clients/python/src/cloacina_client/_generated/models/__init__.py
@@ -1,8 +1,11 @@
 """Contains all the data models used in inputs/outputs"""
 
+from .account_action_response import AccountActionResponse
+from .account_info import AccountInfo
 from .accumulator_status import AccumulatorStatus
 from .agent_info import AgentInfo
 from .compiler_status import CompilerStatus
+from .create_account_request import CreateAccountRequest
 from .create_key_request import CreateKeyRequest
 from .create_tenant_request import CreateTenantRequest
 from .declared_surface import DeclaredSurface
@@ -34,6 +37,8 @@ from .key_created_response import KeyCreatedResponse
 from .key_info import KeyInfo
 from .key_revoked_response import KeyRevokedResponse
 from .key_role import KeyRole
+from .list_response_account_info import ListResponseAccountInfo
+from .list_response_account_info_items_item import ListResponseAccountInfoItemsItem
 from .list_response_accumulator_status import ListResponseAccumulatorStatus
 from .list_response_accumulator_status_items_item import (
     ListResponseAccumulatorStatusItemsItem,
@@ -53,11 +58,15 @@ from .list_response_reactor_status import ListResponseReactorStatus
 from .list_response_reactor_status_items_item import ListResponseReactorStatusItemsItem
 from .list_response_tenant_summary import ListResponseTenantSummary
 from .list_response_tenant_summary_items_item import ListResponseTenantSummaryItemsItem
+from .local_login_request import LocalLoginRequest
+from .local_login_response import LocalLoginResponse
+from .logout_response import LogoutResponse
 from .package_upload_form import PackageUploadForm
 from .reactor_fire import ReactorFire
 from .reactor_fire_inputs import ReactorFireInputs
 from .reactor_fire_timeseries import ReactorFireTimeseries
 from .reactor_status import ReactorStatus
+from .reset_password_request import ResetPasswordRequest
 from .task_execution_detail import TaskExecutionDetail
 from .tenant_created_response import TenantCreatedResponse
 from .tenant_list_response_execution_summary import TenantListResponseExecutionSummary
@@ -81,6 +90,7 @@ from .trigger_execution import TriggerExecution
 from .trigger_pause_response import TriggerPauseResponse
 from .trigger_schedule_info import TriggerScheduleInfo
 from .trigger_schedule_summary import TriggerScheduleSummary
+from .whoami_response import WhoamiResponse
 from .workflow_deleted_response import WorkflowDeletedResponse
 from .workflow_detail import WorkflowDetail
 from .workflow_pause_response import WorkflowPauseResponse
@@ -92,9 +102,12 @@ from .workflow_uploaded_response import WorkflowUploadedResponse
 from .ws_ticket_response import WsTicketResponse
 
 __all__ = (
+    "AccountActionResponse",
+    "AccountInfo",
     "AccumulatorStatus",
     "AgentInfo",
     "CompilerStatus",
+    "CreateAccountRequest",
     "CreateKeyRequest",
     "CreateTenantRequest",
     "DeclaredSurface",
@@ -126,6 +139,8 @@ __all__ = (
     "KeyInfo",
     "KeyRevokedResponse",
     "KeyRole",
+    "ListResponseAccountInfo",
+    "ListResponseAccountInfoItemsItem",
     "ListResponseAccumulatorStatus",
     "ListResponseAccumulatorStatusItemsItem",
     "ListResponseAgentInfo",
@@ -141,11 +156,15 @@ __all__ = (
     "ListResponseReactorStatusItemsItem",
     "ListResponseTenantSummary",
     "ListResponseTenantSummaryItemsItem",
+    "LocalLoginRequest",
+    "LocalLoginResponse",
+    "LogoutResponse",
     "PackageUploadForm",
     "ReactorFire",
     "ReactorFireInputs",
     "ReactorFireTimeseries",
     "ReactorStatus",
+    "ResetPasswordRequest",
     "TaskExecutionDetail",
     "TenantCreatedResponse",
     "TenantListResponseExecutionSummary",
@@ -161,6 +180,7 @@ __all__ = (
     "TriggerPauseResponse",
     "TriggerScheduleInfo",
     "TriggerScheduleSummary",
+    "WhoamiResponse",
     "WorkflowDeletedResponse",
     "WorkflowDetail",
     "WorkflowPauseResponse",

--- a/clients/python/src/cloacina_client/_generated/models/account_action_response.py
+++ b/clients/python/src/cloacina_client/_generated/models/account_action_response.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="AccountActionResponse")
+
+
+@_attrs_define
+class AccountActionResponse:
+    """Outcome of a disable/reset action.
+
+    Attributes:
+        id (str):
+        status (str):
+    """
+
+    id: str
+    status: str
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        id = self.id
+
+        status = self.status
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "id": id,
+                "status": status,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        id = d.pop("id")
+
+        status = d.pop("status")
+
+        account_action_response = cls(
+            id=id,
+            status=status,
+        )
+
+        account_action_response.additional_properties = d
+        return account_action_response
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/clients/python/src/cloacina_client/_generated/models/account_info.py
+++ b/clients/python/src/cloacina_client/_generated/models/account_info.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="AccountInfo")
+
+
+@_attrs_define
+class AccountInfo:
+    """Public view of a local account (never the password hash).
+
+    Attributes:
+        id (str):
+        role (str):
+        status (str):
+        username (str):
+    """
+
+    id: str
+    role: str
+    status: str
+    username: str
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        id = self.id
+
+        role = self.role
+
+        status = self.status
+
+        username = self.username
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "id": id,
+                "role": role,
+                "status": status,
+                "username": username,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        id = d.pop("id")
+
+        role = d.pop("role")
+
+        status = d.pop("status")
+
+        username = d.pop("username")
+
+        account_info = cls(
+            id=id,
+            role=role,
+            status=status,
+            username=username,
+        )
+
+        account_info.additional_properties = d
+        return account_info
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/clients/python/src/cloacina_client/_generated/models/create_account_request.py
+++ b/clients/python/src/cloacina_client/_generated/models/create_account_request.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="CreateAccountRequest")
+
+
+@_attrs_define
+class CreateAccountRequest:
+    """Create a local account in a tenant.
+
+    Attributes:
+        password (str):
+        role (str):
+        username (str):
+    """
+
+    password: str
+    role: str
+    username: str
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        password = self.password
+
+        role = self.role
+
+        username = self.username
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "password": password,
+                "role": role,
+                "username": username,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        password = d.pop("password")
+
+        role = d.pop("role")
+
+        username = d.pop("username")
+
+        create_account_request = cls(
+            password=password,
+            role=role,
+            username=username,
+        )
+
+        create_account_request.additional_properties = d
+        return create_account_request
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/clients/python/src/cloacina_client/_generated/models/list_response_account_info.py
+++ b/clients/python/src/cloacina_client/_generated/models/list_response_account_info.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+if TYPE_CHECKING:
+    from ..models.list_response_account_info_items_item import (
+        ListResponseAccountInfoItemsItem,
+    )
+
+
+T = TypeVar("T", bound="ListResponseAccountInfo")
+
+
+@_attrs_define
+class ListResponseAccountInfo:
+    """Unified list envelope (CLOACI-T-0594 / API-03): every list endpoint
+    returns `{items, total}`. `total` is best-effort — it equals the
+    returned page size when the server doesn't run a separate COUNT.
+
+        Attributes:
+            items (list[ListResponseAccountInfoItemsItem]):
+            total (int):
+    """
+
+    items: list[ListResponseAccountInfoItemsItem]
+    total: int
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        items = []
+        for items_item_data in self.items:
+            items_item = items_item_data.to_dict()
+            items.append(items_item)
+
+        total = self.total
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "items": items,
+                "total": total,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.list_response_account_info_items_item import (
+            ListResponseAccountInfoItemsItem,
+        )
+
+        d = dict(src_dict)
+        items = []
+        _items = d.pop("items")
+        for items_item_data in _items:
+            items_item = ListResponseAccountInfoItemsItem.from_dict(items_item_data)
+
+            items.append(items_item)
+
+        total = d.pop("total")
+
+        list_response_account_info = cls(
+            items=items,
+            total=total,
+        )
+
+        list_response_account_info.additional_properties = d
+        return list_response_account_info
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/clients/python/src/cloacina_client/_generated/models/list_response_account_info_items_item.py
+++ b/clients/python/src/cloacina_client/_generated/models/list_response_account_info_items_item.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="ListResponseAccountInfoItemsItem")
+
+
+@_attrs_define
+class ListResponseAccountInfoItemsItem:
+    """Public view of a local account (never the password hash).
+
+    Attributes:
+        id (str):
+        role (str):
+        status (str):
+        username (str):
+    """
+
+    id: str
+    role: str
+    status: str
+    username: str
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        id = self.id
+
+        role = self.role
+
+        status = self.status
+
+        username = self.username
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "id": id,
+                "role": role,
+                "status": status,
+                "username": username,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        id = d.pop("id")
+
+        role = d.pop("role")
+
+        status = d.pop("status")
+
+        username = d.pop("username")
+
+        list_response_account_info_items_item = cls(
+            id=id,
+            role=role,
+            status=status,
+            username=username,
+        )
+
+        list_response_account_info_items_item.additional_properties = d
+        return list_response_account_info_items_item
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/clients/python/src/cloacina_client/_generated/models/local_login_request.py
+++ b/clients/python/src/cloacina_client/_generated/models/local_login_request.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="LocalLoginRequest")
+
+
+@_attrs_define
+class LocalLoginRequest:
+    """A local-login attempt. `tenant` selects which tenant's account namespace to
+    authenticate against (`None` = a global account).
+
+        Attributes:
+            password (str):
+            username (str):
+            tenant (None | str | Unset):
+    """
+
+    password: str
+    username: str
+    tenant: None | str | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        password = self.password
+
+        username = self.username
+
+        tenant: None | str | Unset
+        if isinstance(self.tenant, Unset):
+            tenant = UNSET
+        else:
+            tenant = self.tenant
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "password": password,
+                "username": username,
+            }
+        )
+        if tenant is not UNSET:
+            field_dict["tenant"] = tenant
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        password = d.pop("password")
+
+        username = d.pop("username")
+
+        def _parse_tenant(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        tenant = _parse_tenant(d.pop("tenant", UNSET))
+
+        local_login_request = cls(
+            password=password,
+            username=username,
+            tenant=tenant,
+        )
+
+        local_login_request.additional_properties = d
+        return local_login_request
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/clients/python/src/cloacina_client/_generated/models/local_login_response.py
+++ b/clients/python/src/cloacina_client/_generated/models/local_login_response.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="LocalLoginResponse")
+
+
+@_attrs_define
+class LocalLoginResponse:
+    """A successful local login. `key` is the minted bearer key — shown exactly
+    once; the SPA stores it (sessionStorage) and presents it as `Bearer`.
+
+        Attributes:
+            key (str):
+            role (str):
+            expires_at (None | str | Unset):
+            tenant_id (None | str | Unset):
+    """
+
+    key: str
+    role: str
+    expires_at: None | str | Unset = UNSET
+    tenant_id: None | str | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        key = self.key
+
+        role = self.role
+
+        expires_at: None | str | Unset
+        if isinstance(self.expires_at, Unset):
+            expires_at = UNSET
+        else:
+            expires_at = self.expires_at
+
+        tenant_id: None | str | Unset
+        if isinstance(self.tenant_id, Unset):
+            tenant_id = UNSET
+        else:
+            tenant_id = self.tenant_id
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "key": key,
+                "role": role,
+            }
+        )
+        if expires_at is not UNSET:
+            field_dict["expires_at"] = expires_at
+        if tenant_id is not UNSET:
+            field_dict["tenant_id"] = tenant_id
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        key = d.pop("key")
+
+        role = d.pop("role")
+
+        def _parse_expires_at(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        expires_at = _parse_expires_at(d.pop("expires_at", UNSET))
+
+        def _parse_tenant_id(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        tenant_id = _parse_tenant_id(d.pop("tenant_id", UNSET))
+
+        local_login_response = cls(
+            key=key,
+            role=role,
+            expires_at=expires_at,
+            tenant_id=tenant_id,
+        )
+
+        local_login_response.additional_properties = d
+        return local_login_response
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/clients/python/src/cloacina_client/_generated/models/logout_response.py
+++ b/clients/python/src/cloacina_client/_generated/models/logout_response.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="LogoutResponse")
+
+
+@_attrs_define
+class LogoutResponse:
+    """
+    Attributes:
+        status (str):
+    """
+
+    status: str
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        status = self.status
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "status": status,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        status = d.pop("status")
+
+        logout_response = cls(
+            status=status,
+        )
+
+        logout_response.additional_properties = d
+        return logout_response
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/clients/python/src/cloacina_client/_generated/models/reset_password_request.py
+++ b/clients/python/src/cloacina_client/_generated/models/reset_password_request.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="ResetPasswordRequest")
+
+
+@_attrs_define
+class ResetPasswordRequest:
+    """Reset a local account's password (admin-reset-only, OQ-12).
+
+    Attributes:
+        password (str):
+    """
+
+    password: str
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        password = self.password
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "password": password,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        password = d.pop("password")
+
+        reset_password_request = cls(
+            password=password,
+        )
+
+        reset_password_request.additional_properties = d
+        return reset_password_request
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/clients/python/src/cloacina_client/_generated/models/whoami_response.py
+++ b/clients/python/src/cloacina_client/_generated/models/whoami_response.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="WhoamiResponse")
+
+
+@_attrs_define
+class WhoamiResponse:
+    """The caller's own identity + role (CLOACI-T-0803) — lets the UI gate
+    write/admin controls to the key's role instead of offering actions that
+    would 403.
+
+        Attributes:
+            is_admin (bool): God-mode flag (cross-tenant platform admin).
+            name (str): The key's display name.
+            role (str): Role within the tenant: `read` | `write` | `admin`.
+            tenant_id (None | str | Unset): Tenant the key is scoped to (`None` = global/public).
+    """
+
+    is_admin: bool
+    name: str
+    role: str
+    tenant_id: None | str | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        is_admin = self.is_admin
+
+        name = self.name
+
+        role = self.role
+
+        tenant_id: None | str | Unset
+        if isinstance(self.tenant_id, Unset):
+            tenant_id = UNSET
+        else:
+            tenant_id = self.tenant_id
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "is_admin": is_admin,
+                "name": name,
+                "role": role,
+            }
+        )
+        if tenant_id is not UNSET:
+            field_dict["tenant_id"] = tenant_id
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        is_admin = d.pop("is_admin")
+
+        name = d.pop("name")
+
+        role = d.pop("role")
+
+        def _parse_tenant_id(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        tenant_id = _parse_tenant_id(d.pop("tenant_id", UNSET))
+
+        whoami_response = cls(
+            is_admin=is_admin,
+            name=name,
+            role=role,
+            tenant_id=tenant_id,
+        )
+
+        whoami_response.additional_properties = d
+        return whoami_response
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/crates/cloacina-client/src/lib.rs
+++ b/crates/cloacina-client/src/lib.rs
@@ -311,9 +311,134 @@ impl Client {
         .await
     }
 
+    /// List the keys scoped to one tenant — tenant-admin self-service
+    /// (CLOACI-T-0784).
+    pub async fn list_tenant_keys(
+        &self,
+        tenant: Option<&str>,
+    ) -> Result<ListResponse<KeyInfo>, ClientError> {
+        let t = self.tenant_of(tenant);
+        self.get_json(&format!("/v1/tenants/{t}/keys")).await
+    }
+
+    /// Revoke a key owned by one tenant — tenant-admin self-service
+    /// (CLOACI-T-0784). A cross-tenant or unknown id is reported as
+    /// not-found.
+    pub async fn revoke_tenant_key(
+        &self,
+        key_id: &str,
+        tenant: Option<&str>,
+    ) -> Result<KeyRevokedResponse, ClientError> {
+        let t = self.tenant_of(tenant);
+        let response = self
+            .request(Method::DELETE, &format!("/v1/tenants/{t}/keys/{key_id}"))
+            .send()
+            .await
+            .map_err(ClientError::from_reqwest)?;
+        Self::parse(response).await
+    }
+
     /// Mint a single-use, short-lived WebSocket ticket.
     pub async fn create_ws_ticket(&self) -> Result<WsTicketResponse, ClientError> {
         self.post_json("/v1/auth/ws-ticket", &Value::Null).await
+    }
+
+    // ---- session / local auth (CLOACI-T-0794/0796/0803) ----
+    //
+    // These DTOs live in `cloacina-server` (not the shared `cloacina-api-types`
+    // contract crate), so the client returns the raw JSON `Value` — the same
+    // escape-hatch shape `get_json`/`post_json` already expose for routes whose
+    // typed DTO isn't on the wire-contract crate.
+
+    /// Username/password login — returns a minted bearer key (the JSON body
+    /// carries `key`, `tenant_id`, `role`, `expires_at`).
+    pub async fn local_login(
+        &self,
+        username: &str,
+        password: &str,
+        tenant: Option<&str>,
+    ) -> Result<Value, ClientError> {
+        let body = serde_json::json!({
+            "username": username,
+            "password": password,
+            "tenant": tenant,
+        });
+        self.post_json("/v1/auth/local/login", &body).await
+    }
+
+    /// Silently re-mint the caller's short-TTL key before it expires.
+    pub async fn refresh(&self) -> Result<Value, ClientError> {
+        self.post_json("/v1/auth/refresh", &Value::Null).await
+    }
+
+    /// Revoke the caller's key + forget any refresh session.
+    pub async fn logout(&self) -> Result<Value, ClientError> {
+        self.post_json("/v1/auth/logout", &Value::Null).await
+    }
+
+    /// The caller's own tenant + role + admin flag.
+    pub async fn whoami(&self) -> Result<Value, ClientError> {
+        self.get_json("/v1/auth/whoami").await
+    }
+
+    // ---- local accounts: tenant-admin management (CLOACI-T-0797) ----
+
+    /// List a tenant's local accounts (never the password hash).
+    pub async fn list_accounts(&self, tenant: Option<&str>) -> Result<Value, ClientError> {
+        let t = self.tenant_of(tenant);
+        self.get_json(&format!("/v1/tenants/{t}/accounts")).await
+    }
+
+    /// Create a local account in a tenant.
+    pub async fn create_account(
+        &self,
+        username: &str,
+        password: &str,
+        role: &str,
+        tenant: Option<&str>,
+    ) -> Result<Value, ClientError> {
+        let t = self.tenant_of(tenant);
+        let body = serde_json::json!({
+            "username": username,
+            "password": password,
+            "role": role,
+        });
+        self.post_json(&format!("/v1/tenants/{t}/accounts"), &body)
+            .await
+    }
+
+    /// Disable (not hard-delete) a local account, preserving history.
+    pub async fn disable_account(
+        &self,
+        account_id: &str,
+        tenant: Option<&str>,
+    ) -> Result<Value, ClientError> {
+        let t = self.tenant_of(tenant);
+        let response = self
+            .request(
+                Method::DELETE,
+                &format!("/v1/tenants/{t}/accounts/{account_id}"),
+            )
+            .send()
+            .await
+            .map_err(ClientError::from_reqwest)?;
+        Self::parse(response).await
+    }
+
+    /// Admin-reset a local account's password.
+    pub async fn reset_password(
+        &self,
+        account_id: &str,
+        password: &str,
+        tenant: Option<&str>,
+    ) -> Result<Value, ClientError> {
+        let t = self.tenant_of(tenant);
+        let body = serde_json::json!({ "password": password });
+        self.post_json(
+            &format!("/v1/tenants/{t}/accounts/{account_id}/password"),
+            &body,
+        )
+        .await
     }
 
     // ---- tenants ----

--- a/ui/src/routes/Connect.tsx
+++ b/ui/src/routes/Connect.tsx
@@ -286,7 +286,7 @@ export function Connect() {
             }}
             data={[
               { label: "Username & password", value: "password" },
-              { label: "API key", value: "key" },
+              { label: "Key", value: "key" },
               { label: "SSO", value: "sso" },
             ]}
           />


### PR DESCRIPTION
Two regressions from the 0.9.0 auth model, surfaced by **nightly-only** jobs the PR CI never ran (both green on the prior nightly) — they blocked the v0.9.0 release nightly gate.

## SDK Contract Matrix
The Rust + Python client SDKs were missing the **entire 0.9.0 auth surface** (local accounts + tenant-scoped keys); only TypeScript had it. Static coverage gate showed 19 violations.
- **Python** (generated): regenerated `_generated/` from `docs/static/openapi.json` (openapi-python-client 0.29.0) → `api/auth/*` + `api/keys/{list_tenant_keys,revoke_tenant_key}` + models; added matching facade methods on `Client` in `_client.py`.
- **Rust** (hand-written `cloacina-client`): added 10 methods (`list_tenant_keys`, `revoke_tenant_key`, `local_login`, `refresh`, `logout`, `whoami`, `list_accounts`, `create_account`, `disable_account`, `reset_password`) using the existing `get_json`/`post_json`/`delete_path` + `tenant_of` conventions.
- Verified: `scripts/check_sdk_coverage.py` → **50 spec operations reachable from all 3 SDKs** (was 19 violations); `cargo build -p cloacina-client` clean.

## UI Acceptance E2E
The new auth-mode `SegmentedControl` option labeled `"API key"` collided with the key input (also `"API key"`), making `getByLabel("API key")` a strict-mode violation → 4 connect/local-auth specs failed. Renamed the option to `"Key"` (the input the tests target stays `"API key"`); also fixes the a11y duplicate accessible-name.

## Note
These checks are nightly-only, so this PR's CI confirms nothing breaks; the actual contract/E2E fix is re-validated by the v0.9.0 release nightly after merge.

https://claude.ai/code/session_01JUdetbkL4byTEJyYM3HPdJ