### PR TITLE
chore(metis): close out CLOACI-I-0127

### DIFF
--- a/.metis/initiatives/CLOACI-I-0127/initiative.md
+++ b/.metis/initiatives/CLOACI-I-0127/initiative.md
@@ -4,14 +4,14 @@ level: initiative
 title: "Kubernetes-first agent runners — K8s-native fleet with UI-driven agent and tenant assignment"
 short_code: "CLOACI-I-0127"
 created_at: 2026-06-20T02:38:01.431843+00:00
-updated_at: 2026-06-20T02:38:01.431843+00:00
+updated_at: 2026-06-28T16:28:06.161622+00:00
 parent: CLOACI-V-0001
 blocked_by: []
 archived: false
 
 tags:
   - "#initiative"
-  - "#phase/discovery"
+  - "#phase/completed"
 
 
 exit_criteria_met: false


### PR DESCRIPTION
Mark the I-0127 initiative completed now that it is squash-merged to main
(e80c8098) and all child tasks (T-0808..T-0814, T-0817, T-0818) are done.

Metis bookkeeping only — no code change.

https://claude.ai/code/session_01VWpWbgCzNdQkFT74S3wPRM