### PR TITLE
ci(release): drop x86_64-apple-darwin (Intel macOS) binary

### DIFF
--- a/.github/workflows/unified_release.yml
+++ b/.github/workflows/unified_release.yml
@@ -392,12 +392,8 @@ jobs:
           - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
             cross: false
-          # Intel runner for the x86_64 leg (CLOACI-T-0807) — macos-latest is
-          # Apple Silicon, so `brew install libpq` yields ARM64 libpq and the
-          # x86_64 link fails (undefined _PQ* symbols).
-          - os: macos-13
-            target: x86_64-apple-darwin
-            cross: false
+          # x86_64-apple-darwin (Intel macOS) intentionally dropped — EOL target
+          # + scarce macos-13 runners; aarch64 (Apple Silicon) covers modern Macs.
           - os: macos-latest
             target: aarch64-apple-darwin
             cross: false


### PR DESCRIPTION
Intel macOS is an EOL target and the `macos-13` Intel runners are scarce — the v0.9.0 backfill job for this leg sat queued indefinitely and never scheduled. Apple Silicon (`aarch64-apple-darwin`) covers modern Macs; `x86_64-unknown-linux-gnu` + `aarch64-unknown-linux-gnu` cover the rest.

Drops `x86_64-apple-darwin` from the Build Binary matrix (now 3 legs: x86_64-linux, aarch64-linux, aarch64-darwin). Builds on top of the #150 native-per-arch fix.

Also done out-of-band: cancelled the stuck v0.9.0 backfill run and deleted the one-off `backfill-v0.9.0-binaries` branch. (v0.9.0 already has 3/4 binaries + full cargo/pip/Docker distribution.)

https://claude.ai/code/session_01JUdetbkL4byTEJyYM3HPdJ