### PR TITLE
fix: I-0127 doc + message polish (post-merge audit nits)

### DIFF
--- a/crates/cloacina-server/src/lib.rs
+++ b/crates/cloacina-server/src/lib.rs
@@ -846,7 +846,7 @@ pub async fn run(
     .map_err(|e| {
         anyhow::anyhow!(
             "FATAL: fleet actuator (CLOACINA_FLEET_ACTUATOR={actuator_kind}) refused to start \
-             — {e}. Set CLOACINA_FLEET_ACTUATOR to a valid, safe value (none | docker) or fix \
+             — {e}. Set CLOACINA_FLEET_ACTUATOR to a valid, safe value (none | docker | kubernetes) or fix \
              the substrate. The server will not start with a misconfigured actuator."
         )
     })?;

--- a/crates/cloacina-server/src/routes/authz.rs
+++ b/crates/cloacina-server/src/routes/authz.rs
@@ -133,7 +133,8 @@ pub enum ResolvedScope {
 /// The authenticated subject, projected into authorization attributes.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Principal {
-    /// The key's tenant scope. `None` == global/public.
+    /// The key's tenant scope. `None` == a global (admin) key with no tenant;
+    /// `"public"` is a real tenant since CLOACI-T-0817, not `None`.
     pub tenant: Option<String>,
     /// The key's role.
     pub role: Level,
@@ -179,8 +180,9 @@ impl Decision {
 ///
 /// - God-mode (`platform_admin`) short-circuits to [`Decision::Permit`].
 /// - `Platform` scope is god-only → otherwise denied.
-/// - `Tenant(t)` requires the principal to belong to `t` (or be a global key
-///   reaching the reserved `"public"` tenant), then `role >= level`.
+/// - `Tenant(t)` requires the principal to belong to `t` (god-mode passes
+///   above), then `role >= level`. A non-admin global (`None`) key reaches no
+///   tenant — `"public"` is a real tenant since CLOACI-T-0817.
 /// - `Any` requires only `role >= level` (the handler scopes data by tenant).
 pub fn evaluate(principal: &Principal, scope: &ResolvedScope, level: Level) -> Decision {
     // God-mode: cross-tenant superuser passes everything.

--- a/docs/content/service/explanation/execution-agent-fleet.md
+++ b/docs/content/service/explanation/execution-agent-fleet.md
@@ -205,11 +205,13 @@ Two numbers bound a tenant's fleet:
   (`CLOACINA_DEFAULT_MAX_AGENTS`, default 4) unless a platform admin sets a
   per-tenant override. A tenant cannot raise its own ceiling; only provision
   within it.
-- **`desired_count`** — the operational target inside `[floor, effective_limit]`.
-  A tenant self-services it through the
+- **`desired_count`** — the operational target. A tenant self-services it in
+  `[0, effective_limit]` through the
   [fleet API]({{< ref "/reference/http-api" >}}#tenant-agent-fleet) (provision
-  `+1`, deprovision `−1`), and a new tenant is seeded with
-  `min(CLOACINA_INITIAL_AGENTS, CLOACINA_DEFAULT_MAX_AGENTS)` on create.
+  `+1`, deprovision `−1` down to 0), and a new tenant is seeded with
+  `min(CLOACINA_INITIAL_AGENTS, CLOACINA_DEFAULT_MAX_AGENTS)` on create. The
+  autoscaler moves it within `[CLOACINA_AUTOSCALE_FLOOR, effective_limit]` — the
+  floor bounds the autoscaler, not the manual deprovision API.
 
 A **back-pressure autoscaler** can move `desired_count` on its own. It runs as a
 single control loop that, each tick (`CLOACINA_AUTOSCALE_INTERVAL_S`, default

--- a/docs/content/service/how-to/deploy-an-execution-agent-fleet.md
+++ b/docs/content/service/how-to/deploy-an-execution-agent-fleet.md
@@ -166,7 +166,7 @@ substrate (a *FleetActuator*). It is off by default
 
 Each tenant has an **effective limit** — the platform default
 (`CLOACINA_DEFAULT_MAX_AGENTS`, default 4) unless a platform admin grants a
-per-tenant override — and a **`desired_count`** within `[floor, effective_limit]`
+per-tenant override — and a **`desired_count`** in `[0, effective_limit]`
 that a tenant scales for itself via the
 [tenant agent fleet API]({{< ref "/reference/http-api" >}}#tenant-agent-fleet).
 Provisioning only sets the target; an actuator (below) turns it into running


### PR DESCRIPTION
Minor nits from a post-merge doc accuracy audit of the I-0127 fleet docs (audit
found no wrong claims):

- **docs** — the manual fleet API range is `[0, effective_limit]` (manual
  deprovision floors at 0); `CLOACINA_AUTOSCALE_FLOOR` bounds only the autoscaler.
- **lib.rs** — the actuator boot-failure message omitted `kubernetes` from the
  valid values.
- **authz.rs** — two stale comments said `None == global/public`; live logic is
  `None => false` since T-0817 (comments only).

No logic change.

https://claude.ai/code/session_01VWpWbgCzNdQkFT74S3wPRM