### PR TITLE
fix(ci): exact Username/Password locators in local-auth e2e (mode-picker collision)

### DIFF
--- a/ui/e2e/local-auth.spec.ts
+++ b/ui/e2e/local-auth.spec.ts
@@ -36,7 +36,7 @@ test("self-manage: tenant-admin creates a local account, then that user signs in
   // 2. Create a local account for the tenant.
   await page.goto("/accounts");
   await expect(page.getByRole("heading", { name: "Local accounts" })).toBeVisible();
-  await page.getByLabel("Username").fill(username);
+  await page.getByLabel("Username", { exact: true }).fill(username);
   await page.getByLabel("Initial password").fill(password);
   await page.getByRole("button", { name: "Create" }).click();
   // The new account appears in the list (active).
@@ -47,8 +47,8 @@ test("self-manage: tenant-admin creates a local account, then that user signs in
   await page.goto("/connect");
   await page.getByText("Username & password").click();
   await page.getByLabel("Server URL").fill(SERVER_URL);
-  await page.getByLabel("Username").fill(username);
-  await page.getByLabel("Password").fill(password);
+  await page.getByLabel("Username", { exact: true }).fill(username);
+  await page.getByLabel("Password", { exact: true }).fill(password);
   await page.getByLabel("Tenant").fill(ACME_TENANT);
   await page.getByRole("button", { name: "Sign in" }).click();
 
@@ -62,8 +62,8 @@ test("self-manage: wrong password is rejected", async ({ page }) => {
   await page.goto("/connect");
   await page.getByText("Username & password").click();
   await page.getByLabel("Server URL").fill(SERVER_URL);
-  await page.getByLabel("Username").fill("definitely-not-a-user");
-  await page.getByLabel("Password").fill("nope");
+  await page.getByLabel("Username", { exact: true }).fill("definitely-not-a-user");
+  await page.getByLabel("Password", { exact: true }).fill("nope");
   await page.getByLabel("Tenant").fill(ACME_TENANT);
   await page.getByRole("button", { name: "Sign in" }).click();
 


### PR DESCRIPTION
The acme-tenant + Accounts-heading fixes (#147) let UI e2e finally reach the local-account **sign-in** step (17 passed, up from 16) — which then hit the *same* class as the original "API key" collision: the `"Username & password"` auth-mode radio matches `getByLabel("Username")`/`("Password")` by substring → 2 elements → strict-mode violation (2 specs).

Fix: exact locators on the Username/Password *inputs* so they dont match the mode picker. Audited all e2e specs — only `local-auth` used these, now all exact; no other collision remains. Re-validated by the v0.9.0 re-cut nightly.

https://claude.ai/code/session_01JUdetbkL4byTEJyYM3HPdJ