### PR TITLE
fix(ci): seed the acme tenant-admin key in UI e2e harness

### DIFF
--- a/.angreal/test/e2e/ui_e2e.py
+++ b/.angreal/test/e2e/ui_e2e.py
@@ -230,7 +230,20 @@ def _ui_e2e(smoke: bool) -> int:
         ]
         preview_cmd = ["npx", "vite", "preview", "--port", str(PREVIEW_PORT), "--strictPort"]
 
-        with _process(server_cmd, home / "server.log") as server:
+        # Seed the demo tenants/keys the auth specs connect with — the acme
+        # tenant-admin (clk_demo_acme_key_0002) + public — matching
+        # docker-compose.demo.yml. Without this the acme tenant/key never exist,
+        # so tenant-admin.spec.ts / local-auth.spec.ts can't sign in and connect
+        # never reaches Overview. (CLOACI-T-0787)
+        server_env = {
+            **os.environ,
+            "CLOACINA_DEMO_TENANT_KEYS": (
+                "public:clk_demo_public_key_0003:admin,"
+                "acme:clk_demo_acme_key_0002:admin"
+            ),
+        }
+
+        with _process(server_cmd, home / "server.log", env=server_env) as server:
             _wait_http(f"{SERVER_URL}/health", proc=server)
             with _process(compiler_cmd, home / "compiler.log"), \
                  _process(preview_cmd, home / "preview.log", cwd=UI_DIR) as preview:


### PR DESCRIPTION
Third nightly-surfaced gap in the v0.9.0 release (these checks never ran in PR CI).

`tenant-admin.spec.ts` / `local-auth.spec.ts` connect as the **acme tenant-admin** (`clk_demo_acme_key_0002`), but the UI e2e harness started `cloacina-server` with only `--bootstrap-key` — **no `CLOACINA_DEMO_TENANT_KEYS`** — so the `acme` tenant + admin key never existed and connect timed out before Overview. The demo stack (`docker-compose.demo.yml`) seeds exactly this; the harness omitted it.

Fix: pass `CLOACINA_DEMO_TENANT_KEYS=public:clk_demo_public_key_0003:admin,acme:clk_demo_acme_key_0002:admin` to the harness server so it seeds those on boot (`bootstrap_demo_tenant_keys`, lib.rs:1653), matching the demo.

Surfaced only after #143 (label) + #145 (DB race) let Playwright reach these specs (16 passed, 3 failed at the acme connect). Re-validated by the v0.9.0 re-cut nightly.

https://claude.ai/code/session_01JUdetbkL4byTEJyYM3HPdJ