### PR TITLE
fix(ci): harden UI e2e DB setup against postgres init-restart race

### DIFF
--- a/.angreal/test/e2e/ui_e2e.py
+++ b/.angreal/test/e2e/ui_e2e.py
@@ -69,12 +69,25 @@ def _run(cmd, cwd=PROJECT_ROOT, env=None):
 
 
 def _fresh_database():
-    subprocess.run(
-        ["docker", "compose", "-f", str(COMPOSE_FILE), "exec", "-T", "postgres",
-         "psql", "-U", "cloacina", "-d", "postgres",
-         "-c", "DROP DATABASE IF EXISTS cloacina WITH (FORCE);",
-         "-c", "CREATE DATABASE cloacina OWNER cloacina;"],
-        check=True, capture_output=True,
+    # `_start_postgres` waits on `pg_isready`, but Postgres can still bounce
+    # during its init-restart window right after that passes — so a single
+    # DROP/CREATE can race a not-yet-stable server and fail with a transient
+    # connection error (exit 56). Retry a few times rather than killing the
+    # whole UI e2e run on a flake; the SQL is idempotent so re-running is safe.
+    last = None
+    for _ in range(10):
+        last = subprocess.run(
+            ["docker", "compose", "-f", str(COMPOSE_FILE), "exec", "-T", "postgres",
+             "psql", "-U", "cloacina", "-d", "postgres",
+             "-c", "DROP DATABASE IF EXISTS cloacina WITH (FORCE);",
+             "-c", "CREATE DATABASE cloacina OWNER cloacina;"],
+            capture_output=True,
+        )
+        if last.returncode == 0:
+            return
+        time.sleep(2)
+    raise subprocess.CalledProcessError(
+        last.returncode, last.args, output=last.stdout, stderr=last.stderr
     )
 
 


### PR DESCRIPTION
The v0.9.0 release nightly failed on **UI Acceptance E2E**, but it was a flaky infra race, **not a test/code failure** (SDK Contract is green; the Playwright stage was never reached).

`_fresh_database()` ran a single `DROP/CREATE` `psql` (check=True) immediately after `_start_postgres()`. `_start_postgres` waits on `pg_isready`, but Postgres can bounce during its init-restart window *after* `pg_isready` first passes, so the `psql` intermittently raced a not-yet-stable server → transient connection error (exit 56) → the whole UI e2e job died before Playwright ran. (The prior nightly got *past* this to the Playwright stage — proof it is intermittent.)

Fix: retry the idempotent `DROP/CREATE` up to 10× with a 2s backoff; raise the real error only if Postgres never stabilizes. Verified by the v0.9.0 re-cut nightly.

https://claude.ai/code/session_01JUdetbkL4byTEJyYM3HPdJ