### PR TITLE
feat(operators): operator framework — WASM task+trigger operators (CLOACI-I-0132)

### DIFF
--- a/.metis/backlog/features/CLOACI-T-0821.md
+++ b/.metis/backlog/features/CLOACI-T-0821.md
@@ -4,15 +4,15 @@ level: task
 title: "WASM-operator spike: Rust -> WASM-component + configured-load (de-risk)"
 short_code: "CLOACI-T-0821"
 created_at: 2026-06-28T23:57:39.265598+00:00
-updated_at: 2026-06-28T23:57:39.265598+00:00
+updated_at: 2026-06-29T00:58:26.876437+00:00
 parent: CLOACI-I-0132
 blocked_by: []
 archived: false
 
 tags:
   - "#task"
-  - "#phase/backlog"
   - "#feature"
+  - "#phase/completed"
 
 
 exit_criteria_met: false
@@ -66,6 +66,8 @@ De-risk the linchpin: confirm a cloacina-macro-authored operator can compile to 
 - **Current Problems**: {What's difficult/slow/buggy now}
 - **Benefits of Fixing**: {What improves after refactoring}
 - **Risk Assessment**: {Risks of not addressing this}
+
+## Acceptance Criteria
 
 ## Acceptance Criteria **[REQUIRED]**
 
@@ -136,4 +138,85 @@ De-risk the linchpin: confirm a cloacina-macro-authored operator can compile to 
 
 ## Status Updates **[REQUIRED]**
 
-*To be added during implementation*
+### 2026-06-28 — SPIKE PROVEN END-TO-END (de-risked; gates Phase B / contract in T-0822)
+
+A fidius-macro-authored SYNCHRONOUS operator compiles to a wasm32-wasip2 component
+and is loaded **configured** (`load_wasm_configured`) + invoked, all inside cloacina.
+Both host tests PASS. Spike is self-contained + workspace-excluded under
+`examples/wasm-operator-spike/` (removable). NOT committed (per review gate).
+
+**Layout**
+- `examples/wasm-operator-spike/operator-fixture/` — author crate, `crate-type=["cdylib"]`,
+  deps `fidius-guest=0.5.4`, `fidius-macro=0.5.4`, `wit-bindgen=0.44`, `serde`. Standalone
+  (empty `[workspace]`). Built to `target/wasm32-wasip2/release/wasm_operator_fixture.wasm`.
+- `examples/wasm-operator-spike/host-spike/` — host test, dep
+  `fidius-host={version="0.5.4",features=["wasm"]}` + `fidius-macro`/`fidius-core`. Test
+  `tests/operator_wasm_spike.rs` builds the fixture, stages it, loads + invokes.
+
+**Working recipe (verified)**
+1. Author: `#[fidius_macro::plugin_interface(version=1, buffer=PluginAllocated, crate="fidius_guest")]`
+   on a `trait MinimalOperator: Send+Sync { fn apply(&self, input:String)->String; }`;
+   `#[fidius_macro::plugin_impl(MinimalOperator, crate="fidius_guest", config=Config)] impl ...`;
+   plus `impl Configured { fn configure(cfg: Config) -> Self {..} }`. `Config` is
+   `Serialize+Deserialize`.
+2. Build: `rustup target add wasm32-wasip2` (already present here); from the fixture dir
+   `cargo build --target wasm32-wasip2 --release`. ~27s cold.
+3. Validate: `wasm-tools validate --features component-model <wasm>` -> VALID COMPONENT (58,370 bytes).
+   `wasm-tools component wit` shows exports:
+   `apply: func(input: string) -> string`, `fidius-interface-hash: func() -> u64`,
+   `fidius-configure: func(config: list<u8>)`, plus the world export
+   `fidius:minimal-operator/minimal-operator@0.1.0`. Imports: only WASI
+   (`wasi:io/error|streams`, `wasi:cli/environment|exit|stderr`) — deny-by-default, no
+   egress unless declared.
+4. Host load+invoke: host **re-declares the same interface** with `crate="fidius_core"` so the
+   macro emits the matching descriptor `MinimalOperator_WASM_DESCRIPTOR` inside companion module
+   `__fidius_MinimalOperator`. Then
+   `host.load_wasm_configured("wasm-operator-pkg", &__fidius_MinimalOperator::MinimalOperator_WASM_DESCRIPTOR, &Config{op:"prefix"})`,
+   `handle.call_method(0, &("test".to_string(),))` -> `"prefix: test"`. Two instances with
+   `op:"prefix"` vs `op:"suffix"` coexist with independent persistent stores. Both tests green.
+
+**Descriptor symbol**: `<Trait>_WASM_DESCRIPTOR` in module `__fidius_<Trait>` (kebab interface
+export `fidius:<kebab>/<kebab>@0.1.0`). The host links against `descriptor.interface_export`;
+the package.toml `interface` field is metadata only. `interface_version` must match (1).
+Integrity is enforced via the `fidius-interface-hash` export vs `descriptor.interface_hash`.
+
+**Sync constraint (CONFIRMED — central to T-0822 contract)**: WASM guests have no async
+runtime, so operator methods MUST be synchronous primitives-in/out. cloacina's primitives
+(`Task::execute`, `Trigger::poll`, accumulator, reactor) are async today; the right bridge is
+an **async host-side wrapper that awaits a spawn_blocking-style call into the sync WASM
+method** (the wasmtime call is a blocking host call). The existing async `CloacinaPlugin`
+interface is NOT WASM-compatible and must not be the WASM operator trait — define a separate
+minimal sync operator trait for the WASM contract.
+
+**Config binding**: the `configure(cfg)` hook + macro-emitted `fidius-configure` export bind
+config ONCE at load (`load_wasm_configured` serializes config and calls the export onto a
+persistent store). Per-call methods then dispatch on the configured instance — config crosses
+the sandbox exactly once. (Internally a OnceLock-style persistent store per instance.)
+
+**Wire**: bincode; single-arg methods require a 1-tuple `(T,)` — `&("test".to_string(),)`.
+
+**WASI**: deny-by-default. Component imports the standard WASI set even when unused; fidius
+provides a zero-grant WasiCtx. Outbound HTTP egress only if the package declares the `http`
+capability AND the embedder supplies an EgressPolicy.
+
+**wasm-feature weight (relevant to gating the operator-execution crate)**: turning on
+`fidius-host` `wasm` pulls wasmtime 45 + cranelift + wasmtime-wasi(+http) — ~55 wasmtime/cranelift
+crates. Cold compile of the host test was **3m04s**; the host-spike `target/` reached **~1.0 GB**.
+Strong signal: gate WASM behind a feature on the operator-execution crate so cdylib/Python-only
+or non-operator builds stay thin. The guest/author side is light (wit-bindgen + fidius-guest,
+~27s, 58 KB artifact).
+
+**Sharp edges**: (1) benign `unexpected cfg "host"` warning from the macro under
+check-cfg — cosmetic. (2) wit-bindgen pinned 0.44; component-model must be explicitly enabled in
+`wasm-tools validate`. (3) author crate must be a standalone `[workspace]` so `cargo build`
+doesn't attach to the cloacina workspace (and stays workspace-excluded via `examples/*`).
+
+**Blockers**: none for the Rust path — fully de-risked. Python operator path
+(componentize-py vs `load_python_configured`) was NOT exercised in this spike; carry into
+T-0822 if a Python-authored WASM operator is in scope.
+
+**Commands + results**
+- `cargo build --target wasm32-wasip2 --release` (fixture) -> Finished, 26.75s.
+- `wasm-tools validate --features component-model wasm_operator_fixture.wasm` -> VALID COMPONENT.
+- `cargo test --release` (host-spike) -> `test configured_operator_loads_and_invokes ... ok`,
+  `test n_differently_configured_instances_coexist ... ok`; `2 passed; 0 failed`.

--- a/.metis/backlog/features/CLOACI-T-0822.md
+++ b/.metis/backlog/features/CLOACI-T-0822.md
@@ -4,15 +4,15 @@ level: task
 title: "Operator contract + manifest schema (macros emit it)"
 short_code: "CLOACI-T-0822"
 created_at: 2026-06-28T23:57:40.497369+00:00
-updated_at: 2026-06-28T23:57:40.497369+00:00
+updated_at: 2026-06-29T01:25:20.619493+00:00
 parent: CLOACI-I-0132
 blocked_by: []
 archived: false
 
 tags:
   - "#task"
-  - "#phase/backlog"
   - "#feature"
+  - "#phase/completed"
 
 
 exit_criteria_met: false
@@ -66,6 +66,12 @@ Define the operator **contract**: a fidius interface per primitive kind + a mani
 - **Current Problems**: {What's difficult/slow/buggy now}
 - **Benefits of Fixing**: {What improves after refactoring}
 - **Risk Assessment**: {Risks of not addressing this}
+
+## Acceptance Criteria
+
+## Acceptance Criteria
+
+## Acceptance Criteria
 
 ## Acceptance Criteria **[REQUIRED]**
 
@@ -136,4 +142,157 @@ Define the operator **contract**: a fidius interface per primitive kind + a mani
 
 ## Status Updates **[REQUIRED]**
 
-*To be added during implementation*
+### 2026-06-28 — CONTRACT DESIGN + TASK-primitive first cut (PROVEN; not committed)
+
+The operator CONTRACT is designed and the TASK primitive is implemented end-to-end
+as a self-contained, workspace-excluded example under
+`examples/operator-contract/` (3 crates, removable). All proofs green. The other
+3 primitives + the real macro wiring are deferred (continuation below). NOT
+committed — awaiting design review.
+
+#### 1. Operator trait(s): per-primitive SYNC fidius `#[plugin_interface]`
+
+DECISION (want confirmed): **one sync trait per primitive kind**, not a unified
+trait. The runtime shapes differ (task: context→context; trigger: ()→fire?;
+accumulator: event→buffer; reactor: criteria→fire?) and fidius's vtable is
+positional, so a unified trait would carry mostly-`NotImplemented` methods like
+`CloacinaPlugin` already does. Per-primitive traits keep each interface minimal,
+its interface-hash tight, and the loader's descriptor selection unambiguous.
+
+The async `cloacina_workflow` primitives (`Task`, `Trigger`, accumulator,
+reactor) are NOT the WASM contract (they're `#[async_trait]`; the guest has no
+runtime — T-0821). Each operator trait is the WASM-compatible SYNC analogue.
+
+TASK trait (implemented, exact signature):
+```rust
+#[plugin_interface(version = 1, buffer = PluginAllocated, crate = "fidius_guest")]
+pub trait TaskOperator: Send + Sync {
+    // JSON(TaskInvocation) in -> JSON(TaskOutcome) out. SYNC.
+    fn execute(&self, invocation_json: String) -> String;
+}
+```
+What crosses the boundary (DECISION — want confirmed): a **JSON String**, not a
+serde struct. `TaskInvocation { context_json: String }` in,
+`TaskOutcome { success, context_json, error }` out — the bytes are
+`JSON(TaskInvocation)` / `JSON(TaskOutcome)`. This (a) exactly matches the
+de-risked spike wire (String→String), (b) mirrors cloacina's existing
+`TaskExecutionRequest`/`TaskExecutionResult` FFI which already carries the
+`Context<Value>` as a JSON string, and (c) sidesteps any risk of fidius mapping
+arbitrary nested serde structs across the component boundary. `(T,)` 1-tuple
+calling convention from the spike holds: `call_method(0, &(inv_json,))`.
+
+Projected sibling shapes (DEFERRED, for review of the pattern):
+- `TriggerOperator::poll(&self, config_json: String) -> String` →
+  `JSON(TriggerPollOutcome { fire: bool, context_json: Option<String> })`
+  (the SYNC analogue of `Trigger::poll → TriggerResult`; `poll_interval` /
+  `cron_expression` / `allow_concurrent` are manifest metadata, not per-call).
+- `AccumulatorOperator::ingest(&self, event_json: String) -> String` →
+  `JSON(AccumulatorOutcome { buffered: bool, emit: Option<String> })`.
+- `ReactorOperator::evaluate(&self, cache_json: String) -> String` →
+  `JSON(ReactorOutcome { fire: bool, fire_context_json: Option<String> })`.
+All four are single-arg JSON-String-in/JSON-String-out, sync.
+
+#### 2. The async↔sync bridge
+
+cloacina's primitives stay async; the WASM call is a blocking host call into
+wasmtime. The bridge is an async host adapter that wraps a configured operator
+handle and awaits a `spawn_blocking` of the wasmtime call:
+```rust
+#[async_trait]
+impl Task for WasmTaskOperator {           // host-side adapter (runtime task)
+    async fn execute(&self, ctx: Context<Value>) -> Result<Context<Value>, TaskError> {
+        let inv = serde_json::to_string(&TaskInvocation { context_json: ctx.to_json()? })?;
+        let handle = self.handle.clone();   // configured PluginHandle (Send)
+        let out_json = tokio::task::spawn_blocking(move || {
+            handle.call_method(0, &(inv,))  // BLOCKING wasmtime call
+        }).await??;
+        let outcome: TaskOutcome = serde_json::from_str(&out_json)?;
+        if outcome.success { Context::from_json(outcome.context_json.unwrap()) .. }
+        else { Err(TaskError::..(outcome.error.unwrap())) }
+    }
+}
+```
+Config binds ONCE at load via `load_wasm_configured` (the `configure` hook +
+macro-emitted `fidius-configure` export); per-call `execute` dispatches on the
+already-configured persistent store. This adapter is the seam where the operator
+plugs back into the existing executor unchanged. (Implementing the live adapter
+is part of the runtime-integration task, not this contract task; the test here
+exercises the same serialize → blocking-call → deserialize sequence inline.)
+
+#### 3. Manifest schema (`OperatorManifest`)
+
+cloacina-defined metadata that travels in the fidius package as a sidecar
+`operator.json` (NOT a call payload). The loader (T-0823) reads it to learn which
+primitive to register and how. Implemented Rust type:
+```
+OperatorManifest {
+  name, version,
+  primitive_kind: PrimitiveKind { Task | Trigger | Accumulator | Reactor },
+  interface: String,         // kebab fidius interface, links the descriptor
+  interface_version: u32,    // must match descriptor.interface_version
+  params: Vec<InputSlot>,    // CLOACI-I-0128 param schema (reused)
+  dependencies: Vec<String>,
+  description, author,
+}
+```
+`interface` + `interface_version` point the loader at the right
+`<Trait>_WASM_DESCRIPTOR`; `primitive_kind` selects which sibling descriptor to
+link; `params` reuses I-0128 `InputSlot` (JSON-Schema-typed) for the injectable
+runtime surface. In the example `InputSlot` is a structural copy of
+`cloacina_api_types::InputSlot` so the example stays self-contained/removable;
+the real manifest reuses the canonical type verbatim.
+
+#### 4. Macro emission
+
+DECISION (want confirmed): a dedicated **`#[operator(kind = task, ...)]`**-flavored
+attribute rather than overloading `#[task]`/`#[trigger]`/etc. Rationale: an
+operator targets a SEPARATE sync trait + a WASM cdylib + a manifest sidecar,
+whereas `#[task]` emits an async `Task` impl + inventory entry into a packaged
+workflow. The two share the metadata-emission SEAM (the same place
+`generate_packaged_registration` builds `PackageTasksMetadata` /
+`get_task_metadata`), so `#[operator]` would: (a) emit the per-primitive sync
+`#[plugin_interface]`/`#[plugin_impl]` (guest side), and (b) emit an
+`OperatorManifest` constructor at the metadata seam (analogous to today's
+`get_task_metadata`) that the build writes to `operator.json` — reusing the
+existing I-0128 `make_params_fn` InputSlot codegen for `params`. Keeping it
+separate avoids forking the (already CG-heavy) `#[task]` codegen and keeps the
+operator interface-hash decoupled from the workflow ABI. Open sub-question for
+review: a unifying `#[operator(kind=...)]` vs four thin attrs
+(`#[task_operator]` …) — leaning to the single `kind`-parameterized attribute.
+
+How this composes with existing packaged-workflow metadata: operators are a
+PARALLEL package shape, not a change to `CloacinaPlugin`. A workflow package
+keeps emitting `PackageTasksMetadata` via `CloacinaPlugin`; an operator package
+emits its own per-primitive interface + `operator.json`. The loader branches on
+`runtime = "wasm"` + presence of `operator.json` to take the operator path.
+
+#### Implemented (first cut — TASK only) vs deferred
+
+IMPLEMENTED & PROVEN (`examples/operator-contract/`, 3 standalone crates):
+- `operator-contract/` — shared contract: `PrimitiveKind`, `OperatorManifest`
+  (+`to_json`/`from_json`), `InputSlot`, `TaskInvocation`, `TaskOutcome`. 2 unit
+  tests green.
+- `task-operator-fixture/` — sync `TaskOperator` `#[plugin_interface]` +
+  `#[plugin_impl(config=Config)]`; reads `name`, writes `result = prefix+name`;
+  builds to a **VALID** wasm32-wasip2 component (117 KB).
+- `host/tests/task_operator_contract.rs` — **3 tests pass**:
+  (1) manifest round-trips (produced → `operator.json` → read) and carries
+  `primitive_kind = Task`; (2) configured operator `load_wasm_configured` +
+  invoke → `result == "hello, world"`, original context preserved;
+  (3) missing required input → clean failed `TaskOutcome` (no trap).
+
+DEFERRED (continuation):
+- Trigger / Accumulator / Reactor sibling traits + wire types (shapes sketched
+  above) — next once the task shape is confirmed.
+- Real macro wiring: the `#[operator(kind=...)]` attribute in `cloacina-macros`
+  emitting interface + `operator.json` at the metadata seam (this task proved the
+  hand-written shape; the spike + this contract de-risk the codegen target).
+- The live async host adapter (`WasmTaskOperator: Task`) wiring into the executor
+  — belongs to the runtime-integration task; bridge sequence proven inline here.
+- Python operator path (componentize-py) — carried from T-0821, still unexercised.
+- Loader (T-0823) consuming `operator.json` to register primitives — unblocked by
+  this schema.
+
+Sharp edges: benign `unexpected cfg "host"` warning from the fidius macro
+(cosmetic, as in T-0821); wasm fixture must be a standalone `[workspace]`; host
+crate cold-compiles wasmtime (~heavy). NOT committed — design review gate.

--- a/.metis/backlog/features/CLOACI-T-0823.md
+++ b/.metis/backlog/features/CLOACI-T-0823.md
@@ -4,15 +4,15 @@ level: task
 title: "Operator loader + registry (load_wasm_configured -> register the primitive)"
 short_code: "CLOACI-T-0823"
 created_at: 2026-06-28T23:57:41.833766+00:00
-updated_at: 2026-06-28T23:57:41.833766+00:00
+updated_at: 2026-06-29T01:48:57.400152+00:00
 parent: CLOACI-I-0132
 blocked_by: []
 archived: false
 
 tags:
   - "#task"
-  - "#phase/backlog"
   - "#feature"
+  - "#phase/completed"
 
 
 exit_criteria_met: false
@@ -66,6 +66,12 @@ Extend cloacina's loader to load a WASM operator via `load_wasm_configured`, rea
 - **Current Problems**: {What's difficult/slow/buggy now}
 - **Benefits of Fixing**: {What improves after refactoring}
 - **Risk Assessment**: {Risks of not addressing this}
+
+## Acceptance Criteria
+
+## Acceptance Criteria
+
+## Acceptance Criteria
 
 ## Acceptance Criteria **[REQUIRED]**
 
@@ -136,4 +142,68 @@ Extend cloacina's loader to load a WASM operator via `load_wasm_configured`, rea
 
 ## Status Updates **[REQUIRED]**
 
-*To be added during implementation*
+### 2026-06-28 — TASK-operator loader + executor bridge: PROVEN end-to-end (not committed)
+
+A WASM **task operator** now loads + runs as a cloacina `Task`, end-to-end,
+behind a default-OFF feature. NOT committed — review gate.
+
+#### Contract promoted to a real crate
+`crates/cloacina-operator-contract` (new workspace member): `OperatorManifest`,
+`PrimitiveKind`, `TaskInvocation`, `TaskOutcome`, `METHOD_EXECUTE`,
+`TASK_OPERATOR_INTERFACE_VERSION`, and the `TaskOperator` sync-trait shape
+(documented; the `#[plugin_interface]` declaration itself is bound to a fidius
+`crate =` target so it lives host-/guest-side, not here). Reuses the **canonical**
+`cloacina_api_types::InputSlot` (re-exported), not a vendored copy. serde-only
+deps -> wasm-buildable. 2 unit tests + 1 doctest green.
+
+#### Loader + executor adapter (feature `operators-wasm`, default OFF)
+`crates/cloacina/src/registry/loader/operator_loader.rs`:
+- Host-side `#[fidius_macro::plugin_interface(version=1, crate="fidius_core")]
+  trait TaskOperator` -> emits `__fidius_TaskOperator::TaskOperator_WASM_DESCRIPTOR`.
+- `load_task_operator(search_path, package_name, &config) -> Arc<dyn Task>`:
+  reads sidecar `operator.json`, requires `primitive_kind == Task` +
+  matching `interface_version` (else fail-closed `LoaderError`), then
+  `load_wasm_configured(component, &config)` (config bound ONCE at load) and
+  wraps the handle.
+- `WasmTaskOperator: Task` — the async/sync bridge: `Context.to_json()` ->
+  `JSON(TaskInvocation)` -> `tokio::spawn_blocking` the wasmtime `call_method(0,
+  (inv,))` -> parse `JSON(TaskOutcome)` -> `Context::from_json` on success, or a
+  `TaskError::ExecutionFailed` from a failed outcome. Handle held in `Arc` so a
+  `'static + Send` clone goes into `spawn_blocking`; the WASM backend serializes
+  calls behind its own store mutex.
+
+Feature wiring: `operators-wasm = ["dep:fidius-macro",
+"dep:cloacina-operator-contract", "fidius-host/wasm"]`. fidius-host has no
+default features, so the default cloacina build pulls neither wasmtime nor
+fidius-macro.
+
+#### Gating proof (no-wasmtime-by-default)
+- `cargo tree -p cloacina -i wasmtime` -> "did not match any packages" (absent).
+- `cargo tree -p cloacina --features operators-wasm -i wasmtime` -> `wasmtime
+  v45.0.3` via `fidius-host`. Symmetric for `fidius-macro`.
+- `cargo check -p cloacina` (default) -> Finished, clean.
+
+#### End-to-end (feature on)
+`crates/cloacina/tests/operator_loader_wasm.rs` (reuses the proven fixture
+`examples/operator-contract/task-operator-fixture`, built to wasm32-wasip2,
+staged as `.wasm` + `package.toml` + `operator.json`):
+- `wasm_task_operator_runs_as_cloacina_task` — load -> `Arc<dyn Task>` -> `execute`
+  `Context{name:"world"}` -> `result == "hello, world"`, `name` preserved.
+- `config_binds_at_load_so_instances_differ` — `hello, ` vs `goodbye, `
+  instances differ.
+- `non_task_primitive_fails_closed` — a Trigger-kind manifest is rejected.
+- `cargo test -p cloacina --features operators-wasm --test operator_loader_wasm`
+  -> `3 passed; 0 failed`. (Benign `unexpected cfg "host"` warning from the
+  fixture's wasm build only; the loader module suppresses it.)
+
+#### Deferred (unchanged scope)
+- **CLOACI-T-0824**: trigger `poll` / accumulator `ingest` / reactor `evaluate`
+  bridges + wire types, and wiring a loaded operator into the Runtime/scheduler
+  registries (this task returns a `Arc<dyn Task>`; it does not register it).
+- **CLOACI-T-0826**: the `#[operator(kind=...)]` authoring macro (manifests are
+  hand-built in the test; the macro emits them at the metadata seam).
+- The async `CloacinaPlugin` packaged-workflow path is untouched (parallel shape).
+- Generic config across arbitrary guest structs stays out of scope: fidius
+  config wire is bincode (the dev=JSON/release=bincode note is stale — fidius
+  is always bincode now), so the loader is generic `<C: Serialize>` and the test
+  passes a concrete `Config{prefix}` matching the guest.

--- a/.metis/backlog/features/CLOACI-T-0824.md
+++ b/.metis/backlog/features/CLOACI-T-0824.md
@@ -4,15 +4,15 @@ level: task
 title: "Configured WASM execution in the runtime/scheduler"
 short_code: "CLOACI-T-0824"
 created_at: 2026-06-28T23:57:42.943615+00:00
-updated_at: 2026-06-28T23:57:42.943615+00:00
+updated_at: 2026-06-29T02:03:09.558810+00:00
 parent: CLOACI-I-0132
 blocked_by: []
 archived: false
 
 tags:
   - "#task"
-  - "#phase/backlog"
   - "#feature"
+  - "#phase/completed"
 
 
 exit_criteria_met: false
@@ -66,6 +66,12 @@ Bridge the runtime/scheduler to invoke a **configured WASM operator** as its bou
 - **Current Problems**: {What's difficult/slow/buggy now}
 - **Benefits of Fixing**: {What improves after refactoring}
 - **Risk Assessment**: {Risks of not addressing this}
+
+## Acceptance Criteria
+
+## Acceptance Criteria
+
+## Acceptance Criteria
 
 ## Acceptance Criteria **[REQUIRED]**
 
@@ -136,4 +142,54 @@ Bridge the runtime/scheduler to invoke a **configured WASM operator** as its bou
 
 ## Status Updates **[REQUIRED]**
 
-*To be added during implementation*
+### 2026-06-28 — TRIGGER bridge + Runtime registration landed (active)
+
+Built on T-0823's idioms (spawn_blocking async->sync bridge, host-side
+`#[plugin_interface]` re-declaration, fail-closed `LoaderError`s). All WASM
+stays behind the default-OFF `operators-wasm` feature.
+
+**Done / proven (must-haves):**
+- Contract crate (`cloacina-operator-contract`): added `TriggerInvocation` /
+  `PollOutcome` wire types (+ `fire`/`skip`/`err` ctors), `METHOD_POLL`,
+  `TRIGGER_OPERATOR_INTERFACE_VERSION`; round-trip unit tests pass.
+- Trigger bridge (`operator_loader.rs`): host-side `TriggerOperator`
+  `#[plugin_interface]` trait (`poll`); `WasmTriggerOperator: impl Trigger`
+  whose async `poll()` spawn_blocks into the sync WASM `poll`, mapping
+  `PollOutcome` -> `TriggerResult::Fire(ctx)`/`Skip`, outcome `error` ->
+  `TriggerError::PollError`. `load_trigger_operator(search_path, package,
+  config, TriggerBinding)`.
+- Runtime registration: `load_operator(runtime, search_path, package, config,
+  OperatorBinding)` reads `operator.json`, dispatches on `primitive_kind`,
+  registers Task -> `register_task(namespace)` / Trigger ->
+  `register_trigger(name)`. Mismatched binding fails closed.
+- Fixture + e2e (`examples/operator-contract/trigger-operator-fixture`,
+  `tests/operator_trigger_wasm.rs`): trigger fixture compiles to wasm32-wasip2,
+  loads, polls Fire/Skip config-bound; registration lands the primitive in the
+  correct `Runtime` registry by `primitive_kind`. 6 tests pass; existing task
+  e2e (3) still green; contract unit tests (4) pass.
+
+**Design wrinkle - poll_interval sourcing:** the operator manifest has no
+poll-interval field (it describes the component, not a deployment), and the
+WASM guest never needs the cadence. So host-side scheduling metadata
+(poll_interval / allow_concurrent / workflow_name / cron_expression) is bound
+via a separate `TriggerBinding` at load - the trigger analogue of "config binds
+once". The guest `poll` decides *whether* to fire; the host decides *how often*.
+
+**Validation (exact):**
+- `cargo test -p cloacina-operator-contract` -> 4 passed.
+- `cargo check -p cloacina` -> clean; `cargo tree -p cloacina` wasmtime count =
+  0 (default), 43 (with `--features operators-wasm`).
+- `cargo test -p cloacina --features operators-wasm --test operator_trigger_wasm`
+  -> 6 passed.
+
+**Deferred (clearly-noted continuation):** ACCUMULATOR + REACTOR. Their sync
+contract traits (`AccumulatorOperator::ingest` / `ReactorOperator::evaluate`)
+and wire types (`AccumulatorInvocation`/`AccumulatorOutcome`,
+`ReactorInvocation`/`ReactorOutcome`) are defined and the `Wasm*Operator`
+bridge shapes are documented in `operator_loader.rs`, but full impl + fixtures
+are left because neither is a plain `Runtime` constructor: the accumulator is a
+stateful `&mut self` event sink driven by `accumulator_runtime` (no `Runtime`
+registry), and a reactor is represented as a `ReactorRegistration` descriptor
+(not a callable) evaluated by the CG scheduler. Wiring those needs threading a
+callable evaluator / event loop through the scheduler - beyond this task's
+surface. Not committed (per reviewer request).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59317f77929f0e679d39364702289274de2f0f0b22cbf50b2b8cff2169a0b27a"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "aead"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -63,6 +72,12 @@ name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "ambient-authority"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
 
 [[package]]
 name = "android_system_properties"
@@ -159,6 +174,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
 name = "argon2"
@@ -423,6 +444,9 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+dependencies = [
+ "allocator-api2",
+]
 
 [[package]]
 name = "byteorder"
@@ -466,12 +490,82 @@ dependencies = [
 ]
 
 [[package]]
+name = "cap-fs-ext"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5528f85b1e134ae811704e41ef80930f56e795923f866813255bc342cc20654"
+dependencies = [
+ "cap-primitives",
+ "cap-std",
+ "io-lifetimes",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "cap-net-ext"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20a158160765c6a7d0d8c072a53d772e4cb243f38b04bfcf6b4939cfbe7482e7"
+dependencies = [
+ "cap-primitives",
+ "cap-std",
+ "rustix",
+ "smallvec",
+]
+
+[[package]]
+name = "cap-primitives"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6cf3aea8a5081171859ef57bc1606b1df6999df4f1110f8eef68b30098d1d3a"
+dependencies = [
+ "ambient-authority",
+ "fs-set-times",
+ "io-extras",
+ "io-lifetimes",
+ "ipnet",
+ "maybe-owned",
+ "rustix",
+ "rustix-linux-procfs",
+ "windows-sys 0.52.0",
+ "winx",
+]
+
+[[package]]
+name = "cap-std"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6dc3090992a735d23219de5c204927163d922f42f575a0189b005c62d37549a"
+dependencies = [
+ "cap-primitives",
+ "io-extras",
+ "io-lifetimes",
+ "rustix",
+]
+
+[[package]]
+name = "cap-time-ext"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "def102506ce40c11710a9b16e614af0cde8e76ae51b1f48c04b8d79f4b671a80"
+dependencies = [
+ "ambient-authority",
+ "cap-primitives",
+ "iana-time-zone",
+ "once_cell",
+ "rustix",
+ "winx",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -624,6 +718,7 @@ dependencies = [
  "cloacina-api-types",
  "cloacina-computation-graph",
  "cloacina-macros",
+ "cloacina-operator-contract",
  "cloacina-workflow",
  "cloacina-workflow-plugin",
  "croner",
@@ -636,6 +731,7 @@ dependencies = [
  "ed25519-dalek",
  "fidius-core",
  "fidius-host",
+ "fidius-macro",
  "futures",
  "hex",
  "inventory",
@@ -783,6 +879,15 @@ dependencies = [
  "serde_json",
  "syn",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "cloacina-operator-contract"
+version = "0.9.0"
+dependencies = [
+ "cloacina-api-types",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -948,6 +1053,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
 
 [[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -982,6 +1096,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpp_demangle"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2bb79cb74d735044c972aae58ed0aaa9a837e85b01106a54c39e42e97f62253"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1000,6 +1123,157 @@ dependencies = [
 ]
 
 [[package]]
+name = "cranelift-assembler-x64"
+version = "0.132.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d521bdbc6098937af83ef4ab6d5c07398126bc71878f7ef4ea9499977978ef5"
+dependencies = [
+ "cranelift-assembler-x64-meta",
+]
+
+[[package]]
+name = "cranelift-assembler-x64-meta"
+version = "0.132.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dde0b83164d4a497860af4236271178bc640512b067101e0853e4f74eaa4df5"
+dependencies = [
+ "cranelift-srcgen",
+]
+
+[[package]]
+name = "cranelift-bforest"
+version = "0.132.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0111d110b72b4efad69a372e29e21628652fd0bcab66967e5c8350ab679affd5"
+dependencies = [
+ "cranelift-entity",
+ "wasmtime-internal-core",
+]
+
+[[package]]
+name = "cranelift-bitset"
+version = "0.132.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf01ecc92fc5499789d79c3b817299d5a8ddd828d31dcf0f9cc3cc66f38dbb36"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "wasmtime-internal-core",
+]
+
+[[package]]
+name = "cranelift-codegen"
+version = "0.132.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cd2563bead0090c3879a7ff7327f7550c9d59bb5d05ecc8cd7886977aa3125a"
+dependencies = [
+ "bumpalo",
+ "cranelift-assembler-x64",
+ "cranelift-bforest",
+ "cranelift-bitset",
+ "cranelift-codegen-meta",
+ "cranelift-codegen-shared",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-isle",
+ "gimli",
+ "hashbrown 0.17.0",
+ "libm",
+ "log",
+ "pulley-interpreter",
+ "regalloc2",
+ "rustc-hash",
+ "serde",
+ "smallvec",
+ "target-lexicon",
+ "wasmtime-internal-core",
+]
+
+[[package]]
+name = "cranelift-codegen-meta"
+version = "0.132.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9640d250d26f9381a73dc7f9862b27928d4809119aec73be0e556612e67b6a99"
+dependencies = [
+ "cranelift-assembler-x64-meta",
+ "cranelift-codegen-shared",
+ "cranelift-srcgen",
+ "heck",
+ "pulley-interpreter",
+]
+
+[[package]]
+name = "cranelift-codegen-shared"
+version = "0.132.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a07f156b90efc94371ddb3536f76e4ab671ad2e093bfa5511e10198cadbb0c47"
+
+[[package]]
+name = "cranelift-control"
+version = "0.132.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d75a76fd9dd37dcbc3d2d2e00abe3281a7e88adc035fba3b8114cc69981576ec"
+dependencies = [
+ "arbitrary",
+]
+
+[[package]]
+name = "cranelift-entity"
+version = "0.132.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eea22522144ba08c7e7ef94bfc25d474ef016c2771974b8ab1986734ac85965"
+dependencies = [
+ "cranelift-bitset",
+ "serde",
+ "serde_derive",
+ "wasmtime-internal-core",
+]
+
+[[package]]
+name = "cranelift-frontend"
+version = "0.132.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efa2826c80dff1d93b19b3cfbcaf9fae44c78d739a98d146dd5bd89c51e14367"
+dependencies = [
+ "cranelift-codegen",
+ "log",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-isle"
+version = "0.132.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e238a69b95c5415456f22189494a12db94f313bb72b6ec9cc88ddf2f1056e28e"
+
+[[package]]
+name = "cranelift-native"
+version = "0.132.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eceb0ebd8d6aef6bb287e8d532a164b0db1c0062961211e9c22a91f67521c098"
+dependencies = [
+ "cranelift-codegen",
+ "libc",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-srcgen"
+version = "0.132.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "004643f39a7bec553de5263d650db30e5b9caec1d5cbe065fd732b7ec9ae40d0"
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "croner"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1014,6 +1288,16 @@ version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
  "crossbeam-utils",
 ]
 
@@ -1226,6 +1510,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "uuid",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1345,6 +1638,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339ee130d97a610ea5a5872d2bbb130fdf68884ff09d3028b81bec8a1ac23bbc"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
 name = "dirs"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1384,6 +1687,17 @@ dependencies = [
  "option-ext",
  "redox_users 0.5.2",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users 0.4.6",
+ "winapi",
 ]
 
 [[package]]
@@ -1496,6 +1810,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1599,11 +1925,15 @@ checksum = "ddd635fb0fb1ab13ab215d140e1462e3127a9e7b7279bf438ee011797ada7283"
 dependencies = [
  "ed25519-dalek",
  "fidius-core",
+ "http",
  "libloading",
  "pyo3-build-config",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "wasmtime",
+ "wasmtime-wasi",
+ "wasmtime-wasi-http",
 ]
 
 [[package]]
@@ -1678,6 +2008,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs-set-times"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
+dependencies = [
+ "io-lifetimes",
+ "rustix",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1769,6 +2110,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "fxprof-processed-profile"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25234f20a3ec0a962a61770cfe39ecf03cb529a6e474ad8cff025ed497eda557"
+dependencies = [
+ "bitflags 2.11.1",
+ "debugid",
+ "rustc-hash",
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1828,6 +2183,18 @@ checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
 dependencies = [
  "opaque-debug",
  "polyval",
+]
+
+[[package]]
+name = "gimli"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf7f043f89559805f8c7cacc432749b2fa0d0a0a9ee46ce47164ed5ba7f126c"
+dependencies = [
+ "fnv",
+ "hashbrown 0.16.1",
+ "indexmap 2.14.0",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -1897,6 +2264,11 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "foldhash 0.2.0",
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "heck"
@@ -2058,7 +2430,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -2350,6 +2722,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-extras"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2285ddfe3054097ef4b2fe909ef8c3bcd1ea52a8f0d274416caebeef39f04a65"
+dependencies = [
+ "io-lifetimes",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2394,6 +2782,36 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "ittapi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b996fe614c41395cdaedf3cf408a9534851090959d90d54a535f675550b64b1"
+dependencies = [
+ "anyhow",
+ "ittapi-sys",
+ "log",
+]
+
+[[package]]
+name = "ittapi-sys"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5385394064fa2c886205dba02598013ce83d3e92d33dbdc0c52fe0e7bf4fc"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -2526,6 +2944,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "leb128"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c83bff1d572d6b9aeef67ddfc8448e4a3737909cb28e81f97c791b9018703e52"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2631,6 +3055,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2644,6 +3077,12 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "maybe-owned"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "md-5"
@@ -2660,6 +3099,15 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memfd"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227"
+dependencies = [
+ "rustix",
+]
 
 [[package]]
 name = "memoffset"
@@ -2957,6 +3405,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
 dependencies = [
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "object"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
+dependencies = [
+ "crc32fast",
+ "hashbrown 0.17.0",
+ "indexmap 2.14.0",
+ "memchr",
 ]
 
 [[package]]
@@ -3362,6 +3822,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "serde",
+]
+
+[[package]]
 name = "postgres-protocol"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3501,6 +3973,29 @@ checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
  "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pulley-interpreter"
+version = "45.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b04adf8f93264685f2c70a3edb8f828c791e71b22659253319c33f29d1165aef"
+dependencies = [
+ "cranelift-bitset",
+ "log",
+ "pulley-macros",
+ "wasmtime-internal-core",
+]
+
+[[package]]
+name = "pulley-macros"
+version = "45.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c120a6af1a574a42efcd9df2ad27cb78bc04118c5e0c69e90599f17301a1c7a"
+dependencies = [
  "proc-macro2",
  "quote",
  "syn",
@@ -3764,6 +4259,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "rdkafka"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3854,6 +4369,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "regalloc2"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de2c52737737f8609e94f975dee22854a2d5c125772d4b1cf292120f4d45c186"
+dependencies = [
+ "allocator-api2",
+ "bumpalo",
+ "hashbrown 0.17.0",
+ "log",
+ "rustc-hash",
+ "smallvec",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3922,7 +4451,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -3980,6 +4509,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4005,6 +4540,16 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustix-linux-procfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc84bf7e9aa16c4f2c758f27412dc9841341e16aa682d9c7ac308fe3ee12056"
+dependencies = [
+ "once_cell",
+ "rustix",
 ]
 
 [[package]]
@@ -4205,6 +4750,10 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "serde"
@@ -4499,6 +5048,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -4883,10 +5435,12 @@ version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
+ "indexmap 2.14.0",
  "serde_core",
  "serde_spanned 1.1.1",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
+ "toml_writer",
  "winnow 0.7.15",
 ]
 
@@ -5302,6 +5856,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5543,6 +6103,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-compose"
+version = "0.248.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96ba953e2b9b4b4b52a31cf4e3ee1c1374c872b6e012cf2138d1c37cba00bfd6"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap 2.14.0",
+ "log",
+ "petgraph",
+ "smallvec",
+ "wasm-encoder 0.248.0",
+ "wasmparser 0.248.0",
+ "wat",
+]
+
+[[package]]
 name = "wasm-encoder"
 version = "0.236.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5560,6 +6137,26 @@ checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
 dependencies = [
  "leb128fmt",
  "wasmparser 0.244.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.248.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac92cf547bc18d27ecc521015c08c353b4f18b84ab388bb6d1b6b682c620d9b6"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.248.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.252.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8185ae345fa5687c054626ff9a50e7089797a343d9904d1dc9820eb4c4d3196f"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.252.0",
 ]
 
 [[package]]
@@ -5624,6 +6221,395 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmparser"
+version = "0.248.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa4439c5eee9df71ee0c6efb37f63b1fcb1fec38f85f5142c54e7ed05d33091a"
+dependencies = [
+ "bitflags 2.11.1",
+ "hashbrown 0.17.0",
+ "indexmap 2.14.0",
+ "semver",
+ "serde",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.252.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3eb099dcadcde5be9eef55e3a337128efd4e44b4c93122487e4d2e4e1c6627c"
+dependencies = [
+ "bitflags 2.11.1",
+ "indexmap 2.14.0",
+ "semver",
+]
+
+[[package]]
+name = "wasmprinter"
+version = "0.248.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b264a5410b008d4d199a92bf536eae703cbd614482fc1ec53831cf19e1c183"
+dependencies = [
+ "anyhow",
+ "termcolor",
+ "wasmparser 0.248.0",
+]
+
+[[package]]
+name = "wasmtime"
+version = "45.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a83ef84ac8bab735c89e27b0268b0586099fbe81281ae45be2b8e4f407b2daa"
+dependencies = [
+ "addr2line",
+ "async-trait",
+ "bitflags 2.11.1",
+ "bumpalo",
+ "cc",
+ "cfg-if",
+ "encoding_rs",
+ "futures",
+ "fxprof-processed-profile",
+ "gimli",
+ "ittapi",
+ "libc",
+ "log",
+ "mach2",
+ "memfd",
+ "object",
+ "once_cell",
+ "postcard",
+ "pulley-interpreter",
+ "rayon",
+ "rustix",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "smallvec",
+ "target-lexicon",
+ "tempfile",
+ "wasm-compose",
+ "wasm-encoder 0.248.0",
+ "wasmparser 0.248.0",
+ "wasmtime-environ",
+ "wasmtime-internal-cache",
+ "wasmtime-internal-component-macro",
+ "wasmtime-internal-component-util",
+ "wasmtime-internal-core",
+ "wasmtime-internal-cranelift",
+ "wasmtime-internal-fiber",
+ "wasmtime-internal-jit-debug",
+ "wasmtime-internal-jit-icache-coherence",
+ "wasmtime-internal-unwinder",
+ "wasmtime-internal-versioned-export-macros",
+ "wasmtime-internal-winch",
+ "wat",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "wasmtime-environ"
+version = "45.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439686d3deb38525c86b88bbc90f7ba669f70c8edc7d6b35147c738bbef5ff76"
+dependencies = [
+ "anyhow",
+ "cpp_demangle",
+ "cranelift-bforest",
+ "cranelift-bitset",
+ "cranelift-entity",
+ "gimli",
+ "hashbrown 0.17.0",
+ "indexmap 2.14.0",
+ "log",
+ "object",
+ "postcard",
+ "rustc-demangle",
+ "semver",
+ "serde",
+ "serde_derive",
+ "sha2 0.10.9",
+ "smallvec",
+ "target-lexicon",
+ "wasm-encoder 0.248.0",
+ "wasmparser 0.248.0",
+ "wasmprinter",
+ "wasmtime-internal-component-util",
+ "wasmtime-internal-core",
+]
+
+[[package]]
+name = "wasmtime-internal-cache"
+version = "45.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f2799e6c35393c2a38999f13e4c80ab5d5d9756082bb554cbd1f60485a18293"
+dependencies = [
+ "base64 0.22.1",
+ "directories-next",
+ "log",
+ "postcard",
+ "rustix",
+ "serde",
+ "serde_derive",
+ "sha2 0.10.9",
+ "toml 0.9.12+spec-1.1.0",
+ "wasmtime-environ",
+ "windows-sys 0.61.2",
+ "zstd",
+]
+
+[[package]]
+name = "wasmtime-internal-component-macro"
+version = "45.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81d2c5850fb8c448792453765d97f6f01096a32708f3c36798e86220763c90c0"
+dependencies = [
+ "anyhow",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasmtime-internal-component-util",
+ "wasmtime-internal-wit-bindgen",
+ "wit-parser 0.248.0",
+]
+
+[[package]]
+name = "wasmtime-internal-component-util"
+version = "45.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ed79c4e9ab416dcc5e46b9d1ec9b7c2e3c730deab525996b0de45a35fc8b2c3"
+
+[[package]]
+name = "wasmtime-internal-core"
+version = "45.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3073c03f97f871fe6400e68621c863b93ba79296f8e570285231952d23fcc804"
+dependencies = [
+ "anyhow",
+ "hashbrown 0.17.0",
+ "libm",
+ "serde",
+]
+
+[[package]]
+name = "wasmtime-internal-cranelift"
+version = "45.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a15981261d361f9c93b42929f446b4009840853ceea181ad6e17730f4016a0b"
+dependencies = [
+ "cfg-if",
+ "cranelift-codegen",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-frontend",
+ "cranelift-native",
+ "gimli",
+ "itertools 0.14.0",
+ "log",
+ "object",
+ "pulley-interpreter",
+ "smallvec",
+ "target-lexicon",
+ "thiserror 2.0.18",
+ "wasmparser 0.248.0",
+ "wasmtime-environ",
+ "wasmtime-internal-core",
+ "wasmtime-internal-unwinder",
+ "wasmtime-internal-versioned-export-macros",
+]
+
+[[package]]
+name = "wasmtime-internal-fiber"
+version = "45.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33aed9d91d54c9f861ba7e3c3130bded8a7a63e01fe58c3a9a36b45d6ee0fb57"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "rustix",
+ "wasmtime-environ",
+ "wasmtime-internal-versioned-export-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "wasmtime-internal-jit-debug"
+version = "45.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "944942118aab67e7b4febfe88a65d0af4cfd10af8ed0e79fd6cf39d75359ab7e"
+dependencies = [
+ "cc",
+ "object",
+ "rustix",
+ "wasmtime-internal-versioned-export-macros",
+]
+
+[[package]]
+name = "wasmtime-internal-jit-icache-coherence"
+version = "45.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37dee05e8c35759826f6b926cd949c51f771b6a58619d8e60c63c3f3d3e5e59b"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasmtime-internal-core",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "wasmtime-internal-unwinder"
+version = "45.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a83f7ebe911a6f1605ff0d3a678472ddb1fcc57c3e2f6bae5dd4d170b625b3ed"
+dependencies = [
+ "cfg-if",
+ "cranelift-codegen",
+ "log",
+ "object",
+ "wasmtime-environ",
+]
+
+[[package]]
+name = "wasmtime-internal-versioned-export-macros"
+version = "45.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d75980644456dc003238766254b0e5f002704630237ccd0728747991fe2739d7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "wasmtime-internal-winch"
+version = "45.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81af36995b4720b32e3d667541b548a27184a859d09a6ee745eaba095f5a6f6e"
+dependencies = [
+ "cranelift-codegen",
+ "gimli",
+ "log",
+ "object",
+ "target-lexicon",
+ "wasmparser 0.248.0",
+ "wasmtime-environ",
+ "wasmtime-internal-cranelift",
+ "winch-codegen",
+]
+
+[[package]]
+name = "wasmtime-internal-wit-bindgen"
+version = "45.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada06667b7948892703fcc9f0b9b337c2e78c334d74d4fa62e2f75f07fbb3659"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.1",
+ "heck",
+ "indexmap 2.14.0",
+ "wit-parser 0.248.0",
+]
+
+[[package]]
+name = "wasmtime-wasi"
+version = "45.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd8e9db77f7b60f4c5f6f72847f55eb646ed7ed2f68e362559ee07dc543fb408"
+dependencies = [
+ "async-trait",
+ "bitflags 2.11.1",
+ "bytes",
+ "cap-fs-ext",
+ "cap-net-ext",
+ "cap-std",
+ "cap-time-ext",
+ "cfg-if",
+ "fs-set-times",
+ "futures",
+ "io-extras",
+ "io-lifetimes",
+ "rand 0.10.1",
+ "rustix",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
+ "wasmtime",
+ "wasmtime-wasi-io",
+ "wiggle",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "wasmtime-wasi-http"
+version = "45.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b7f2587ebe31df3d143baebe3aa9f6712955507e15778fe00097eb77da9ebe"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tracing",
+ "wasmtime",
+ "wasmtime-wasi",
+ "wasmtime-wasi-io",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "wasmtime-wasi-io"
+version = "45.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3805f02be91374a4fd02c0f947daf07bbaa6fbebb5909de5305fa5b0e9568f30"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures",
+ "tracing",
+ "wasmtime",
+]
+
+[[package]]
+name = "wast"
+version = "35.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ef140f1b49946586078353a453a1d28ba90adfc54dde75710bc1931de204d68"
+dependencies = [
+ "leb128",
+]
+
+[[package]]
+name = "wast"
+version = "252.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "942a3449d6a593fccc111a6241c8df52bda168af30e40bf9580d4394d7374c65"
+dependencies = [
+ "bumpalo",
+ "leb128fmt",
+ "memchr",
+ "unicode-width",
+ "wasm-encoder 0.252.0",
+]
+
+[[package]]
+name = "wat"
+version = "1.252.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c72a4ba7088f7bac94cf516e49882bdf97068904a563768cf249efc839ec42cb"
+dependencies = [
+ "wast 252.0.0",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5641,6 +6627,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -5663,6 +6658,46 @@ dependencies = [
  "objc2-system-configuration",
  "wasite",
  "web-sys",
+]
+
+[[package]]
+name = "wiggle"
+version = "45.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aca130e25a57e29bbb541441b6e261970a8469580bffebe904d96f0df67e41d"
+dependencies = [
+ "bitflags 2.11.1",
+ "thiserror 2.0.18",
+ "tracing",
+ "wasmtime",
+ "wasmtime-environ",
+ "wiggle-macro",
+]
+
+[[package]]
+name = "wiggle-generate"
+version = "45.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f0a45b47e893521cad81819f2e0db18a8b05086fd4bfb35369ed8830a8f0148"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasmtime-environ",
+ "witx",
+]
+
+[[package]]
+name = "wiggle-macro"
+version = "45.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e297e0325cffa6d368386b6e672e9d6c6a7ad34bdb8a5f49319db4decef2a990"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wiggle-generate",
 ]
 
 [[package]]
@@ -5695,6 +6730,25 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "winch-codegen"
+version = "45.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d73bc25d27222248f9bafc7e9945f61e74275360c3ea0d34008810d436140a53"
+dependencies = [
+ "cranelift-assembler-x64",
+ "cranelift-codegen",
+ "gimli",
+ "regalloc2",
+ "smallvec",
+ "target-lexicon",
+ "thiserror 2.0.18",
+ "wasmparser 0.248.0",
+ "wasmtime-environ",
+ "wasmtime-internal-core",
+ "wasmtime-internal-cranelift",
+]
 
 [[package]]
 name = "windows-core"
@@ -5922,6 +6976,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "winx"
+version = "0.36.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
+dependencies = [
+ "bitflags 2.11.1",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6110,6 +7174,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-parser"
+version = "0.248.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "247ad505da2915a082fe13204c5ba8788425aea1de54f43b284818cf82637856"
+dependencies = [
+ "anyhow",
+ "hashbrown 0.17.0",
+ "id-arena",
+ "indexmap 2.14.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.248.0",
+]
+
+[[package]]
+name = "witx"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e366f27a5cabcddb2706a78296a40b8fcc451e1a6aba2fc1d94b4a01bdaaef4b"
+dependencies = [
+ "anyhow",
+ "log",
+ "thiserror 1.0.69",
+ "wast 35.0.2",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6233,3 +7328,31 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crates/cloacina", "crates/cloacina-api-types", "crates/cloacina-client", "crates/cloacina-build", "crates/cloacinactl", "crates/cloacina-server", "crates/cloacina-agent", "crates/cloacina-compiler", "crates/cloacina-macros", "crates/cloacina-workflow-plugin", "crates/cloacina-testing", "crates/cloacina-workflow", "crates/cloacina-computation-graph", "crates/cloacina-python"]
+members = ["crates/cloacina", "crates/cloacina-api-types", "crates/cloacina-client", "crates/cloacina-build", "crates/cloacinactl", "crates/cloacina-server", "crates/cloacina-agent", "crates/cloacina-compiler", "crates/cloacina-macros", "crates/cloacina-workflow-plugin", "crates/cloacina-testing", "crates/cloacina-workflow", "crates/cloacina-computation-graph", "crates/cloacina-operator-contract", "crates/cloacina-python"]
 exclude = ["examples/*"]
 resolver = "2"
 
@@ -23,6 +23,7 @@ cloacina-api-types = { version = "0.9.0", path = "crates/cloacina-api-types" }
 cloacina-client = { version = "0.9.0", path = "crates/cloacina-client" }
 cloacina-macros = { version = "0.9.0", path = "crates/cloacina-macros" }
 cloacina-workflow = { version = "0.9.0", path = "crates/cloacina-workflow" }
+cloacina-operator-contract = { version = "0.9.0", path = "crates/cloacina-operator-contract" }
 clap = { version = "4.0", features = ["derive", "env"] }
 anyhow = { version = "1.0" }
 toml = { version = "0.8" }

--- a/crates/cloacina-operator-contract/Cargo.toml
+++ b/crates/cloacina-operator-contract/Cargo.toml
@@ -1,0 +1,30 @@
+# CLOACI-T-0823 — operator contract (real workspace crate, promoted from the
+# proven `examples/operator-contract/operator-contract` first cut).
+#
+# The cloacina-defined OPERATOR CONTRACT shared by the host loader and the WASM
+# guest. It carries:
+#   * the operator MANIFEST schema (`OperatorManifest` / `PrimitiveKind`) — the
+#     sidecar `operator.json` metadata the loader (T-0823) reads to learn which
+#     primitive a component implements, plus its param schema + dependencies. It
+#     reuses the canonical CLOACI-I-0128 `InputSlot` (from `cloacina-api-types`),
+#     NOT a vendored copy.
+#   * the per-primitive WASM-boundary wire types — for the TASK primitive that is
+#     `TaskInvocation` in / `TaskOutcome` out (serde-serializable, sync).
+#
+# Deps are serde-only (+ the serde-only `cloacina-api-types`) so the crate
+# compiles for BOTH the host and the wasm32-wasip2 guest.
+[package]
+name = "cloacina-operator-contract"
+version.workspace = true
+edition = "2021"
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation.workspace = true
+description = "WASM operator contract for cloacina — operator manifest schema + per-primitive sync wire types (CLOACI-I-0132)."
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json.workspace = true
+cloacina-api-types = { workspace = true }

--- a/crates/cloacina-operator-contract/src/lib.rs
+++ b/crates/cloacina-operator-contract/src/lib.rs
@@ -58,8 +58,13 @@
 //! method index for `execute` is `0` ([`METHOD_EXECUTE`]).
 //!
 //! Sibling primitives (trigger `poll`, accumulator `ingest`, reactor `evaluate`)
-//! are all single-arg JSON-String-in/JSON-String-out, sync — their wire types
-//! are deferred to CLOACI-T-0824 alongside their loader/registry wiring.
+//! are all single-arg JSON-String-in/JSON-String-out, sync. CLOACI-T-0824 lands
+//! the TRIGGER primitive end-to-end ([`TriggerInvocation`] in / [`PollOutcome`]
+//! out, bridged to [`cloacina_workflow::Trigger`] by the host loader) plus the
+//! Runtime-registry wiring, and defines the ACCUMULATOR
+//! ([`AccumulatorInvocation`] / [`AccumulatorOutcome`]) and REACTOR
+//! ([`ReactorInvocation`] / [`ReactorOutcome`]) wire types whose full host
+//! bridge/fixture is a noted continuation.
 
 use serde::{Deserialize, Serialize};
 
@@ -72,10 +77,33 @@ pub use cloacina_api_types::InputSlot;
 /// The vtable method index of `TaskOperator::execute` (the single sync method).
 pub const METHOD_EXECUTE: usize = 0;
 
+/// The vtable method index of `TriggerOperator::poll` (the single sync method).
+pub const METHOD_POLL: usize = 0;
+
+/// The vtable method index of `AccumulatorOperator::ingest` (CLOACI-T-0824
+/// continuation — wire type defined, bridge sketched).
+pub const METHOD_INGEST: usize = 0;
+
+/// The vtable method index of `ReactorOperator::evaluate` (CLOACI-T-0824
+/// continuation — wire type defined, bridge sketched).
+pub const METHOD_EVALUATE: usize = 0;
+
 /// The fidius interface version of the TASK-operator contract. Must match the
 /// `version` passed to the guest/host `#[plugin_interface(version = ..)]` and is
 /// cross-checked against [`OperatorManifest::interface_version`] by the loader.
 pub const TASK_OPERATOR_INTERFACE_VERSION: u32 = 1;
+
+/// The fidius interface version of the TRIGGER-operator contract. Cross-checked
+/// against [`OperatorManifest::interface_version`] for trigger primitives.
+pub const TRIGGER_OPERATOR_INTERFACE_VERSION: u32 = 1;
+
+/// The fidius interface version of the ACCUMULATOR-operator contract
+/// (continuation — see [`AccumulatorInvocation`]).
+pub const ACCUMULATOR_OPERATOR_INTERFACE_VERSION: u32 = 1;
+
+/// The fidius interface version of the REACTOR-operator contract
+/// (continuation — see [`ReactorInvocation`]).
+pub const REACTOR_OPERATOR_INTERFACE_VERSION: u32 = 1;
 
 /// Which cloacina runtime primitive a WASM operator implements. The loader
 /// (CLOACI-T-0823 for `Task`; the rest land in T-0824) switches on this to pick
@@ -190,6 +218,125 @@ impl TaskOutcome {
     }
 }
 
+// ---------------------------------------------------------------------------
+// TRIGGER primitive — the WASM-boundary wire types (CLOACI-T-0824).
+// ---------------------------------------------------------------------------
+
+/// What crosses INTO a trigger operator's `poll`. The async `Trigger::poll`
+/// takes no arguments, but every operator method is single-arg over the WASM
+/// boundary, so the host passes this (currently-empty) envelope. `context_json`
+/// is reserved so a future host can feed the last-fired context back into a
+/// poll without a wire break.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct TriggerInvocation {
+    /// Reserved: JSON-serialized context from a prior fire, if the host chooses
+    /// to thread it through. Empty for all current poll calls.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_json: Option<String>,
+}
+
+/// What crosses OUT of a trigger operator's `poll`. The host bridge maps this to
+/// a [`cloacina_workflow::TriggerResult`]: `fire == true` →
+/// `Fire(context_json?)`, `fire == false` → `Skip`. A populated `error` is
+/// surfaced as a `TriggerError::PollError` (polling then continues next tick).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PollOutcome {
+    /// Whether the workflow should fire this tick.
+    pub fire: bool,
+    /// Optional JSON-serialized `Context` to fire with (only meaningful when
+    /// `fire`). `None` fires with no context.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_json: Option<String>,
+    /// Optional poll error; surfaced as `TriggerError::PollError` by the host.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+impl PollOutcome {
+    /// Fire the workflow, optionally carrying a context JSON.
+    pub fn fire(context_json: Option<String>) -> Self {
+        Self {
+            fire: true,
+            context_json,
+            error: None,
+        }
+    }
+
+    /// Skip this tick (keep polling).
+    pub fn skip() -> Self {
+        Self {
+            fire: false,
+            context_json: None,
+            error: None,
+        }
+    }
+
+    /// A failed poll, surfaced host-side as `TriggerError::PollError`.
+    pub fn err(message: impl Into<String>) -> Self {
+        Self {
+            fire: false,
+            context_json: None,
+            error: Some(message.into()),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ACCUMULATOR primitive — wire types (CLOACI-T-0824 continuation).
+// ---------------------------------------------------------------------------
+
+/// What crosses INTO an accumulator operator's `ingest`: one raw event. Mirrors
+/// `cloacina`'s `Accumulator::process(event: Vec<u8>) -> Option<Output>`, except
+/// the bytes are base64/JSON-string-carried to keep the boundary a JSON String
+/// like the other primitives. The host event loop calls `ingest` per event and
+/// forwards any produced boundary to the reactor.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AccumulatorInvocation {
+    /// Raw event payload as a JSON string (the guest owns deserialization, the
+    /// runtime is format-agnostic — mirrors the native `Accumulator` contract).
+    pub event_json: String,
+}
+
+/// What crosses OUT of an accumulator operator's `ingest`: an optional boundary
+/// for the reactor (mirrors `Option<Self::Output>`). `boundary_json == None`
+/// means "buffered, no boundary emitted this event".
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AccumulatorOutcome {
+    /// JSON-serialized boundary to forward to the reactor, if one was produced.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub boundary_json: Option<String>,
+    /// Optional ingest error.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// REACTOR primitive — wire types (CLOACI-T-0824 continuation).
+// ---------------------------------------------------------------------------
+
+/// What crosses INTO a reactor operator's `evaluate`: the set of currently-held
+/// boundaries (one JSON blob per named accumulator slot). Mirrors the reactor's
+/// firing-criteria evaluation over its accumulator set.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ReactorInvocation {
+    /// JSON-serialized boundaries keyed by accumulator name.
+    pub boundaries_json: String,
+}
+
+/// What crosses OUT of a reactor operator's `evaluate`: whether to fire the
+/// downstream computation graph, and the context to fire it with.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ReactorOutcome {
+    /// Whether the reactor's firing criteria are satisfied.
+    pub fire: bool,
+    /// JSON-serialized context to fire the graph with (only when `fire`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_json: Option<String>,
+    /// Optional evaluate error.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -235,5 +382,46 @@ mod tests {
         let err = TaskOutcome::err("boom");
         assert!(!err.success);
         assert_eq!(err.error.as_deref(), Some("boom"));
+    }
+
+    #[test]
+    fn trigger_wire_round_trips() {
+        let inv = TriggerInvocation::default();
+        let s = serde_json::to_string(&inv).unwrap();
+        let back: TriggerInvocation = serde_json::from_str(&s).unwrap();
+        assert_eq!(inv, back);
+
+        let fire = PollOutcome::fire(Some(r#"{"hit":true}"#.into()));
+        let s = serde_json::to_string(&fire).unwrap();
+        let back: PollOutcome = serde_json::from_str(&s).unwrap();
+        assert_eq!(fire, back);
+        assert!(back.fire);
+        assert_eq!(back.context_json.as_deref(), Some(r#"{"hit":true}"#));
+
+        let skip = PollOutcome::skip();
+        assert!(!skip.fire);
+        assert!(skip.context_json.is_none());
+
+        let err = PollOutcome::err("poll boom");
+        assert!(!err.fire);
+        assert_eq!(err.error.as_deref(), Some("poll boom"));
+    }
+
+    #[test]
+    fn accumulator_and_reactor_wire_round_trip() {
+        let acc = AccumulatorOutcome {
+            boundary_json: Some(r#"{"sum":3}"#.into()),
+            error: None,
+        };
+        let s = serde_json::to_string(&acc).unwrap();
+        assert_eq!(serde_json::from_str::<AccumulatorOutcome>(&s).unwrap(), acc);
+
+        let rea = ReactorOutcome {
+            fire: true,
+            context_json: Some(r#"{"go":1}"#.into()),
+            error: None,
+        };
+        let s = serde_json::to_string(&rea).unwrap();
+        assert_eq!(serde_json::from_str::<ReactorOutcome>(&s).unwrap(), rea);
     }
 }

--- a/crates/cloacina-operator-contract/src/lib.rs
+++ b/crates/cloacina-operator-contract/src/lib.rs
@@ -1,0 +1,239 @@
+/*
+ *  Copyright 2025-2026 Colliery Software
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+//! # Operator contract (CLOACI-I-0132)
+//!
+//! The cloacina-defined OPERATOR CONTRACT shared by the host loader
+//! ([`cloacina`]'s `operators-wasm` path, CLOACI-T-0823) and a WASM guest
+//! operator. It carries two distinct things:
+//!
+//! 1. **The operator MANIFEST schema** ([`OperatorManifest`] / [`PrimitiveKind`])
+//!    — package metadata the macros emit (CLOACI-T-0826) and that the loader
+//!    reads to learn which cloacina primitive (task | trigger | accumulator |
+//!    reactor) a component implements, plus its param schema and dependencies.
+//!    The manifest does NOT cross the per-call WASM boundary; it travels
+//!    alongside the component in the fidius package as a sidecar `operator.json`.
+//!
+//! 2. **The per-primitive WASM-BOUNDARY wire types.** Operator methods are
+//!    SYNCHRONOUS (the guest has no async runtime — CLOACI-T-0821) and everything
+//!    that crosses the sandbox is serde-serializable. For the TASK primitive that
+//!    is [`TaskInvocation`] in / [`TaskOutcome`] out. To stay faithful to the
+//!    de-risked spike (String wire) and to cloacina's existing
+//!    `TaskExecutionRequest`/`TaskExecutionResult` FFI (context carried as a JSON
+//!    string), the boundary moves a JSON string: `JSON(TaskInvocation)` in,
+//!    `JSON(TaskOutcome)` out.
+//!
+//! ## The `TaskOperator` sync trait shape
+//!
+//! The TASK primitive's WASM interface is a single SYNC method — the
+//! WASM-compatible analogue of the async `cloacina_workflow::Task::execute`:
+//!
+//! ```rust,ignore
+//! // guest declares with crate = "fidius_guest"; host loader re-declares the
+//! // identical trait with crate = "fidius_core" to obtain the matching
+//! // `TaskOperator_WASM_DESCRIPTOR` (CLOACI-T-0821).
+//! #[plugin_interface(version = 1, buffer = PluginAllocated, crate = "fidius_guest")]
+//! pub trait TaskOperator: Send + Sync {
+//!     /// `JSON(TaskInvocation)` in -> `JSON(TaskOutcome)` out. SYNC.
+//!     fn execute(&self, invocation_json: String) -> String;
+//! }
+//! ```
+//!
+//! The `#[plugin_interface]` declaration itself lives wherever a fidius `crate =`
+//! target is bound (guest crate / host loader); it cannot live here because this
+//! crate is fidius-agnostic so it stays wasm-buildable from serde alone. The
+//! method index for `execute` is `0` ([`METHOD_EXECUTE`]).
+//!
+//! Sibling primitives (trigger `poll`, accumulator `ingest`, reactor `evaluate`)
+//! are all single-arg JSON-String-in/JSON-String-out, sync — their wire types
+//! are deferred to CLOACI-T-0824 alongside their loader/registry wiring.
+
+use serde::{Deserialize, Serialize};
+
+/// Re-export of the canonical CLOACI-I-0128 input-slot descriptor. The operator
+/// manifest's `params` reuse this verbatim (NOT a vendored copy), so an
+/// operator's injectable runtime surface is described with the same
+/// JSON-Schema-typed slots the rest of cloacina uses.
+pub use cloacina_api_types::InputSlot;
+
+/// The vtable method index of `TaskOperator::execute` (the single sync method).
+pub const METHOD_EXECUTE: usize = 0;
+
+/// The fidius interface version of the TASK-operator contract. Must match the
+/// `version` passed to the guest/host `#[plugin_interface(version = ..)]` and is
+/// cross-checked against [`OperatorManifest::interface_version`] by the loader.
+pub const TASK_OPERATOR_INTERFACE_VERSION: u32 = 1;
+
+/// Which cloacina runtime primitive a WASM operator implements. The loader
+/// (CLOACI-T-0823 for `Task`; the rest land in T-0824) switches on this to pick
+/// the matching fidius interface descriptor and register the component against
+/// the right runtime subsystem.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PrimitiveKind {
+    /// `execute(context) -> context` — the unit of work (implemented here).
+    Task,
+    /// `poll() -> TriggerResult` — a specialized trigger (T-0824).
+    Trigger,
+    /// `ingest(event) -> buffer` — accumulates boundary events (T-0824).
+    Accumulator,
+    /// `evaluate(criteria) -> fire?` — fires a computation graph (T-0824).
+    Reactor,
+}
+
+/// The cloacina operator manifest — emitted by the macros (the same seam that
+/// emits packaged-workflow `PackageTasksMetadata`, CLOACI-T-0826), serialized
+/// into the fidius package as a sidecar `operator.json`, and read by the loader.
+///
+/// `interface` / `interface_version` link the manifest to the fidius descriptor
+/// the host must load: the descriptor's `interface_export` is what gets linked,
+/// `interface_version` must match, and the `fidius-interface-hash` export gates
+/// integrity (CLOACI-T-0821). The manifest only tells the loader *which*
+/// descriptor + primitive; it is metadata, not a call payload.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct OperatorManifest {
+    /// Operator name (author-given, unique within a package).
+    pub name: String,
+    /// Operator version (semver string).
+    pub version: String,
+    /// Which runtime primitive this operator plugs into.
+    pub primitive_kind: PrimitiveKind,
+    /// fidius interface name (kebab) the component exports, e.g. `task-operator`.
+    pub interface: String,
+    /// fidius interface version — must match the descriptor's interface version.
+    pub interface_version: u32,
+    /// Declared param schema (CLOACI-I-0128 [`InputSlot`]s) for the operator's
+    /// injectable runtime surface (task context keys / trigger config / etc.).
+    #[serde(default)]
+    pub params: Vec<InputSlot>,
+    /// Other operators/packages this operator depends on (names).
+    #[serde(default)]
+    pub dependencies: Vec<String>,
+    /// Optional human description.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Optional author.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub author: Option<String>,
+}
+
+impl OperatorManifest {
+    /// Serialize to the JSON form that travels in the package (sidecar
+    /// `operator.json`). JSON (not TOML) because `InputSlot::schema` is an
+    /// arbitrary JSON-Schema fragment.
+    pub fn to_json(&self) -> Result<String, serde_json::Error> {
+        serde_json::to_string_pretty(self)
+    }
+
+    /// Parse the package's `operator.json` back into a manifest.
+    pub fn from_json(s: &str) -> Result<Self, serde_json::Error> {
+        serde_json::from_str(s)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// TASK primitive — the WASM-boundary wire types.
+// ---------------------------------------------------------------------------
+
+/// What crosses INTO a task operator's `execute`: the runtime context as a JSON
+/// string (mirrors `cloacina`'s `TaskExecutionRequest.context_json`). The host
+/// async bridge serializes `Context<serde_json::Value>` to this before the
+/// blocking WASM call.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TaskInvocation {
+    /// JSON-serialized `Context<serde_json::Value>` data map.
+    pub context_json: String,
+}
+
+/// What crosses OUT of a task operator's `execute` (mirrors cloacina's
+/// `TaskExecutionResult`). The host bridge rebuilds `Context` from
+/// `context_json` on success, or surfaces `error` as a `TaskError`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TaskOutcome {
+    pub success: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_json: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+impl TaskOutcome {
+    /// A successful outcome carrying the updated context JSON.
+    pub fn ok(context_json: String) -> Self {
+        Self {
+            success: true,
+            context_json: Some(context_json),
+            error: None,
+        }
+    }
+
+    /// A failed outcome carrying an error message (surfaced as a `TaskError`).
+    pub fn err(message: impl Into<String>) -> Self {
+        Self {
+            success: false,
+            context_json: None,
+            error: Some(message.into()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn manifest_round_trips_through_json() {
+        let m = OperatorManifest {
+            name: "greet".into(),
+            version: "0.1.0".into(),
+            primitive_kind: PrimitiveKind::Task,
+            interface: "task-operator".into(),
+            interface_version: TASK_OPERATOR_INTERFACE_VERSION,
+            params: vec![InputSlot::required(
+                "name",
+                serde_json::json!({"type": "string"}),
+            )],
+            dependencies: vec![],
+            description: Some("prefixes a name".into()),
+            author: None,
+        };
+        let json = m.to_json().unwrap();
+        let back = OperatorManifest::from_json(&json).unwrap();
+        assert_eq!(m, back);
+        assert_eq!(back.primitive_kind, PrimitiveKind::Task);
+        assert_eq!(back.params[0].name, "name");
+    }
+
+    #[test]
+    fn task_wire_round_trips() {
+        let inv = TaskInvocation {
+            context_json: r#"{"name":"world"}"#.into(),
+        };
+        let s = serde_json::to_string(&inv).unwrap();
+        let back: TaskInvocation = serde_json::from_str(&s).unwrap();
+        assert_eq!(inv, back);
+
+        let out = TaskOutcome::ok(r#"{"name":"world","result":"hi world"}"#.into());
+        let s = serde_json::to_string(&out).unwrap();
+        let back: TaskOutcome = serde_json::from_str(&s).unwrap();
+        assert_eq!(out, back);
+        assert!(back.success);
+
+        let err = TaskOutcome::err("boom");
+        assert!(!err.success);
+        assert_eq!(err.error.as_deref(), Some("boom"));
+    }
+}

--- a/crates/cloacina/Cargo.toml
+++ b/crates/cloacina/Cargo.toml
@@ -23,6 +23,16 @@ sqlite = ["diesel/sqlite", "diesel/returning_clauses_for_sqlite_3_35", "deadpool
 auth = ["postgres"]
 macros = ["cloacina-macros"]
 kafka = ["rdkafka"]
+# CLOACI-I-0132 / T-0823 — WASM task-operator loader + executor bridge.
+# OFF by default: enabling it turns on fidius-host's `wasm` feature (→ wasmtime +
+# cranelift, ~55 crates) and pulls fidius-macro (for the host-side interface
+# descriptor) + the operator contract crate. The default cloacina build pulls
+# NONE of this.
+operators-wasm = [
+    "dep:fidius-macro",
+    "dep:cloacina-operator-contract",
+    "fidius-host/wasm",
+]
 
 [dependencies]
 # Workspace dependencies
@@ -51,6 +61,10 @@ dotenvy = { version = "0.15" }
 bzip2 = { version = "0.4" }
 fidius-host = "0.5.4"
 fidius-core = "0.5.4"
+# Only compiled in when `operators-wasm` is on (host-side interface descriptor +
+# the shared operator contract). Default builds pull neither.
+fidius-macro = { version = "0.5.4", optional = true }
+cloacina-operator-contract = { workspace = true, optional = true }
 libloading = { version = "0.8" }
 parking_lot = { version = "0.12" }
 rdkafka = { version = "0.39", features = ["tokio"], optional = true }

--- a/crates/cloacina/src/registry/loader/mod.rs
+++ b/crates/cloacina/src/registry/loader/mod.rs
@@ -33,4 +33,7 @@ pub use package_loader::PackageLoader;
 pub use task_registrar::TaskRegistrar;
 
 #[cfg(feature = "operators-wasm")]
-pub use operator_loader::{load_task_operator, WasmTaskOperator};
+pub use operator_loader::{
+    load_operator, load_task_operator, load_trigger_operator, OperatorBinding, TriggerBinding,
+    WasmTaskOperator, WasmTriggerOperator,
+};

--- a/crates/cloacina/src/registry/loader/mod.rs
+++ b/crates/cloacina/src/registry/loader/mod.rs
@@ -22,8 +22,15 @@
 
 pub mod ffi_trigger;
 pub mod ffi_triggerless_graph;
+/// WASM task-operator loader + executor adapter (CLOACI-I-0132 / T-0823).
+/// Default-OFF behind the `operators-wasm` feature.
+#[cfg(feature = "operators-wasm")]
+pub mod operator_loader;
 pub mod package_loader;
 pub mod task_registrar;
 
 pub use package_loader::PackageLoader;
 pub use task_registrar::TaskRegistrar;
+
+#[cfg(feature = "operators-wasm")]
+pub use operator_loader::{load_task_operator, WasmTaskOperator};

--- a/crates/cloacina/src/registry/loader/operator_loader.rs
+++ b/crates/cloacina/src/registry/loader/operator_loader.rs
@@ -1,0 +1,260 @@
+/*
+ *  Copyright 2025-2026 Colliery Software
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+// The fidius `#[plugin_interface]` macro emits a `#[cfg(host)]`-style gate that
+// the workspace's check-cfg lint flags as unknown — benign (see CLOACI-T-0821).
+#![allow(unexpected_cfgs)]
+
+//! WASM operator loader + task-executor adapter (CLOACI-I-0132 / T-0823).
+//!
+//! Loads a WASM **task operator** package (a `.wasm` component + a sidecar
+//! `operator.json` manifest) and wraps the configured fidius handle as a
+//! [`crate::task::Task`] the existing async executor can run unchanged.
+//!
+//! Gated behind the default-OFF `operators-wasm` feature: enabling it turns on
+//! `fidius-host`'s `wasm` feature (→ wasmtime/cranelift) and pulls
+//! `fidius-macro` + `cloacina-operator-contract`. The default cloacina build
+//! pulls none of this (verified via `cargo tree`).
+//!
+//! ## Flow
+//!
+//! 1. Read the package's `operator.json` into an [`OperatorManifest`].
+//! 2. Require `primitive_kind == Task` (trigger/accumulator/reactor loading is
+//!    CLOACI-T-0824) and `interface_version` matching the contract.
+//! 3. `load_wasm_configured(component, &config)` — config binds ONCE at load.
+//! 4. Wrap the handle as a [`WasmTaskOperator`]; its `impl Task` is the
+//!    **async↔sync bridge**: serialize `Context` → `JSON(TaskInvocation)` →
+//!    `spawn_blocking` the wasmtime `call_method` → parse `JSON(TaskOutcome)` →
+//!    rebuild `Context`, surfacing a failed outcome as a [`TaskError`].
+//!
+//! ## Deferred (CLOACI-T-0824)
+//!
+//! The trigger `poll` / accumulator `ingest` / reactor `evaluate` bridges and
+//! the Runtime-registry wiring (registering a loaded operator into the scheduler
+//! registries) live in T-0824. The `#[operator]` authoring macro is T-0826.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use chrono::Utc;
+use serde::Serialize;
+
+use cloacina_operator_contract::{
+    OperatorManifest, PrimitiveKind, TaskInvocation, TaskOutcome, METHOD_EXECUTE,
+    TASK_OPERATOR_INTERFACE_VERSION,
+};
+use fidius_host::PluginHost;
+
+use crate::context::Context;
+use crate::error::TaskError;
+use crate::registry::error::LoaderError;
+use crate::task::{Task, TaskNamespace};
+
+/// Host-side re-declaration of the TASK-operator interface. This is the SAME
+/// trait shape the guest implements; declaring it with `crate = "fidius_core"`
+/// makes the fidius macro emit the matching `TaskOperator_WASM_DESCRIPTOR` (in
+/// the companion `__fidius_TaskOperator` module) that the loader links the
+/// component against. The `fidius-interface-hash` export then gates integrity at
+/// load (CLOACI-T-0821).
+#[fidius_macro::plugin_interface(version = 1, buffer = PluginAllocated, crate = "fidius_core")]
+pub trait TaskOperator: Send + Sync {
+    /// `JSON(TaskInvocation)` in -> `JSON(TaskOutcome)` out. SYNC.
+    fn execute(&self, invocation_json: String) -> String;
+}
+
+/// The sidecar manifest filename inside a WASM operator package.
+pub const OPERATOR_MANIFEST_FILE: &str = "operator.json";
+
+/// A loaded, configured WASM task operator wrapped as a cloacina [`Task`].
+///
+/// Holds the configured fidius [`PluginHandle`](fidius_host::PluginHandle) (the
+/// `configure` hook bound the operator's config once at load, so per-call
+/// `execute` dispatches on the already-configured persistent store). The handle
+/// is held behind an [`Arc`] so the async bridge can hand a `'static + Send`
+/// clone to `spawn_blocking`; concurrent calls are serialized inside the handle
+/// (the WASM backend guards its store with a mutex).
+pub struct WasmTaskOperator {
+    id: String,
+    handle: Arc<fidius_host::PluginHandle>,
+    dependencies: Vec<TaskNamespace>,
+}
+
+impl WasmTaskOperator {
+    /// The operator's declared name (its task id).
+    pub fn name(&self) -> &str {
+        &self.id
+    }
+}
+
+impl std::fmt::Debug for WasmTaskOperator {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WasmTaskOperator")
+            .field("id", &self.id)
+            .field("dependencies", &self.dependencies)
+            .finish_non_exhaustive()
+    }
+}
+
+#[async_trait]
+impl Task for WasmTaskOperator {
+    /// The async↔sync bridge: serialize the context, hop into the blocking
+    /// wasmtime call on a `spawn_blocking` thread, and rebuild the context from
+    /// the outcome. A failed [`TaskOutcome`] becomes a [`TaskError`].
+    async fn execute(
+        &self,
+        context: Context<serde_json::Value>,
+    ) -> Result<Context<serde_json::Value>, TaskError> {
+        let id = self.id.clone();
+
+        // Context -> JSON(TaskInvocation).
+        let context_json = context
+            .to_json()
+            .map_err(|e| exec_err(&id, format!("serialize context: {e}")))?;
+        let inv_json = serde_json::to_string(&TaskInvocation { context_json })
+            .map_err(|e| exec_err(&id, format!("serialize invocation: {e}")))?;
+
+        // Blocking wasmtime call off the async executor.
+        let handle = self.handle.clone();
+        let call_id = id.clone();
+        let out_json: String = tokio::task::spawn_blocking(move || {
+            handle.call_method::<_, String>(METHOD_EXECUTE, &(inv_json,))
+        })
+        .await
+        .map_err(|e| exec_err(&call_id, format!("operator task join: {e}")))?
+        .map_err(|e| exec_err(&call_id, format!("operator FFI call: {e}")))?;
+
+        // JSON(TaskOutcome) -> Context (or surface the failure).
+        let outcome: TaskOutcome = serde_json::from_str(&out_json)
+            .map_err(|e| exec_err(&id, format!("parse outcome: {e}")))?;
+
+        if outcome.success {
+            let updated = outcome
+                .context_json
+                .ok_or_else(|| exec_err(&id, "successful outcome missing context_json"))?;
+            Context::from_json(updated)
+                .map_err(|e| exec_err(&id, format!("rebuild context: {e}")))
+        } else {
+            Err(exec_err(
+                &id,
+                outcome
+                    .error
+                    .unwrap_or_else(|| "operator reported failure with no message".to_string()),
+            ))
+        }
+    }
+
+    fn id(&self) -> &str {
+        &self.id
+    }
+
+    fn dependencies(&self) -> &[TaskNamespace] {
+        &self.dependencies
+    }
+}
+
+fn exec_err(task_id: &str, message: impl Into<String>) -> TaskError {
+    TaskError::ExecutionFailed {
+        message: message.into(),
+        task_id: task_id.to_string(),
+        timestamp: Utc::now(),
+    }
+}
+
+/// Read and parse a package's sidecar `operator.json` manifest.
+pub fn read_operator_manifest(package_dir: &Path) -> Result<OperatorManifest, LoaderError> {
+    let path = package_dir.join(OPERATOR_MANIFEST_FILE);
+    let raw = std::fs::read_to_string(&path).map_err(|e| LoaderError::FileSystem {
+        path: path.display().to_string(),
+        error: e.to_string(),
+    })?;
+    OperatorManifest::from_json(&raw).map_err(|e| LoaderError::ManifestParse {
+        reason: format!("{OPERATOR_MANIFEST_FILE}: {e}"),
+    })
+}
+
+/// Load a WASM **task** operator and return it as a runnable [`Task`].
+///
+/// `search_path` is a directory containing operator package subdirectories;
+/// `package_name` is the `[package].name` in the package's `package.toml` (what
+/// fidius matches on). `config` binds the operator's per-instance configuration
+/// once at load (the `configure` hook) — two loads with different configs yield
+/// two independently-configured operators.
+///
+/// Fails closed (a clear [`LoaderError`]) if the package is missing, the
+/// manifest is unreadable, the primitive is not a `Task`, or the interface
+/// version doesn't match the contract. (fidius's `fidius-interface-hash` export
+/// additionally gates ABI integrity inside `load_wasm_configured`.)
+pub fn load_task_operator<C: Serialize>(
+    search_path: impl AsRef<Path>,
+    package_name: &str,
+    config: &C,
+) -> Result<Arc<dyn Task>, LoaderError> {
+    let search_path = search_path.as_ref();
+
+    let host = PluginHost::builder()
+        .search_path(search_path)
+        .build()
+        .map_err(|e| LoaderError::LibraryLoad {
+            path: search_path.display().to_string(),
+            error: format!("build plugin host: {e}"),
+        })?;
+
+    // Resolve the package directory so we can read its sidecar manifest.
+    let dir = host
+        .find_wasm_package(package_name)
+        .map_err(|e| LoaderError::Validation {
+            reason: format!("locate wasm operator package '{package_name}': {e}"),
+        })?;
+
+    let manifest = read_operator_manifest(&dir)?;
+
+    if manifest.primitive_kind != PrimitiveKind::Task {
+        return Err(LoaderError::Validation {
+            reason: format!(
+                "operator '{}' is {:?}, not Task; trigger/accumulator/reactor loading is CLOACI-T-0824",
+                manifest.name, manifest.primitive_kind
+            ),
+        });
+    }
+
+    if manifest.interface_version != TASK_OPERATOR_INTERFACE_VERSION {
+        return Err(LoaderError::Validation {
+            reason: format!(
+                "operator '{}' declares task-operator interface v{}, loader supports v{}",
+                manifest.name, manifest.interface_version, TASK_OPERATOR_INTERFACE_VERSION
+            ),
+        });
+    }
+
+    // Config binds ONCE here; the integrity hash is checked inside fidius.
+    let handle = host
+        .load_wasm_configured(
+            package_name,
+            &__fidius_TaskOperator::TaskOperator_WASM_DESCRIPTOR,
+            config,
+        )
+        .map_err(|e| LoaderError::LibraryLoad {
+            path: dir.display().to_string(),
+            error: format!("load_wasm_configured: {e}"),
+        })?;
+
+    Ok(Arc::new(WasmTaskOperator {
+        id: manifest.name,
+        handle: Arc::new(handle),
+        dependencies: Vec::new(),
+    }))
+}

--- a/crates/cloacina/src/registry/loader/operator_loader.rs
+++ b/crates/cloacina/src/registry/loader/operator_loader.rs
@@ -18,51 +18,80 @@
 // the workspace's check-cfg lint flags as unknown — benign (see CLOACI-T-0821).
 #![allow(unexpected_cfgs)]
 
-//! WASM operator loader + task-executor adapter (CLOACI-I-0132 / T-0823).
+//! WASM operator loader + primitive adapters (CLOACI-I-0132 / T-0823, T-0824).
 //!
-//! Loads a WASM **task operator** package (a `.wasm` component + a sidecar
-//! `operator.json` manifest) and wraps the configured fidius handle as a
-//! [`crate::task::Task`] the existing async executor can run unchanged.
+//! Loads a WASM **operator** package (a `.wasm` component + a sidecar
+//! `operator.json` manifest) and wraps the configured fidius handle as the
+//! cloacina primitive the manifest's `primitive_kind` names — a
+//! [`crate::task::Task`] (T-0823) or a [`crate::trigger::Trigger`] (T-0824) —
+//! that the existing async executor / scheduler can run unchanged, then
+//! registers it into a [`Runtime`] so it participates in workflows/schedules
+//! exactly like a macro-authored one.
 //!
 //! Gated behind the default-OFF `operators-wasm` feature: enabling it turns on
 //! `fidius-host`'s `wasm` feature (→ wasmtime/cranelift) and pulls
 //! `fidius-macro` + `cloacina-operator-contract`. The default cloacina build
 //! pulls none of this (verified via `cargo tree`).
 //!
-//! ## Flow
+//! ## Flow (per primitive)
 //!
 //! 1. Read the package's `operator.json` into an [`OperatorManifest`].
-//! 2. Require `primitive_kind == Task` (trigger/accumulator/reactor loading is
-//!    CLOACI-T-0824) and `interface_version` matching the contract.
+//! 2. Require the `primitive_kind` the caller asked for and an
+//!    `interface_version` matching that primitive's contract.
 //! 3. `load_wasm_configured(component, &config)` — config binds ONCE at load.
-//! 4. Wrap the handle as a [`WasmTaskOperator`]; its `impl Task` is the
-//!    **async↔sync bridge**: serialize `Context` → `JSON(TaskInvocation)` →
-//!    `spawn_blocking` the wasmtime `call_method` → parse `JSON(TaskOutcome)` →
-//!    rebuild `Context`, surfacing a failed outcome as a [`TaskError`].
+//! 4. Wrap the handle as the matching adapter and run the **async↔sync bridge**:
+//!    serialize the async input → `JSON(...Invocation)` → `spawn_blocking` the
+//!    wasmtime `call_method` → parse `JSON(...Outcome)` → rebuild the async
+//!    result, surfacing a failed outcome as the primitive's normal error.
+//!    - TASK: `Context` → [`TaskInvocation`] / [`TaskOutcome`] → `Context`.
+//!    - TRIGGER: `()` → [`TriggerInvocation`] / [`PollOutcome`] →
+//!      [`TriggerResult`].
 //!
-//! ## Deferred (CLOACI-T-0824)
+//! ## Runtime registration
 //!
-//! The trigger `poll` / accumulator `ingest` / reactor `evaluate` bridges and
-//! the Runtime-registry wiring (registering a loaded operator into the scheduler
-//! registries) live in T-0824. The `#[operator]` authoring macro is T-0826.
+//! [`load_operator`] reads the manifest and dispatches on `primitive_kind`,
+//! registering the configured primitive into a [`Runtime`] (Task →
+//! [`Runtime::register_task`], Trigger → [`Runtime::register_trigger`]). The
+//! registered constructor hands out `Arc` clones that share the one configured
+//! fidius handle, so every `get_task`/`get_trigger` call dispatches into the
+//! same sandboxed instance.
+//!
+//! ## Continuation (CLOACI-T-0824 follow-up)
+//!
+//! The ACCUMULATOR `ingest` / REACTOR `evaluate` bridges have their sync
+//! contract traits ([`AccumulatorOperator`] / [`ReactorOperator`]) and wire
+//! types defined here + in the contract crate, and their adapter shape is
+//! sketched ([`WasmAccumulatorOperator`] / [`WasmReactorOperator`]); a full
+//! event-loop / reactor-firing impl + fixtures is a noted continuation because
+//! those primitives are not simple `Runtime` constructors (the accumulator has
+//! no `Runtime` registry; a reactor registers a `ReactorRegistration`
+//! descriptor, not a callable). The `#[operator]` authoring macro is T-0826.
 
 use std::path::Path;
 use std::sync::Arc;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use chrono::Utc;
 use serde::Serialize;
 
 use cloacina_operator_contract::{
-    OperatorManifest, PrimitiveKind, TaskInvocation, TaskOutcome, METHOD_EXECUTE,
-    TASK_OPERATOR_INTERFACE_VERSION,
+    OperatorManifest, PollOutcome, PrimitiveKind, TaskInvocation, TaskOutcome, TriggerInvocation,
+    METHOD_EXECUTE, METHOD_POLL, TASK_OPERATOR_INTERFACE_VERSION,
+    TRIGGER_OPERATOR_INTERFACE_VERSION,
 };
 use fidius_host::PluginHost;
 
 use crate::context::Context;
 use crate::error::TaskError;
 use crate::registry::error::LoaderError;
+use crate::runtime::Runtime;
 use crate::task::{Task, TaskNamespace};
+use crate::trigger::{Trigger, TriggerResult};
+// The leaf-crate `Trigger` trait (re-exported as `crate::trigger::Trigger`)
+// returns `cloacina_workflow::TriggerError`, NOT the engine-local
+// `crate::trigger::TriggerError`, so the `impl Trigger` must use that type.
+use cloacina_workflow::TriggerError;
 
 /// Host-side re-declaration of the TASK-operator interface. This is the SAME
 /// trait shape the guest implements; declaring it with `crate = "fidius_core"`
@@ -74,6 +103,17 @@ use crate::task::{Task, TaskNamespace};
 pub trait TaskOperator: Send + Sync {
     /// `JSON(TaskInvocation)` in -> `JSON(TaskOutcome)` out. SYNC.
     fn execute(&self, invocation_json: String) -> String;
+}
+
+/// Host-side re-declaration of the TRIGGER-operator interface (CLOACI-T-0824).
+/// Same trait shape the guest implements; the fidius macro emits the matching
+/// `TriggerOperator_WASM_DESCRIPTOR` (in `__fidius_TriggerOperator`) the loader
+/// links the component against. Single SYNC method — the WASM analogue of the
+/// async `cloacina_workflow::Trigger::poll`.
+#[fidius_macro::plugin_interface(version = 1, buffer = PluginAllocated, crate = "fidius_core")]
+pub trait TriggerOperator: Send + Sync {
+    /// `JSON(TriggerInvocation)` in -> `JSON(PollOutcome)` out. SYNC.
+    fn poll(&self, invocation_json: String) -> String;
 }
 
 /// The sidecar manifest filename inside a WASM operator package.
@@ -257,4 +297,325 @@ pub fn load_task_operator<C: Serialize>(
         handle: Arc::new(handle),
         dependencies: Vec::new(),
     }))
+}
+
+// ===========================================================================
+// TRIGGER primitive (CLOACI-T-0824)
+// ===========================================================================
+
+/// Host-side scheduling metadata bound to a trigger operator at load.
+///
+/// The WASM guest's `poll` decides *whether* to fire; the *cadence* and the
+/// scheduler-routing metadata (poll interval, cron expression, target workflow,
+/// concurrency) are host concerns the guest never sees. The operator manifest
+/// has no poll-interval field (it describes the component, not a deployment), so
+/// these are bound here — the trigger analogue of "config binds once at load".
+#[derive(Debug, Clone)]
+pub struct TriggerBinding {
+    /// How often the reconciler polls this trigger (ignored for cron triggers).
+    pub poll_interval: Duration,
+    /// Whether concurrent fires with the same context hash are allowed.
+    pub allow_concurrent: bool,
+    /// The workflow this trigger fires (the `#[trigger(on = "...")]` binding).
+    pub workflow_name: String,
+    /// Optional cron expression; `Some` routes to the cron scheduler instead of
+    /// the poll-interval trigger registry.
+    pub cron_expression: Option<String>,
+}
+
+impl Default for TriggerBinding {
+    fn default() -> Self {
+        Self {
+            poll_interval: Duration::from_secs(60),
+            allow_concurrent: false,
+            workflow_name: String::new(),
+            cron_expression: None,
+        }
+    }
+}
+
+/// A loaded, configured WASM trigger operator wrapped as a cloacina [`Trigger`].
+///
+/// Mirrors [`WasmTaskOperator`]: holds the configured fidius handle behind an
+/// [`Arc`] so the async `poll` bridge can hand a `'static + Send` clone to
+/// `spawn_blocking`. The host-side [`TriggerBinding`] supplies the scheduling
+/// metadata the `Trigger` trait exposes (`poll_interval`, `workflow_name`, …).
+pub struct WasmTriggerOperator {
+    name: String,
+    handle: Arc<fidius_host::PluginHandle>,
+    binding: TriggerBinding,
+}
+
+impl std::fmt::Debug for WasmTriggerOperator {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WasmTriggerOperator")
+            .field("name", &self.name)
+            .field("binding", &self.binding)
+            .finish_non_exhaustive()
+    }
+}
+
+#[async_trait]
+impl Trigger for WasmTriggerOperator {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn poll_interval(&self) -> Duration {
+        self.binding.poll_interval
+    }
+
+    fn allow_concurrent(&self) -> bool {
+        self.binding.allow_concurrent
+    }
+
+    fn cron_expression(&self) -> Option<String> {
+        self.binding.cron_expression.clone()
+    }
+
+    fn workflow_name(&self) -> &str {
+        &self.binding.workflow_name
+    }
+
+    /// The async↔sync bridge: serialize the (empty) invocation, hop into the
+    /// blocking wasmtime `poll` on a `spawn_blocking` thread, and map the
+    /// [`PollOutcome`] to a [`TriggerResult`]. A populated outcome `error`
+    /// becomes a [`TriggerError::PollError`].
+    async fn poll(&self) -> Result<TriggerResult, TriggerError> {
+        let name = self.name.clone();
+
+        let inv_json = serde_json::to_string(&TriggerInvocation::default()).map_err(|e| {
+            TriggerError::PollError {
+                message: format!("trigger '{name}': serialize invocation: {e}"),
+            }
+        })?;
+
+        let handle = self.handle.clone();
+        let call_name = name.clone();
+        let out_json: String = tokio::task::spawn_blocking(move || {
+            handle.call_method::<_, String>(METHOD_POLL, &(inv_json,))
+        })
+        .await
+        .map_err(|e| TriggerError::PollError {
+            message: format!("trigger '{call_name}': poll join: {e}"),
+        })?
+        .map_err(|e| TriggerError::PollError {
+            message: format!("trigger '{call_name}': poll FFI call: {e}"),
+        })?;
+
+        let outcome: PollOutcome =
+            serde_json::from_str(&out_json).map_err(|e| TriggerError::PollError {
+                message: format!("trigger '{name}': parse poll outcome: {e}"),
+            })?;
+
+        if let Some(err) = outcome.error {
+            return Err(TriggerError::PollError {
+                message: format!("trigger '{name}': {err}"),
+            });
+        }
+
+        if !outcome.fire {
+            return Ok(TriggerResult::Skip);
+        }
+
+        match outcome.context_json {
+            None => Ok(TriggerResult::Fire(None)),
+            Some(ctx_json) => {
+                let ctx = Context::from_json(ctx_json).map_err(|e| TriggerError::PollError {
+                    message: format!("trigger '{name}': rebuild fire context: {e}"),
+                })?;
+                Ok(TriggerResult::Fire(Some(ctx)))
+            }
+        }
+    }
+}
+
+/// Load a WASM **trigger** operator and return it as a runnable [`Trigger`].
+///
+/// `config` binds the operator's per-instance WASM configuration once at load
+/// (the guest's `configure` hook); `binding` supplies the host-side scheduling
+/// metadata the `Trigger` trait exposes (poll interval / cron / target
+/// workflow). Fails closed if the package is missing, the manifest is
+/// unreadable, the primitive is not a `Trigger`, or the interface version
+/// doesn't match the trigger contract.
+pub fn load_trigger_operator<C: Serialize>(
+    search_path: impl AsRef<Path>,
+    package_name: &str,
+    config: &C,
+    binding: TriggerBinding,
+) -> Result<Arc<dyn Trigger>, LoaderError> {
+    let search_path = search_path.as_ref();
+
+    let host = PluginHost::builder()
+        .search_path(search_path)
+        .build()
+        .map_err(|e| LoaderError::LibraryLoad {
+            path: search_path.display().to_string(),
+            error: format!("build plugin host: {e}"),
+        })?;
+
+    let dir = host
+        .find_wasm_package(package_name)
+        .map_err(|e| LoaderError::Validation {
+            reason: format!("locate wasm operator package '{package_name}': {e}"),
+        })?;
+
+    let manifest = read_operator_manifest(&dir)?;
+
+    if manifest.primitive_kind != PrimitiveKind::Trigger {
+        return Err(LoaderError::Validation {
+            reason: format!(
+                "operator '{}' is {:?}, not Trigger",
+                manifest.name, manifest.primitive_kind
+            ),
+        });
+    }
+
+    if manifest.interface_version != TRIGGER_OPERATOR_INTERFACE_VERSION {
+        return Err(LoaderError::Validation {
+            reason: format!(
+                "operator '{}' declares trigger-operator interface v{}, loader supports v{}",
+                manifest.name, manifest.interface_version, TRIGGER_OPERATOR_INTERFACE_VERSION
+            ),
+        });
+    }
+
+    let handle = host
+        .load_wasm_configured(
+            package_name,
+            &__fidius_TriggerOperator::TriggerOperator_WASM_DESCRIPTOR,
+            config,
+        )
+        .map_err(|e| LoaderError::LibraryLoad {
+            path: dir.display().to_string(),
+            error: format!("load_wasm_configured: {e}"),
+        })?;
+
+    Ok(Arc::new(WasmTriggerOperator {
+        name: manifest.name,
+        handle: Arc::new(handle),
+        binding,
+    }))
+}
+
+// ===========================================================================
+// Runtime registration — dispatch on primitive_kind (CLOACI-T-0824)
+// ===========================================================================
+
+/// Per-primitive binding the caller supplies to [`load_operator`]. The variant
+/// must match the loaded operator's `primitive_kind` or the load fails closed.
+pub enum OperatorBinding {
+    /// Register the loaded operator as a [`Task`] under this namespace.
+    Task {
+        /// The namespace the task constructor is registered under (the same
+        /// 4-tuple a macro-authored task would occupy).
+        namespace: TaskNamespace,
+    },
+    /// Register the loaded operator as a [`Trigger`] with this scheduling
+    /// metadata. The trigger is keyed in the registry by the manifest `name`.
+    Trigger(TriggerBinding),
+}
+
+/// Load a WASM operator and register the configured primitive into `runtime`,
+/// dispatching on the manifest's `primitive_kind`.
+///
+/// This is the seam that makes a loaded operator a first-class participant in
+/// workflows/schedules: after this returns, `runtime.get_task(ns)` /
+/// `runtime.get_trigger(name)` hand out the configured operator exactly as they
+/// would a macro-authored one. The registered constructor clones a shared `Arc`
+/// over the single configured fidius handle, so every instantiation dispatches
+/// into the same sandboxed store.
+///
+/// Fails closed if the [`OperatorBinding`] variant doesn't match the operator's
+/// declared `primitive_kind`, or on any underlying load error.
+pub fn load_operator<C: Serialize>(
+    runtime: &Runtime,
+    search_path: impl AsRef<Path>,
+    package_name: &str,
+    config: &C,
+    binding: OperatorBinding,
+) -> Result<(), LoaderError> {
+    let search_path = search_path.as_ref();
+
+    // Peek the manifest so a mismatched binding fails before we pay for a load.
+    let host = PluginHost::builder()
+        .search_path(search_path)
+        .build()
+        .map_err(|e| LoaderError::LibraryLoad {
+            path: search_path.display().to_string(),
+            error: format!("build plugin host: {e}"),
+        })?;
+    let dir = host
+        .find_wasm_package(package_name)
+        .map_err(|e| LoaderError::Validation {
+            reason: format!("locate wasm operator package '{package_name}': {e}"),
+        })?;
+    let manifest = read_operator_manifest(&dir)?;
+
+    match (&binding, manifest.primitive_kind) {
+        (OperatorBinding::Task { namespace }, PrimitiveKind::Task) => {
+            let task = load_task_operator(search_path, package_name, config)?;
+            let namespace = namespace.clone();
+            runtime.register_task(namespace, move || task.clone());
+            Ok(())
+        }
+        (OperatorBinding::Trigger(tb), PrimitiveKind::Trigger) => {
+            let name = manifest.name.clone();
+            let trigger = load_trigger_operator(search_path, package_name, config, tb.clone())?;
+            runtime.register_trigger(name, move || trigger.clone());
+            Ok(())
+        }
+        (_, kind) => Err(LoaderError::Validation {
+            reason: format!(
+                "operator '{}' is {:?}, which does not match the supplied binding \
+                 (accumulator/reactor registration is a CLOACI-T-0824 continuation)",
+                manifest.name, kind
+            ),
+        }),
+    }
+}
+
+// ===========================================================================
+// ACCUMULATOR + REACTOR primitives — sketched continuation (CLOACI-T-0824)
+// ===========================================================================
+//
+// The contract traits + wire types are defined (here and in the contract
+// crate). The host bridges below mirror the task/trigger pattern but are left
+// as a clearly-noted continuation: unlike Task/Trigger, neither primitive is a
+// plain `Runtime` constructor.
+//
+//   * ACCUMULATOR — `cloacina::computation_graph::accumulator::Accumulator` is a
+//     stateful `&mut self` event sink (`process(Vec<u8>) -> Option<Output>`)
+//     driven by an async runtime loop (`accumulator_runtime`), NOT a `Runtime`
+//     registry entry. A `WasmAccumulatorOperator` would own the configured
+//     handle and, per event, `spawn_blocking` the sync `ingest`
+//     (`JSON(AccumulatorInvocation)` -> `JSON(AccumulatorOutcome)`) and forward
+//     any `boundary_json` to the reactor via the `BoundarySender`. Wiring it in
+//     means standing up that event loop against a loaded handle.
+//
+//   * REACTOR — the runtime represents a reactor as a `ReactorRegistration`
+//     *descriptor* (name + accumulator set + reaction mode), not a callable;
+//     firing is evaluated by the CG scheduler. A `WasmReactorOperator` would
+//     bridge the firing *decision* (`JSON(ReactorInvocation)` ->
+//     `JSON(ReactorOutcome)`), but registering it requires threading a callable
+//     evaluator through the scheduler, which is beyond this task's surface.
+//
+// The sync contract traits are declared host-side so the descriptors exist and
+// the shapes are validated by the compiler; the adapters are intentionally not
+// yet implemented.
+
+/// Host-side re-declaration of the ACCUMULATOR-operator interface (continuation).
+/// `JSON(AccumulatorInvocation)` in -> `JSON(AccumulatorOutcome)` out. SYNC.
+#[fidius_macro::plugin_interface(version = 1, buffer = PluginAllocated, crate = "fidius_core")]
+pub trait AccumulatorOperator: Send + Sync {
+    /// Ingest one event, optionally producing a boundary for the reactor.
+    fn ingest(&self, invocation_json: String) -> String;
+}
+
+/// Host-side re-declaration of the REACTOR-operator interface (continuation).
+/// `JSON(ReactorInvocation)` in -> `JSON(ReactorOutcome)` out. SYNC.
+#[fidius_macro::plugin_interface(version = 1, buffer = PluginAllocated, crate = "fidius_core")]
+pub trait ReactorOperator: Send + Sync {
+    /// Evaluate firing criteria over the held boundaries.
+    fn evaluate(&self, invocation_json: String) -> String;
 }

--- a/crates/cloacina/tests/operator_loader_wasm.rs
+++ b/crates/cloacina/tests/operator_loader_wasm.rs
@@ -1,0 +1,198 @@
+/*
+ *  Copyright 2025-2026 Colliery Software
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+//! CLOACI-T-0823 — end-to-end: a WASM **task operator** runs as a cloacina
+//! [`Task`].
+//!
+//! Builds the proven task-operator fixture (a wasm32-wasip2 component), stages
+//! it as an operator package (`.wasm` + `package.toml` + sidecar
+//! `operator.json`), loads it through the cloacina `operators-wasm` loader to
+//! get a `Arc<dyn Task>`, runs `execute` with a `Context { name: "world" }`, and
+//! asserts the resulting context has `result == "hello, world"`. A second load
+//! with a different prefix proves config-binding (the two operators differ).
+//!
+//! Feature-gated: only built/run with `--features operators-wasm` (which pulls
+//! wasmtime). The default cloacina build excludes this entirely.
+#![cfg(feature = "operators-wasm")]
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::OnceLock;
+
+use cloacina::registry::loader::operator_loader::load_task_operator;
+use cloacina::Context;
+use cloacina_operator_contract::{InputSlot, OperatorManifest, PrimitiveKind};
+use serde::Serialize;
+
+/// Per-instance config the loader binds once at load (mirrors the fixture's
+/// `Config { prefix }`). bincode-compatible with the guest struct.
+#[derive(Serialize)]
+struct Config {
+    prefix: String,
+}
+
+/// The manifest the `#[operator]` macro (CLOACI-T-0826) WOULD emit for the
+/// fixture; constructed by hand here. Uses the REAL contract crate's types
+/// (canonical `InputSlot` reused, not vendored).
+fn fixture_manifest() -> OperatorManifest {
+    OperatorManifest {
+        name: "greet".into(),
+        version: "0.1.0".into(),
+        primitive_kind: PrimitiveKind::Task,
+        interface: "task-operator".into(),
+        interface_version: 1,
+        params: vec![InputSlot::required(
+            "name",
+            serde_json::json!({"type": "string"}),
+        )],
+        dependencies: vec![],
+        description: Some("Prefixes the context `name` into `result`.".into()),
+        author: Some("CLOACI-T-0823".into()),
+    }
+}
+
+/// Build the operator fixture to a wasm component once; return its bytes. Reuses
+/// the proven fixture under `examples/operator-contract/task-operator-fixture`.
+fn component() -> &'static [u8] {
+    static BYTES: OnceLock<Vec<u8>> = OnceLock::new();
+    BYTES.get_or_init(|| {
+        let fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../examples/operator-contract/task-operator-fixture");
+        let status = Command::new("cargo")
+            .args(["build", "--target", "wasm32-wasip2", "--release"])
+            .current_dir(&fixture)
+            .status()
+            .expect("spawn cargo build --target wasm32-wasip2");
+        assert!(status.success(), "task-operator-fixture wasm build failed");
+        std::fs::read(fixture.join("target/wasm32-wasip2/release/task_operator_fixture.wasm"))
+            .expect("read built wasm component")
+    })
+}
+
+/// Stage the component + package.toml + the operator manifest sidecar.
+fn stage(root: &Path) {
+    let dir = root.join("task-operator-pkg");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("task_operator_fixture.wasm"), component()).unwrap();
+    std::fs::write(
+        dir.join("package.toml"),
+        "[package]\nname = \"task-operator-pkg\"\nversion = \"0.1.0\"\n\
+         interface = \"task-operator\"\ninterface_version = 1\nruntime = \"wasm\"\n\n\
+         [metadata]\ncategory = \"operator\"\n\n\
+         [wasm]\ncomponent = \"task_operator_fixture.wasm\"\n",
+    )
+    .unwrap();
+    std::fs::write(dir.join("operator.json"), fixture_manifest().to_json().unwrap()).unwrap();
+}
+
+#[tokio::test]
+async fn wasm_task_operator_runs_as_cloacina_task() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    stage(tmp.path());
+
+    // Load the operator through the cloacina loader → a runnable Task.
+    let task = load_task_operator(
+        tmp.path(),
+        "task-operator-pkg",
+        &Config {
+            prefix: "hello, ".into(),
+        },
+    )
+    .expect("load_task_operator");
+
+    assert_eq!(task.id(), "greet");
+    assert!(task.dependencies().is_empty());
+
+    // Run it as a Task with a real Context.
+    let mut ctx = Context::new();
+    ctx.insert("name", serde_json::json!("world")).unwrap();
+
+    let out = task.execute(ctx).await.expect("operator task execute");
+
+    assert_eq!(
+        out.get("result"),
+        Some(&serde_json::json!("hello, world")),
+        "operator should write result = prefix + name"
+    );
+    // Original context key is preserved across the boundary.
+    assert_eq!(out.get("name"), Some(&serde_json::json!("world")));
+}
+
+#[tokio::test]
+async fn config_binds_at_load_so_instances_differ() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    stage(tmp.path());
+
+    let hello = load_task_operator(
+        tmp.path(),
+        "task-operator-pkg",
+        &Config {
+            prefix: "hello, ".into(),
+        },
+    )
+    .expect("load hello operator");
+
+    let goodbye = load_task_operator(
+        tmp.path(),
+        "task-operator-pkg",
+        &Config {
+            prefix: "goodbye, ".into(),
+        },
+    )
+    .expect("load goodbye operator");
+
+    let mk = || {
+        let mut c = Context::new();
+        c.insert("name", serde_json::json!("world")).unwrap();
+        c
+    };
+
+    let hello_out = hello.execute(mk()).await.unwrap();
+    let goodbye_out = goodbye.execute(mk()).await.unwrap();
+
+    assert_eq!(hello_out.get("result"), Some(&serde_json::json!("hello, world")));
+    assert_eq!(
+        goodbye_out.get("result"),
+        Some(&serde_json::json!("goodbye, world")),
+    );
+    assert_ne!(hello_out.get("result"), goodbye_out.get("result"));
+}
+
+#[tokio::test]
+async fn non_task_primitive_fails_closed() {
+    // A manifest that claims a non-Task primitive must be rejected by the
+    // Task loader (trigger/accumulator/reactor loading is CLOACI-T-0824).
+    let tmp = tempfile::TempDir::new().unwrap();
+    stage(tmp.path());
+    // Overwrite the sidecar with a non-Task primitive_kind.
+    let mut manifest = fixture_manifest();
+    manifest.primitive_kind = PrimitiveKind::Trigger;
+    std::fs::write(
+        tmp.path().join("task-operator-pkg").join("operator.json"),
+        manifest.to_json().unwrap(),
+    )
+    .unwrap();
+
+    let result = load_task_operator(
+        tmp.path(),
+        "task-operator-pkg",
+        &Config { prefix: "x".into() },
+    );
+    match result {
+        Ok(_) => panic!("non-Task primitive should fail closed"),
+        Err(err) => assert!(format!("{err}").contains("not Task"), "got: {err}"),
+    }
+}

--- a/crates/cloacina/tests/operator_trigger_wasm.rs
+++ b/crates/cloacina/tests/operator_trigger_wasm.rs
@@ -1,0 +1,343 @@
+/*
+ *  Copyright 2025-2026 Colliery Software
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+//! CLOACI-T-0824 — end-to-end: a WASM **trigger operator** runs as a cloacina
+//! [`Trigger`], and a loaded operator registers into the correct [`Runtime`]
+//! registry by `primitive_kind`.
+//!
+//! Builds the trigger-operator fixture (a wasm32-wasip2 component), stages it as
+//! an operator package (`.wasm` + `package.toml` + sidecar `operator.json`),
+//! loads it through the cloacina `operators-wasm` loader to get an
+//! `Arc<dyn Trigger>`, and asserts `poll()` returns `Fire`/`Skip` per the
+//! config bound at load. Then proves the Runtime-registration path: loading a
+//! trigger operator lands it in `Runtime::get_trigger`, and loading the task
+//! operator lands it in `Runtime::get_task` — each keyed by `primitive_kind`.
+//!
+//! Feature-gated: only built/run with `--features operators-wasm`.
+#![cfg(feature = "operators-wasm")]
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use cloacina::registry::loader::operator_loader::{
+    load_operator, load_trigger_operator, OperatorBinding, TriggerBinding,
+};
+use cloacina::trigger::TriggerResult;
+use cloacina::{Context, Runtime, TaskNamespace};
+use cloacina_operator_contract::{InputSlot, OperatorManifest, PrimitiveKind};
+use serde::Serialize;
+
+/// Per-instance config the loader binds once at load (mirrors the trigger
+/// fixture's `Config { should_fire, message }`).
+#[derive(Serialize)]
+struct TriggerConfig {
+    should_fire: bool,
+    message: String,
+}
+
+/// Config for the task fixture (mirrors `task-operator-fixture::Config`).
+#[derive(Serialize)]
+struct TaskConfig {
+    prefix: String,
+}
+
+fn trigger_manifest() -> OperatorManifest {
+    OperatorManifest {
+        name: "tick".into(),
+        version: "0.1.0".into(),
+        primitive_kind: PrimitiveKind::Trigger,
+        interface: "trigger-operator".into(),
+        interface_version: 1,
+        params: vec![InputSlot::optional(
+            "should_fire",
+            serde_json::json!({"type": "boolean"}),
+            Some(serde_json::json!(false)),
+        )],
+        dependencies: vec![],
+        description: Some("Fires (or skips) on a config flag.".into()),
+        author: Some("CLOACI-T-0824".into()),
+    }
+}
+
+fn task_manifest() -> OperatorManifest {
+    OperatorManifest {
+        name: "greet".into(),
+        version: "0.1.0".into(),
+        primitive_kind: PrimitiveKind::Task,
+        interface: "task-operator".into(),
+        interface_version: 1,
+        params: vec![InputSlot::required(
+            "name",
+            serde_json::json!({"type": "string"}),
+        )],
+        dependencies: vec![],
+        description: Some("Prefixes the context `name` into `result`.".into()),
+        author: Some("CLOACI-T-0824".into()),
+    }
+}
+
+/// Build a fixture crate under `examples/operator-contract/<dir>` to a wasm
+/// component once; return its bytes.
+fn build_component(dir_name: &'static str, wasm_file: &'static str) -> Vec<u8> {
+    let fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../examples/operator-contract")
+        .join(dir_name);
+    let status = Command::new("cargo")
+        .args(["build", "--target", "wasm32-wasip2", "--release"])
+        .current_dir(&fixture)
+        .status()
+        .expect("spawn cargo build --target wasm32-wasip2");
+    assert!(status.success(), "{dir_name} wasm build failed");
+    std::fs::read(
+        fixture
+            .join("target/wasm32-wasip2/release")
+            .join(wasm_file),
+    )
+    .expect("read built wasm component")
+}
+
+fn trigger_component() -> &'static [u8] {
+    static BYTES: OnceLock<Vec<u8>> = OnceLock::new();
+    BYTES.get_or_init(|| {
+        build_component("trigger-operator-fixture", "trigger_operator_fixture.wasm")
+    })
+}
+
+fn task_component() -> &'static [u8] {
+    static BYTES: OnceLock<Vec<u8>> = OnceLock::new();
+    BYTES.get_or_init(|| build_component("task-operator-fixture", "task_operator_fixture.wasm"))
+}
+
+/// Stage a wasm operator package: component + package.toml + operator.json.
+fn stage(
+    root: &Path,
+    pkg: &str,
+    wasm_file: &str,
+    bytes: &[u8],
+    interface: &str,
+    manifest: &OperatorManifest,
+) {
+    let dir = root.join(pkg);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join(wasm_file), bytes).unwrap();
+    std::fs::write(
+        dir.join("package.toml"),
+        format!(
+            "[package]\nname = \"{pkg}\"\nversion = \"0.1.0\"\n\
+             interface = \"{interface}\"\ninterface_version = 1\nruntime = \"wasm\"\n\n\
+             [metadata]\ncategory = \"operator\"\n\n\
+             [wasm]\ncomponent = \"{wasm_file}\"\n"
+        ),
+    )
+    .unwrap();
+    std::fs::write(dir.join("operator.json"), manifest.to_json().unwrap()).unwrap();
+}
+
+fn stage_trigger(root: &Path) {
+    stage(
+        root,
+        "trigger-operator-pkg",
+        "trigger_operator_fixture.wasm",
+        trigger_component(),
+        "trigger-operator",
+        &trigger_manifest(),
+    );
+}
+
+fn stage_task(root: &Path) {
+    stage(
+        root,
+        "task-operator-pkg",
+        "task_operator_fixture.wasm",
+        task_component(),
+        "task-operator",
+        &task_manifest(),
+    );
+}
+
+#[tokio::test]
+async fn wasm_trigger_operator_fires_when_configured() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    stage_trigger(tmp.path());
+
+    let trigger = load_trigger_operator(
+        tmp.path(),
+        "trigger-operator-pkg",
+        &TriggerConfig {
+            should_fire: true,
+            message: "boundary crossed".into(),
+        },
+        TriggerBinding {
+            poll_interval: Duration::from_secs(5),
+            allow_concurrent: true,
+            workflow_name: "my_workflow".into(),
+            cron_expression: None,
+        },
+    )
+    .expect("load_trigger_operator");
+
+    assert_eq!(trigger.name(), "tick");
+    assert_eq!(trigger.poll_interval(), Duration::from_secs(5));
+    assert!(trigger.allow_concurrent());
+    assert_eq!(trigger.workflow_name(), "my_workflow");
+    assert!(trigger.cron_expression().is_none());
+
+    let result = trigger.poll().await.expect("poll");
+    assert!(result.should_fire(), "config should_fire=true → Fire");
+    let ctx = result.into_context().expect("fire carries a context");
+    assert_eq!(ctx.get("reason"), Some(&serde_json::json!("boundary crossed")));
+}
+
+#[tokio::test]
+async fn wasm_trigger_operator_skips_when_configured_off() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    stage_trigger(tmp.path());
+
+    let trigger = load_trigger_operator(
+        tmp.path(),
+        "trigger-operator-pkg",
+        &TriggerConfig {
+            should_fire: false,
+            message: "unused".into(),
+        },
+        TriggerBinding::default(),
+    )
+    .expect("load_trigger_operator");
+
+    let result = trigger.poll().await.expect("poll");
+    assert!(
+        !result.should_fire(),
+        "config should_fire=false → Skip, got {result:?}"
+    );
+    assert!(matches!(result, TriggerResult::Skip));
+}
+
+#[tokio::test]
+async fn non_trigger_primitive_fails_closed() {
+    // The task package's manifest claims primitive Task; the trigger loader
+    // must reject it.
+    let tmp = tempfile::TempDir::new().unwrap();
+    stage_task(tmp.path());
+
+    let result = load_trigger_operator(
+        tmp.path(),
+        "task-operator-pkg",
+        &TaskConfig {
+            prefix: "x".into(),
+        },
+        TriggerBinding::default(),
+    );
+    match result {
+        Ok(_) => panic!("a Task package must not load as a Trigger"),
+        Err(err) => assert!(format!("{err}").contains("not Trigger"), "got: {err}"),
+    }
+}
+
+#[tokio::test]
+async fn load_operator_registers_trigger_into_runtime() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    stage_trigger(tmp.path());
+
+    let runtime = Runtime::empty();
+    assert!(runtime.get_trigger("tick").is_none());
+
+    load_operator(
+        &runtime,
+        tmp.path(),
+        "trigger-operator-pkg",
+        &TriggerConfig {
+            should_fire: true,
+            message: "registered fire".into(),
+        },
+        OperatorBinding::Trigger(TriggerBinding {
+            poll_interval: Duration::from_secs(30),
+            allow_concurrent: false,
+            workflow_name: "wf".into(),
+            cron_expression: None,
+        }),
+    )
+    .expect("load_operator (trigger)");
+
+    // Registered in the trigger registry, NOT the task registry.
+    assert_eq!(runtime.trigger_names(), vec!["tick".to_string()]);
+    let trigger = runtime.get_trigger("tick").expect("registered trigger");
+    assert_eq!(trigger.poll_interval(), Duration::from_secs(30));
+
+    // And it actually dispatches into the configured sandbox.
+    let result = trigger.poll().await.expect("poll registered trigger");
+    let ctx = result.into_context().expect("fire");
+    assert_eq!(ctx.get("reason"), Some(&serde_json::json!("registered fire")));
+}
+
+#[tokio::test]
+async fn load_operator_registers_task_into_runtime() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    stage_task(tmp.path());
+
+    let runtime = Runtime::empty();
+    let ns = TaskNamespace::new("public", "task-operator-pkg", "ops", "greet");
+    assert!(runtime.get_task(&ns).is_none());
+
+    load_operator(
+        &runtime,
+        tmp.path(),
+        "task-operator-pkg",
+        &TaskConfig {
+            prefix: "hello, ".into(),
+        },
+        OperatorBinding::Task {
+            namespace: ns.clone(),
+        },
+    )
+    .expect("load_operator (task)");
+
+    // Registered in the task registry, NOT the trigger registry.
+    assert!(runtime.trigger_names().is_empty());
+    let task = runtime.get_task(&ns).expect("registered task");
+
+    let mut ctx = Context::new();
+    ctx.insert("name", serde_json::json!("world")).unwrap();
+    let out = task.execute(ctx).await.expect("execute registered task");
+    assert_eq!(out.get("result"), Some(&serde_json::json!("hello, world")));
+}
+
+#[tokio::test]
+async fn load_operator_rejects_mismatched_binding() {
+    // Task package, but caller hands a Trigger binding → fail closed.
+    let tmp = tempfile::TempDir::new().unwrap();
+    stage_task(tmp.path());
+
+    let runtime = Runtime::empty();
+    let result = load_operator(
+        &runtime,
+        tmp.path(),
+        "task-operator-pkg",
+        &TaskConfig {
+            prefix: "x".into(),
+        },
+        OperatorBinding::Trigger(TriggerBinding::default()),
+    );
+    match result {
+        Ok(_) => panic!("mismatched binding must fail closed"),
+        Err(err) => assert!(
+            format!("{err}").contains("does not match"),
+            "got: {err}"
+        ),
+    }
+    assert!(runtime.trigger_names().is_empty());
+}

--- a/examples/operator-contract/host/Cargo.toml
+++ b/examples/operator-contract/host/Cargo.toml
@@ -1,0 +1,27 @@
+# CLOACI-T-0822 operator contract — host side (tests).
+#
+# Loads the task-operator-fixture component via fidius `load_wasm_configured`,
+# proves (1) the operator MANIFEST round-trips (produced -> package -> read) and
+# carries the primitive kind the loader switches on, and (2) the configured
+# TASK operator loads + invokes across the sandbox with a serialized context.
+#
+# Standalone crate, EXCLUDED from the cloacina workspace (under examples/* plus
+# the empty [workspace] table). fidius-host `wasm` feature pulls wasmtime.
+[workspace]
+
+[package]
+name = "operator-contract-host"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+fidius-host = { version = "0.5.4", features = ["wasm"] }
+fidius-macro = "0.5.4"
+fidius-core = "0.5.4"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+operator-contract = { path = "../operator-contract" }
+
+[dev-dependencies]
+tempfile = "3"

--- a/examples/operator-contract/host/src/lib.rs
+++ b/examples/operator-contract/host/src/lib.rs
@@ -1,0 +1,2 @@
+// CLOACI-T-0822 operator contract — host side (empty lib; the proof is the
+// integration test under tests/).

--- a/examples/operator-contract/host/tests/task_operator_contract.rs
+++ b/examples/operator-contract/host/tests/task_operator_contract.rs
@@ -1,0 +1,202 @@
+// CLOACI-T-0822 operator contract — host load + invoke + manifest round-trip.
+//
+// Two proofs:
+//   1. `manifest_round_trips_and_carries_primitive_kind` — the cloacina operator
+//      MANIFEST the macros emit serializes into the package and reads back
+//      identically, exposing the `primitive_kind` the loader (T-0823) switches
+//      on to pick the descriptor.
+//   2. `configured_task_operator_loads_and_invokes` — a fidius-macro-authored
+//      SYNC `TaskOperator` (wasm32-wasip2 component) is loaded *configured*
+//      (`load_wasm_configured`) and invoked with a serialized task context; the
+//      operator reads `name`, writes `result`, and hands the context back.
+//
+// The host re-declares the SAME `TaskOperator` interface the fixture implements
+// (with `crate = "fidius_core"`) so the macro emits a matching
+// `TaskOperator_WASM_DESCRIPTOR` (companion module `__fidius_TaskOperator`).
+
+#![allow(unexpected_cfgs)]
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::OnceLock;
+
+use fidius_host::PluginHost;
+use operator_contract::{InputSlot, OperatorManifest, PrimitiveKind, TaskInvocation, TaskOutcome};
+use serde::Serialize;
+
+/// Per-instance config the host binds once (mirrors the fixture's `Config`).
+#[derive(Serialize)]
+struct Config {
+    prefix: String,
+}
+
+// SAME interface as the fixture → matching macro-generated descriptor + hash.
+// `crate = "fidius_core"` is the host-side variant of the guest's
+// `crate = "fidius_guest"` declaration.
+#[fidius_macro::plugin_interface(version = 1, buffer = PluginAllocated, crate = "fidius_core")]
+pub trait TaskOperator: Send + Sync {
+    fn execute(&self, invocation_json: String) -> String;
+}
+
+/// The manifest the `#[task(operator)]` macro WOULD emit for the fixture. In the
+/// real integration this is generated at the existing metadata-emission seam
+/// (alongside `PackageTasksMetadata`) and written into the package; here we
+/// construct it by hand to prove the schema + round-trip.
+fn fixture_manifest() -> OperatorManifest {
+    OperatorManifest {
+        name: "greet".into(),
+        version: "0.1.0".into(),
+        primitive_kind: PrimitiveKind::Task,
+        interface: "task-operator".into(),
+        interface_version: 1,
+        params: vec![InputSlot::required(
+            "name",
+            serde_json::json!({"type": "string"}),
+        )],
+        dependencies: vec![],
+        description: Some("Prefixes the context `name` into `result`.".into()),
+        author: Some("CLOACI-T-0822".into()),
+    }
+}
+
+/// Build the operator fixture to a wasm component once, return its bytes.
+fn component() -> &'static [u8] {
+    static BYTES: OnceLock<Vec<u8>> = OnceLock::new();
+    BYTES.get_or_init(|| {
+        let fixture =
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../task-operator-fixture");
+        let status = Command::new("cargo")
+            .args(["build", "--target", "wasm32-wasip2", "--release"])
+            .current_dir(&fixture)
+            .status()
+            .expect("cargo build --target wasm32-wasip2");
+        assert!(status.success(), "task-operator-fixture wasm build failed");
+        std::fs::read(
+            fixture.join("target/wasm32-wasip2/release/task_operator_fixture.wasm"),
+        )
+        .unwrap()
+    })
+}
+
+/// Stage the component + package.toml + the operator manifest sidecar.
+fn stage(root: &Path) {
+    let dir = root.join("task-operator-pkg");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("task_operator_fixture.wasm"), component()).unwrap();
+    std::fs::write(
+        dir.join("package.toml"),
+        "[package]\nname = \"task-operator-pkg\"\nversion = \"0.1.0\"\n\
+         interface = \"task-operator\"\ninterface_version = 1\nruntime = \"wasm\"\n\n\
+         [metadata]\ncategory = \"operator\"\n\n\
+         [wasm]\ncomponent = \"task_operator_fixture.wasm\"\n",
+    )
+    .unwrap();
+    // The cloacina operator manifest travels as a sidecar (what the loader reads).
+    std::fs::write(
+        dir.join("operator.json"),
+        fixture_manifest().to_json().unwrap(),
+    )
+    .unwrap();
+}
+
+#[test]
+fn manifest_round_trips_and_carries_primitive_kind() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    stage(tmp.path());
+
+    // Read the manifest back the way the loader (T-0823) would.
+    let raw = std::fs::read_to_string(
+        tmp.path().join("task-operator-pkg").join("operator.json"),
+    )
+    .unwrap();
+    let read = OperatorManifest::from_json(&raw).unwrap();
+
+    assert_eq!(read, fixture_manifest(), "manifest must round-trip exactly");
+    assert_eq!(
+        read.primitive_kind,
+        PrimitiveKind::Task,
+        "loader switches on primitive_kind to pick the descriptor"
+    );
+    assert_eq!(read.interface, "task-operator");
+    assert_eq!(read.interface_version, 1);
+    assert_eq!(read.params.len(), 1);
+    assert_eq!(read.params[0].name, "name");
+    assert!(read.params[0].required);
+}
+
+#[test]
+fn configured_task_operator_loads_and_invokes() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    stage(tmp.path());
+
+    // Loader flow: read manifest → confirm it's a Task → load via TaskOperator.
+    let raw = std::fs::read_to_string(
+        tmp.path().join("task-operator-pkg").join("operator.json"),
+    )
+    .unwrap();
+    let manifest = OperatorManifest::from_json(&raw).unwrap();
+    assert_eq!(manifest.primitive_kind, PrimitiveKind::Task);
+
+    let host = PluginHost::builder()
+        .search_path(tmp.path())
+        .build()
+        .unwrap();
+
+    let handle = host
+        .load_wasm_configured(
+            "task-operator-pkg",
+            &__fidius_TaskOperator::TaskOperator_WASM_DESCRIPTOR,
+            &Config {
+                prefix: "hello, ".into(),
+            },
+        )
+        .expect("load_wasm_configured");
+
+    // Host async wrapper would do this serialize/spawn_blocking call:
+    let invocation = TaskInvocation {
+        context_json: serde_json::json!({ "name": "world" }).to_string(),
+    };
+    let inv_json = serde_json::to_string(&invocation).unwrap();
+
+    // execute is method 0; single arg → tuple (T,); config already bound.
+    let out_json: String = handle.call_method(0, &(inv_json,)).unwrap();
+    let outcome: TaskOutcome = serde_json::from_str(&out_json).unwrap();
+
+    assert!(outcome.success, "outcome: {outcome:?}");
+    let ctx: serde_json::Value =
+        serde_json::from_str(&outcome.context_json.unwrap()).unwrap();
+    assert_eq!(ctx["result"], "hello, world");
+    // Original context key is preserved.
+    assert_eq!(ctx["name"], "world");
+}
+
+#[test]
+fn missing_required_input_surfaces_as_failed_outcome() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    stage(tmp.path());
+    let host = PluginHost::builder()
+        .search_path(tmp.path())
+        .build()
+        .unwrap();
+
+    let handle = host
+        .load_wasm_configured(
+            "task-operator-pkg",
+            &__fidius_TaskOperator::TaskOperator_WASM_DESCRIPTOR,
+            &Config {
+                prefix: "x".into(),
+            },
+        )
+        .unwrap();
+
+    // Context without the required `name` → a clean failed outcome, not a trap.
+    let invocation = TaskInvocation {
+        context_json: serde_json::json!({ "other": 1 }).to_string(),
+    };
+    let inv_json = serde_json::to_string(&invocation).unwrap();
+    let out_json: String = handle.call_method(0, &(inv_json,)).unwrap();
+    let outcome: TaskOutcome = serde_json::from_str(&out_json).unwrap();
+
+    assert!(!outcome.success);
+    assert!(outcome.error.unwrap().contains("name"));
+}

--- a/examples/operator-contract/operator-contract/Cargo.toml
+++ b/examples/operator-contract/operator-contract/Cargo.toml
@@ -1,0 +1,23 @@
+# CLOACI-T-0822 operator contract — shared contract types.
+#
+# Host- AND guest-shared, language-neutral contract for WASM operators:
+#   * the operator MANIFEST schema (name, version, primitive kind, param
+#     schema, dependencies) — cloacina-defined metadata that travels in the
+#     fidius package and tells the loader (T-0823) which primitive to register.
+#   * the per-primitive WASM-boundary wire types (task: TaskInvocation in,
+#     TaskOutcome out) — bincode/JSON-serializable, sync.
+#
+# Standalone (empty [workspace]) so the whole example stays workspace-excluded
+# and removable, matching the T-0821 spike ethos. Depends only on serde +
+# serde_json so it compiles for BOTH the host and the wasm32-wasip2 guest.
+[workspace]
+
+[package]
+name = "operator-contract"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/examples/operator-contract/operator-contract/src/lib.rs
+++ b/examples/operator-contract/operator-contract/src/lib.rs
@@ -1,0 +1,213 @@
+// CLOACI-T-0822 operator contract — shared, language-neutral contract types.
+//
+// This crate is the cloacina-defined OPERATOR CONTRACT shared by the host and
+// the WASM guest. It carries two distinct things:
+//
+//   1. The operator MANIFEST schema ([`OperatorManifest`] / [`PrimitiveKind`]) —
+//      package metadata the macros emit and that the loader (T-0823) reads to
+//      learn which cloacina primitive (task | trigger | accumulator | reactor)
+//      a component implements, plus its param schema and dependencies. The
+//      manifest does NOT cross the per-call WASM boundary; it travels alongside
+//      the component in the fidius package.
+//
+//   2. The per-primitive WASM-BOUNDARY wire types. Operator methods are
+//      SYNCHRONOUS (the guest has no async runtime — T-0821) and everything
+//      that crosses the sandbox is serde-serializable. For the TASK primitive
+//      that is [`TaskInvocation`] in / [`TaskOutcome`] out. To stay faithful to
+//      the de-risked spike (String->String wire) and to cloacina's existing
+//      `TaskExecutionRequest`/`TaskExecutionResult` FFI (context carried as a
+//      JSON string), the boundary moves a JSON string: `JSON(TaskInvocation)`
+//      in, `JSON(TaskOutcome)` out.
+//
+// NOTE: [`InputSlot`] below is a structural copy of `cloacina_api_types::InputSlot`
+// (the CLOACI-I-0128 descriptor). It is vendored here ONLY so this example stays
+// self-contained and removable; in the real integration the manifest reuses the
+// canonical `cloacina_api_types::InputSlot` verbatim.
+
+use serde::{Deserialize, Serialize};
+
+/// Which cloacina runtime primitive a WASM operator implements. The loader
+/// (T-0823) switches on this to pick the matching fidius interface descriptor
+/// and register the component against the right runtime subsystem.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PrimitiveKind {
+    /// `execute(context) -> context` — the unit of work (this first cut).
+    Task,
+    /// `poll() -> TriggerResult` — a specialized trigger.
+    Trigger,
+    /// `ingest(event) -> buffer` — accumulates boundary events.
+    Accumulator,
+    /// `evaluate(criteria) -> fire?` — fires a computation graph.
+    Reactor,
+}
+
+/// One declared input slot — a named, JSON-Schema-typed value the operator's
+/// runtime surface accepts. Structural copy of `cloacina_api_types::InputSlot`
+/// (CLOACI-I-0128); see module docs.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct InputSlot {
+    pub name: String,
+    pub schema: serde_json::Value,
+    pub required: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default: Option<serde_json::Value>,
+}
+
+impl InputSlot {
+    pub fn required(name: impl Into<String>, schema: serde_json::Value) -> Self {
+        Self {
+            name: name.into(),
+            schema,
+            required: true,
+            default: None,
+        }
+    }
+
+    pub fn optional(
+        name: impl Into<String>,
+        schema: serde_json::Value,
+        default: Option<serde_json::Value>,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            schema,
+            required: false,
+            default,
+        }
+    }
+}
+
+/// The cloacina operator manifest — emitted by the macros (the same seam that
+/// emits packaged-workflow `PackageTasksMetadata`), serialized into the fidius
+/// package, and read by the loader (T-0823).
+///
+/// `interface` / `interface_version` link the manifest to the fidius descriptor
+/// the host must load: the descriptor's `interface_export` is what gets linked,
+/// `interface_version` must match, and the `fidius-interface-hash` export gates
+/// integrity (T-0821). The manifest only tells the loader *which* descriptor +
+/// primitive; it is metadata, not a call payload.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct OperatorManifest {
+    /// Operator name (author-given, unique within a package).
+    pub name: String,
+    /// Operator version (semver string).
+    pub version: String,
+    /// Which runtime primitive this operator plugs into.
+    pub primitive_kind: PrimitiveKind,
+    /// fidius interface name (kebab) the component exports, e.g. `task-operator`.
+    pub interface: String,
+    /// fidius interface version — must match the descriptor's `interface_version`.
+    pub interface_version: u32,
+    /// Declared param schema (CLOACI-I-0128 `InputSlot`s) for the operator's
+    /// injectable runtime surface (task context keys / trigger config / etc.).
+    #[serde(default)]
+    pub params: Vec<InputSlot>,
+    /// Other operators/packages this operator depends on (names).
+    #[serde(default)]
+    pub dependencies: Vec<String>,
+    /// Optional human description.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Optional author.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub author: Option<String>,
+}
+
+impl OperatorManifest {
+    /// Serialize to the JSON form that travels in the package (sidecar
+    /// `operator.json`). JSON (not TOML) because `InputSlot::schema` is an
+    /// arbitrary JSON-Schema fragment.
+    pub fn to_json(&self) -> Result<String, serde_json::Error> {
+        serde_json::to_string_pretty(self)
+    }
+
+    /// Parse the package's `operator.json` back into a manifest.
+    pub fn from_json(s: &str) -> Result<Self, serde_json::Error> {
+        serde_json::from_str(s)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// TASK primitive — the WASM-boundary wire types (this first cut).
+// ---------------------------------------------------------------------------
+
+/// What crosses INTO a task operator's `execute`: the runtime context as a JSON
+/// string (mirrors `cloacina`'s `TaskExecutionRequest.context_json`). The host
+/// async wrapper serializes `Context<serde_json::Value>` to this before the
+/// blocking WASM call.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TaskInvocation {
+    /// JSON-serialized `Context<serde_json::Value>` data map.
+    pub context_json: String,
+}
+
+/// What crosses OUT of a task operator's `execute` (mirrors cloacina's
+/// `TaskExecutionResult`). The host wrapper rebuilds `Context` from
+/// `context_json` on success, or surfaces `error` as a `TaskError`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TaskOutcome {
+    pub success: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_json: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+impl TaskOutcome {
+    pub fn ok(context_json: String) -> Self {
+        Self {
+            success: true,
+            context_json: Some(context_json),
+            error: None,
+        }
+    }
+
+    pub fn err(message: impl Into<String>) -> Self {
+        Self {
+            success: false,
+            context_json: None,
+            error: Some(message.into()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn manifest_round_trips_through_json() {
+        let m = OperatorManifest {
+            name: "greet".into(),
+            version: "0.1.0".into(),
+            primitive_kind: PrimitiveKind::Task,
+            interface: "task-operator".into(),
+            interface_version: 1,
+            params: vec![InputSlot::required("name", serde_json::json!({"type": "string"}))],
+            dependencies: vec![],
+            description: Some("prefixes a name".into()),
+            author: None,
+        };
+        let json = m.to_json().unwrap();
+        let back = OperatorManifest::from_json(&json).unwrap();
+        assert_eq!(m, back);
+        assert_eq!(back.primitive_kind, PrimitiveKind::Task);
+    }
+
+    #[test]
+    fn task_wire_round_trips() {
+        let inv = TaskInvocation {
+            context_json: r#"{"name":"world"}"#.into(),
+        };
+        let s = serde_json::to_string(&inv).unwrap();
+        let back: TaskInvocation = serde_json::from_str(&s).unwrap();
+        assert_eq!(inv, back);
+
+        let out = TaskOutcome::ok(r#"{"name":"world","result":"hi world"}"#.into());
+        let s = serde_json::to_string(&out).unwrap();
+        let back: TaskOutcome = serde_json::from_str(&s).unwrap();
+        assert_eq!(out, back);
+        assert!(back.success);
+    }
+}

--- a/examples/operator-contract/operator-contract/src/lib.rs
+++ b/examples/operator-contract/operator-contract/src/lib.rs
@@ -172,6 +172,58 @@ impl TaskOutcome {
     }
 }
 
+// ---------------------------------------------------------------------------
+// TRIGGER primitive — the WASM-boundary wire types (CLOACI-T-0824).
+// ---------------------------------------------------------------------------
+
+/// What crosses INTO a trigger operator's `poll`. The async `Trigger::poll`
+/// takes no arguments, but every operator method is single-arg over the WASM
+/// boundary, so the host passes this (currently-empty) envelope.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct TriggerInvocation {
+    /// Reserved: JSON context from a prior fire, if the host threads it through.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_json: Option<String>,
+}
+
+/// What crosses OUT of a trigger operator's `poll`. The host maps this to a
+/// `TriggerResult`: `fire` → `Fire(context_json?)`, else `Skip`; `error` →
+/// `TriggerError::PollError`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PollOutcome {
+    pub fire: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_json: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+impl PollOutcome {
+    pub fn fire(context_json: Option<String>) -> Self {
+        Self {
+            fire: true,
+            context_json,
+            error: None,
+        }
+    }
+
+    pub fn skip() -> Self {
+        Self {
+            fire: false,
+            context_json: None,
+            error: None,
+        }
+    }
+
+    pub fn err(message: impl Into<String>) -> Self {
+        Self {
+            fire: false,
+            context_json: None,
+            error: Some(message.into()),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/examples/operator-contract/task-operator-fixture/Cargo.toml
+++ b/examples/operator-contract/task-operator-fixture/Cargo.toml
@@ -1,0 +1,35 @@
+# CLOACI-T-0822 operator contract — TASK operator guest fixture.
+#
+# A SYNCHRONOUS task operator authored with the fidius macros and built to a
+# wasm32-wasip2 component (the T-0821 recipe). Implements the `TaskOperator`
+# contract: JSON(TaskInvocation) in -> JSON(TaskOutcome) out. Config (the
+# instance's `prefix`) binds ONCE via the macro-emitted `fidius-configure`
+# export; `execute` then reads it without the caller re-passing it.
+#
+# Standalone crate, EXCLUDED from the cloacina workspace (under examples/*,
+# plus the empty [workspace] table below) so `cargo build --target
+# wasm32-wasip2` stays self-contained.
+[workspace]
+
+[package]
+name = "task-operator-fixture"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+fidius-guest = "0.5.4"
+fidius-macro = "0.5.4"
+wit-bindgen = "0.44"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+# Shared, language-neutral contract types (wire structs). serde-only → wasm-safe.
+operator-contract = { path = "../operator-contract" }
+
+[profile.release]
+opt-level = "s"
+lto = true
+strip = true

--- a/examples/operator-contract/task-operator-fixture/src/lib.rs
+++ b/examples/operator-contract/task-operator-fixture/src/lib.rs
@@ -1,0 +1,83 @@
+// CLOACI-T-0822 operator contract — TASK operator guest fixture.
+//
+// Proves the TASK-operator contract shape end-to-end: a SYNCHRONOUS fidius
+// operator implementing `TaskOperator` (the per-primitive sync trait), compiled
+// to a wasm32-wasip2 component, configured once and invoked across the sandbox.
+//
+// Contract recap (T-0821 constraints):
+//   * methods are SYNCHRONOUS — the guest has no async runtime.
+//   * config binds ONCE via `configure` (macro-emitted `fidius-configure`).
+//   * single-arg method, bincode/JSON wire: here `JSON(TaskInvocation)` in ->
+//     `JSON(TaskOutcome)` out (String boundary, matching the de-risked spike and
+//     cloacina's existing context-as-JSON-string FFI).
+
+use fidius_macro::{plugin_impl, plugin_interface};
+use operator_contract::{TaskInvocation, TaskOutcome};
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+
+/// Per-instance configuration, bound once at load via `configure`.
+#[derive(Serialize, Deserialize)]
+pub struct Config {
+    /// Prefix applied to the context's `name` to produce `result`.
+    pub prefix: String,
+}
+
+/// The TASK-operator contract. ONE sync method: take the serialized task
+/// invocation, return the serialized outcome. This is the WASM-compatible
+/// analogue of the async `cloacina_workflow::Task::execute`.
+///
+/// Declared with `crate = "fidius_guest"` so the macro emits the guest-side
+/// export + descriptor; the host re-declares the SAME trait with
+/// `crate = "fidius_core"` to get a matching descriptor + interface hash.
+#[plugin_interface(version = 1, buffer = PluginAllocated, crate = "fidius_guest")]
+pub trait TaskOperator: Send + Sync {
+    /// `JSON(TaskInvocation)` in -> `JSON(TaskOutcome)` out.
+    fn execute(&self, invocation_json: String) -> String;
+}
+
+pub struct Configured {
+    cfg: Config,
+}
+
+#[plugin_impl(TaskOperator, crate = "fidius_guest", config = Config)]
+impl TaskOperator for Configured {
+    fn execute(&self, invocation_json: String) -> String {
+        let outcome = self.run(&invocation_json);
+        // The boundary moves a JSON string; never panic across the sandbox.
+        serde_json::to_string(&outcome)
+            .unwrap_or_else(|e| format!(r#"{{"success":false,"error":"encode: {e}"}}"#))
+    }
+}
+
+impl Configured {
+    fn configure(cfg: Config) -> Self {
+        Self { cfg }
+    }
+
+    /// The actual task body: read `name` from the context, write
+    /// `result = "{prefix}{name}"`, hand the updated context back.
+    fn run(&self, invocation_json: &str) -> TaskOutcome {
+        let inv: TaskInvocation = match serde_json::from_str(invocation_json) {
+            Ok(v) => v,
+            Err(e) => return TaskOutcome::err(format!("decode invocation: {e}")),
+        };
+        let mut ctx: Map<String, Value> = match serde_json::from_str(&inv.context_json) {
+            Ok(Value::Object(m)) => m,
+            Ok(_) => return TaskOutcome::err("context_json is not a JSON object"),
+            Err(e) => return TaskOutcome::err(format!("decode context: {e}")),
+        };
+        let name = match ctx.get("name").and_then(Value::as_str) {
+            Some(s) => s.to_string(),
+            None => return TaskOutcome::err("context missing required `name`"),
+        };
+        ctx.insert(
+            "result".to_string(),
+            Value::String(format!("{}{}", self.cfg.prefix, name)),
+        );
+        match serde_json::to_string(&Value::Object(ctx)) {
+            Ok(updated) => TaskOutcome::ok(updated),
+            Err(e) => TaskOutcome::err(format!("encode context: {e}")),
+        }
+    }
+}

--- a/examples/operator-contract/trigger-operator-fixture/Cargo.toml
+++ b/examples/operator-contract/trigger-operator-fixture/Cargo.toml
@@ -1,0 +1,36 @@
+# CLOACI-T-0824 operator contract — TRIGGER operator guest fixture.
+#
+# A SYNCHRONOUS trigger operator authored with the fidius macros and built to a
+# wasm32-wasip2 component (the T-0821 recipe). Implements the `TriggerOperator`
+# contract: JSON(TriggerInvocation) in -> JSON(PollOutcome) out. Config (whether
+# this instance should fire, and the message it fires with) binds ONCE via the
+# macro-emitted `fidius-configure` export; `poll` then reads it without the
+# caller re-passing it — proving config-bound Fire/Skip across the sandbox.
+#
+# Standalone crate, EXCLUDED from the cloacina workspace (under examples/*, plus
+# the empty [workspace] table below) so `cargo build --target wasm32-wasip2`
+# stays self-contained.
+[workspace]
+
+[package]
+name = "trigger-operator-fixture"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+fidius-guest = "0.5.4"
+fidius-macro = "0.5.4"
+wit-bindgen = "0.44"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+# Shared, language-neutral contract types (wire structs). serde-only → wasm-safe.
+operator-contract = { path = "../operator-contract" }
+
+[profile.release]
+opt-level = "s"
+lto = true
+strip = true

--- a/examples/operator-contract/trigger-operator-fixture/src/lib.rs
+++ b/examples/operator-contract/trigger-operator-fixture/src/lib.rs
@@ -1,0 +1,81 @@
+// CLOACI-T-0824 operator contract — TRIGGER operator guest fixture.
+//
+// Proves the TRIGGER-operator contract shape end-to-end: a SYNCHRONOUS fidius
+// operator implementing `TriggerOperator` (the per-primitive sync trait),
+// compiled to a wasm32-wasip2 component, configured once and polled across the
+// sandbox. This is the WASM-compatible analogue of the async
+// `cloacina_workflow::Trigger::poll`.
+//
+// Contract recap (T-0821 constraints):
+//   * methods are SYNCHRONOUS — the guest has no async runtime.
+//   * config binds ONCE via `configure` (macro-emitted `fidius-configure`).
+//   * single-arg method, JSON wire: here `JSON(TriggerInvocation)` in ->
+//     `JSON(PollOutcome)` out (String boundary).
+//
+// The config decides Fire vs Skip, so two loads with different configs yield a
+// firing trigger and a skipping one — proving the poll outcome is config-bound.
+
+use fidius_macro::{plugin_impl, plugin_interface};
+use operator_contract::{PollOutcome, TriggerInvocation};
+use serde::{Deserialize, Serialize};
+
+/// Per-instance configuration, bound once at load via `configure`.
+#[derive(Serialize, Deserialize)]
+pub struct Config {
+    /// Whether this trigger instance fires when polled.
+    pub should_fire: bool,
+    /// The message written into the fired context's `reason` key.
+    pub message: String,
+}
+
+/// The TRIGGER-operator contract. ONE sync method: take the serialized poll
+/// invocation, return the serialized outcome.
+///
+/// Declared with `crate = "fidius_guest"` so the macro emits the guest-side
+/// export + descriptor; the host re-declares the SAME trait with
+/// `crate = "fidius_core"` to get a matching descriptor + interface hash.
+#[plugin_interface(version = 1, buffer = PluginAllocated, crate = "fidius_guest")]
+pub trait TriggerOperator: Send + Sync {
+    /// `JSON(TriggerInvocation)` in -> `JSON(PollOutcome)` out.
+    fn poll(&self, invocation_json: String) -> String;
+}
+
+pub struct Configured {
+    cfg: Config,
+}
+
+#[plugin_impl(TriggerOperator, crate = "fidius_guest", config = Config)]
+impl TriggerOperator for Configured {
+    fn poll(&self, invocation_json: String) -> String {
+        let outcome = self.run(&invocation_json);
+        // The boundary moves a JSON string; never panic across the sandbox.
+        serde_json::to_string(&outcome)
+            .unwrap_or_else(|e| format!(r#"{{"fire":false,"error":"encode: {e}"}}"#))
+    }
+}
+
+impl Configured {
+    fn configure(cfg: Config) -> Self {
+        Self { cfg }
+    }
+
+    /// The actual poll body: when `should_fire`, return `Fire` with a context
+    /// carrying `reason = message`; otherwise `Skip`.
+    fn run(&self, invocation_json: &str) -> PollOutcome {
+        // Decode the (currently-empty) invocation envelope — proves the wire
+        // shape even though the body ignores it.
+        if let Err(e) = serde_json::from_str::<TriggerInvocation>(invocation_json) {
+            return PollOutcome::err(format!("decode invocation: {e}"));
+        }
+
+        if !self.cfg.should_fire {
+            return PollOutcome::skip();
+        }
+
+        let ctx = serde_json::json!({ "reason": self.cfg.message });
+        match serde_json::to_string(&ctx) {
+            Ok(context_json) => PollOutcome::fire(Some(context_json)),
+            Err(e) => PollOutcome::err(format!("encode context: {e}")),
+        }
+    }
+}

--- a/examples/wasm-operator-spike/host-spike/Cargo.toml
+++ b/examples/wasm-operator-spike/host-spike/Cargo.toml
@@ -1,0 +1,24 @@
+# CLOACI-T-0821 WASM-operator spike — host side.
+#
+# Standalone crate, EXCLUDED from the cloacina workspace (under examples/*).
+# Depends on fidius-host with the `wasm` feature (pulls wasmtime) and loads
+# the operator-fixture component via `load_wasm_configured`, invokes it, and
+# asserts two differently-configured instances coexist.
+#
+# The empty [workspace] table keeps it self-contained.
+[workspace]
+
+[package]
+name = "wasm-operator-host-spike"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+fidius-host = { version = "0.5.4", features = ["wasm"] }
+fidius-macro = "0.5.4"
+fidius-core = "0.5.4"
+serde = { version = "1", features = ["derive"] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/examples/wasm-operator-spike/host-spike/src/lib.rs
+++ b/examples/wasm-operator-spike/host-spike/src/lib.rs
@@ -1,0 +1,2 @@
+// CLOACI-T-0821 WASM-operator spike — host side (empty lib; the spike is the
+// integration test under tests/).

--- a/examples/wasm-operator-spike/host-spike/tests/operator_wasm_spike.rs
+++ b/examples/wasm-operator-spike/host-spike/tests/operator_wasm_spike.rs
@@ -1,0 +1,121 @@
+// CLOACI-T-0821 WASM-operator spike — host load + invoke.
+//
+// Proves a fidius-macro-authored SYNCHRONOUS operator, compiled to a
+// wasm32-wasip2 component, is loaded *configured* (`load_wasm_configured`)
+// and invoked across the sandbox boundary, and that N differently-configured
+// instances coexist.
+//
+// The host re-declares the SAME interface the fixture implements (with
+// `crate = "fidius_core"`) so the macro emits a matching
+// `MinimalOperator_WASM_DESCRIPTOR` (companion module `__fidius_MinimalOperator`).
+// The descriptor's `interface_export` is what the host links against; the
+// package.toml `interface` field is metadata only.
+
+#![allow(unexpected_cfgs)]
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::OnceLock;
+
+use fidius_host::PluginHost;
+use serde::Serialize;
+
+#[derive(Serialize)]
+struct Config {
+    op: String,
+}
+
+// SAME interface as the fixture → matching macro-generated descriptor + hash.
+#[fidius_macro::plugin_interface(version = 1, buffer = PluginAllocated, crate = "fidius_core")]
+pub trait MinimalOperator: Send + Sync {
+    fn apply(&self, input: String) -> String;
+}
+
+/// Build the operator fixture to a wasm component once, return its bytes.
+fn component() -> &'static [u8] {
+    static BYTES: OnceLock<Vec<u8>> = OnceLock::new();
+    BYTES.get_or_init(|| {
+        let fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../operator-fixture");
+        let status = Command::new("cargo")
+            .args(["build", "--target", "wasm32-wasip2", "--release"])
+            .current_dir(&fixture)
+            .status()
+            .expect("cargo build --target wasm32-wasip2");
+        assert!(status.success(), "operator-fixture wasm build failed");
+        std::fs::read(
+            fixture.join("target/wasm32-wasip2/release/wasm_operator_fixture.wasm"),
+        )
+        .unwrap()
+    })
+}
+
+/// Stage the component + a package.toml where `find_wasm_package` resolves it.
+fn stage(root: &std::path::Path) {
+    let dir = root.join("wasm-operator-pkg");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("wasm_operator_fixture.wasm"), component()).unwrap();
+    std::fs::write(
+        dir.join("package.toml"),
+        "[package]\nname = \"wasm-operator-pkg\"\nversion = \"0.1.0\"\n\
+         interface = \"minimal-operator\"\ninterface_version = 1\nruntime = \"wasm\"\n\n\
+         [metadata]\ncategory = \"test\"\n\n\
+         [wasm]\ncomponent = \"wasm_operator_fixture.wasm\"\n",
+    )
+    .unwrap();
+}
+
+#[test]
+fn configured_operator_loads_and_invokes() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    stage(tmp.path());
+    let host = PluginHost::builder()
+        .search_path(tmp.path())
+        .build()
+        .unwrap();
+
+    let handle = host
+        .load_wasm_configured(
+            "wasm-operator-pkg",
+            &__fidius_MinimalOperator::MinimalOperator_WASM_DESCRIPTOR,
+            &Config { op: "prefix".into() },
+        )
+        .expect("load_wasm_configured");
+
+    // apply is method 0; single arg → tuple (T,); config already bound.
+    let out: String = handle.call_method(0, &("test".to_string(),)).unwrap();
+    assert_eq!(out, "prefix: test");
+
+    // Config persists across calls on the same configured instance.
+    let out2: String = handle.call_method(0, &("again".to_string(),)).unwrap();
+    assert_eq!(out2, "prefix: again");
+}
+
+#[test]
+fn n_differently_configured_instances_coexist() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    stage(tmp.path());
+    let host = PluginHost::builder()
+        .search_path(tmp.path())
+        .build()
+        .unwrap();
+
+    let a = host
+        .load_wasm_configured(
+            "wasm-operator-pkg",
+            &__fidius_MinimalOperator::MinimalOperator_WASM_DESCRIPTOR,
+            &Config { op: "prefix".into() },
+        )
+        .unwrap();
+    let b = host
+        .load_wasm_configured(
+            "wasm-operator-pkg",
+            &__fidius_MinimalOperator::MinimalOperator_WASM_DESCRIPTOR,
+            &Config { op: "suffix".into() },
+        )
+        .unwrap();
+
+    let oa: String = a.call_method(0, &("x".to_string(),)).unwrap();
+    let ob: String = b.call_method(0, &("y".to_string(),)).unwrap();
+    assert_eq!(oa, "prefix: x");
+    assert_eq!(ob, "suffix: y");
+}

--- a/examples/wasm-operator-spike/operator-fixture/Cargo.toml
+++ b/examples/wasm-operator-spike/operator-fixture/Cargo.toml
@@ -1,0 +1,32 @@
+# CLOACI-T-0821 WASM-operator spike — author fixture.
+#
+# Standalone crate, EXCLUDED from the cloacina workspace (lives under
+# examples/*, which the root Cargo.toml excludes). The empty [workspace]
+# table below makes it fully self-contained so `cargo build` from this dir
+# does not try to attach to the cloacina workspace.
+#
+# A minimal SYNCHRONOUS fidius operator authored with the fidius macros and
+# built to a wasm32-wasip2 component. `#[plugin_impl(.., config = Config)]`
+# binds config once via the macro-emitted `fidius-configure` export; `apply`
+# then uses the bound config without the caller re-passing it.
+[workspace]
+
+[package]
+name = "wasm-operator-fixture"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+fidius-guest = "0.5.4"
+fidius-macro = "0.5.4"
+wit-bindgen = "0.44"
+serde = { version = "1", features = ["derive"] }
+
+[profile.release]
+opt-level = "s"
+lto = true
+strip = true

--- a/examples/wasm-operator-spike/operator-fixture/src/lib.rs
+++ b/examples/wasm-operator-spike/operator-fixture/src/lib.rs
@@ -1,0 +1,38 @@
+// CLOACI-T-0821 WASM-operator spike — author fixture.
+//
+// A minimal, SYNCHRONOUS fidius operator. The existing cloacina
+// `CloacinaPlugin` interface is async/tokio (WASM guests have no runtime),
+// so the operator contract probed here is deliberately one method with
+// primitives in/out. The host binds `Config` once via the macro-emitted
+// `fidius-configure` export; `apply` then uses `self.cfg.op` without the
+// caller re-passing it. N differently-configured instances coexist.
+
+use fidius_macro::{plugin_impl, plugin_interface};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+pub struct Config {
+    pub op: String,
+}
+
+#[plugin_interface(version = 1, buffer = PluginAllocated, crate = "fidius_guest")]
+pub trait MinimalOperator: Send + Sync {
+    fn apply(&self, input: String) -> String;
+}
+
+pub struct Configured {
+    cfg: Config,
+}
+
+#[plugin_impl(MinimalOperator, crate = "fidius_guest", config = Config)]
+impl MinimalOperator for Configured {
+    fn apply(&self, input: String) -> String {
+        format!("{}: {}", self.cfg.op, input)
+    }
+}
+
+impl Configured {
+    fn configure(cfg: Config) -> Self {
+        Self { cfg }
+    }
+}


### PR DESCRIPTION
The functional core of **CLOACI-I-0132 — Operators**: reusable, parameterized,
**WASM-sandboxed** operators that run as cloacina primitives. Tasks T-0821..0824.

- **T-0821 spike** — proved a fidius-macro-authored sync operator → wasm32-wasip2
  component → `load_wasm_configured` → invoke (`examples/wasm-operator-spike/`).
- **T-0822 contract** — per-primitive sync operator traits; JSON-string wire; sidecar
  `operator.json` manifest (`primitive_kind` + I-0128 `InputSlot` params); the
  async↔sync bridge (`examples/operator-contract/`).
- **T-0823 loader** — new `cloacina-operator-contract` crate; the loader +
  `WasmTaskOperator: impl Task` — a sandboxed WASM operator runs as a real cloacina
  `Task`, end-to-end.
- **T-0824 trigger + registration** — `WasmTriggerOperator: impl Trigger`; loaded
  operators register into the `Runtime` by `primitive_kind`.

**Gating (key):** all WASM/wasmtime is behind a **default-OFF `operators-wasm`
feature**. Default cloacina pulls **zero wasmtime** (`cargo tree -i wasmtime` →
none); wasmtime 45 only with the feature. Default `cargo check` clean. The WASM
e2e tests (task + trigger, 9 total) run with the feature on (validated locally;
they need the wasm32 target + wasmtime, so they're not in the default CI lane).

**Remaining in I-0132:** accumulator/reactor execution (needs scheduler-level
wiring — follow-up), the `#[operator]` authoring macro (T-0826), seed built-in
operators (T-0825), distribution (T-0827).

https://claude.ai/code/session_01VWpWbgCzNdQkFT74S3wPRM