### PR TITLE
feat(constructors): provider packaging + load-from-package + signing (CLOACI-T-0827)

### DIFF
--- a/.metis/backlog/features/CLOACI-T-0827.md
+++ b/.metis/backlog/features/CLOACI-T-0827.md
@@ -1,18 +1,18 @@
 ---
-id: operator-distribution-as-fidius
+id: constructor-distribution-as-fidius
 level: task
 title: "Constructor distribution as fidius provider packages + registry load"
 short_code: "CLOACI-T-0827"
 created_at: 2026-06-28T23:57:48.544299+00:00
-updated_at: 2026-06-28T23:57:48.544299+00:00
+updated_at: 2026-06-29T11:44:42.503204+00:00
 parent: CLOACI-I-0132
 blocked_by: []
 archived: false
 
 tags:
   - "#task"
-  - "#phase/backlog"
   - "#feature"
+  - "#phase/completed"
 
 
 exit_criteria_met: false
@@ -66,6 +66,12 @@ Constructors distributed as **fidius provider packages** (signed, versioned) + t
 - **Current Problems**: {What's difficult/slow/buggy now}
 - **Benefits of Fixing**: {What improves after refactoring}
 - **Risk Assessment**: {Risks of not addressing this}
+
+## Acceptance Criteria
+
+## Acceptance Criteria
+
+## Acceptance Criteria
 
 ## Acceptance Criteria **[REQUIRED]**
 
@@ -136,4 +142,28 @@ Constructors distributed as **fidius provider packages** (signed, versioned) + t
 
 ## Status Updates **[REQUIRED]**
 
-*To be added during implementation*
+### 2026-06-29 — Provider packaging + signed load-from-package landed (branch `i0132-t0827-packaging`, NOT committed)
+
+**Implemented (mirrors workflow packaging, reuses fidius rather than a parallel format):**
+
+1. **Provider package format + packaging step** — `crates/cloacina/src/packaging/constructor_provider.rs` (new, gated by new default-OFF `constructor-packaging` feature). `package_constructor_provider()` builds the crate to `wasm32-wasip2`, runs its manifest-emitter bin (`emit_manifest`) for the constructor manifest JSON, stages a fidius `runtime = "wasm"` package dir (`package.toml` + the `.wasm` component + `constructor.json` sidecar + a new N-capable `provider.json` index), optionally Ed25519-signs it (reusing fidius's `package_digest` + `package.sig` scheme, byte-compatible with `fidius_host::verify_package`), then packs via `fidius_core::package::pack_package` → `<name>-<version>.cloacina`. `ProviderManifest { constructors: Vec<…> }` is structured for N constructors; single is wired end-to-end (a fidius `[wasm]` package binds one component; N-per-archive is the noted follow-on).
+
+2. **Command** — `cloacinactl constructor package <crate-dir> [--out] [--sign-key K] [--manifest-bin emit_manifest] [--debug]` (`crates/cloacinactl/src/nouns/constructor/mod.rs`, wired in `nouns/mod.rs` + `main.rs`). cloacinactl enables `cloacina/constructor-packaging` (wasmtime-free).
+
+3. **Loader resolves the packaged form** — `constructor_loader.rs`: new `unpack_provider_archive()` (unpack + optional Ed25519 signature verify; fails closed on hostile/tampered/unsigned-when-required archive) and `load_task_constructor_from_package()` (unpack/verify → delegate to existing loose-dir `load_task_constructor`, since fidius resolves a package by its `[package].name` regardless of dir name). Loose-dir path unchanged.
+
+**Gating (intact):** new `constructor-packaging` feature pulls only the serde-only contract crate — NOT `fidius-host/wasm`. `constructors-wasm` now implies `constructor-packaging`. `cargo tree -p cloacina -i wasmtime` ABSENT under both default and `constructor-packaging`; only the wasm *loader* pulls wasmtime.
+
+**Validation (all run, all green):**
+- `cargo check -p cloacina` (default) — Finished clean.
+- `cargo check -p cloacina --features constructor-packaging` — clean; `cargo tree … -i wasmtime` → "did not match any packages" (absent).
+- `cargo check -p cloacinactl` — clean.
+- `cargo test -p cloacina --features constructors-wasm --test constructor_provider_package_wasm` — **4 passed**: signed package → load-from-package → runs as Task → `result == "hello, world"`; wrong-key fails closed; tampered (repacked) package fails signature verification; missing `constructor.json` fails closed.
+- Regression `--test constructor_macro_wasm` — 4 passed (loose-dir path intact).
+- Packaging lib unit tests — 2 passed.
+- CLI smoke: `cloacinactl constructor package <fixture>` → archive `prefix-0.1.0/{package.toml,constructor.json,provider.json,task_constructor_macro_fixture.wasm}`.
+- `cargo fmt --all -- --check` exit 0.
+
+**Deferred (noted, not built):** remote registry/publish endpoint (push/pull providers); signing-key management; multi-constructor-per-archive packing (data model is already N-shaped); Python authoring/consumer surface; trigger/accumulator/reactor packaging (only `task` codegen exists today).
+
+**NOT committed — left for review.**

--- a/.metis/backlog/features/CLOACI-T-0829.md
+++ b/.metis/backlog/features/CLOACI-T-0829.md
@@ -1,0 +1,144 @@
+---
+id: constructor-consumption-surface
+level: task
+title: "Constructor consumption surface — instantiate constructors in workflows (Rust + Python)"
+short_code: "CLOACI-T-0829"
+created_at: 2026-06-29T11:16:30.362953+00:00
+updated_at: 2026-06-29T11:16:30.362953+00:00
+parent: CLOACI-I-0132
+blocked_by: []
+archived: false
+
+tags:
+  - "#task"
+  - "#phase/backlog"
+  - "#feature"
+
+
+exit_criteria_met: false
+initiative_id: NULL
+---
+
+# Constructor consumption surface — instantiate constructors in workflows (Rust + Python)
+
+*This template includes sections for various types of tasks. Delete sections that don't apply to your specific use case.*
+
+## Parent Initiative **[CONDITIONAL: Assigned Task]**
+
+[[Parent Initiative]]
+
+## Objective **[REQUIRED]**
+
+The surface for a workflow author to USE (consume) a constructor — the gap flagged during T-0827 planning (Python consumption, plus Rust). Today the framework loads + runs constructors (task/trigger) and the `#[constructor]` AUTHORING macro exists, but there is NO consumer surface in either language: a workflow author cannot yet declaratively wire a packaged constructor into a workflow.
+
+**Scope:**
+- **Rust consumer** — a declarative form (e.g. `constructor!(id=.., from="provider@ver", constructor="name", config={..}, dependencies=[..])`) inside `#[workflow]` that references a packaged constructor (a provider package from [[CLOACI-T-0827]]) as a primitive node — resolved + registered at build/load, executed by the runtime.
+- **Python consumer (cloaca)** — the equivalent so a Python workflow can instantiate + wire a constructor. NOTE: execution is ALREADY language-agnostic (the Rust runtime runs the WASM constructor); this is purely the cloaca authoring/instantiation surface, not a new mechanism.
+- `#[constructor]` for the **trigger / accumulator / reactor** authoring kinds (the macro currently errors for non-task), so the other primitives are authorable as constructors.
+
+**AC:** a Rust `#[workflow]` references a packaged constructor (config + deps) and it runs end-to-end; a Python (cloaca) workflow does the same; `#[constructor(kind=trigger)]` authors a trigger constructor. May decompose (Rust / Python / macro-kinds) if large. Blocked by CLOACI-T-0827; accumulator/reactor kinds also blocked by CLOACI-T-0828.
+
+## Backlog Item Details **[CONDITIONAL: Backlog Item]**
+
+{Delete this section when task is assigned to an initiative}
+
+### Type
+- [ ] Bug - Production issue that needs fixing
+- [ ] Feature - New functionality or enhancement  
+- [ ] Tech Debt - Code improvement or refactoring
+- [ ] Chore - Maintenance or setup work
+
+### Priority
+- [ ] P0 - Critical (blocks users/revenue)
+- [ ] P1 - High (important for user experience)
+- [ ] P2 - Medium (nice to have)
+- [ ] P3 - Low (when time permits)
+
+### Impact Assessment **[CONDITIONAL: Bug]**
+- **Affected Users**: {Number/percentage of users affected}
+- **Reproduction Steps**: 
+  1. {Step 1}
+  2. {Step 2}
+  3. {Step 3}
+- **Expected vs Actual**: {What should happen vs what happens}
+
+### Business Justification **[CONDITIONAL: Feature]**
+- **User Value**: {Why users need this}
+- **Business Value**: {Impact on metrics/revenue}
+- **Effort Estimate**: {Rough size - S/M/L/XL}
+
+### Technical Debt Impact **[CONDITIONAL: Tech Debt]**
+- **Current Problems**: {What's difficult/slow/buggy now}
+- **Benefits of Fixing**: {What improves after refactoring}
+- **Risk Assessment**: {Risks of not addressing this}
+
+## Acceptance Criteria **[REQUIRED]**
+
+- [ ] {Specific, testable requirement 1}
+- [ ] {Specific, testable requirement 2}
+- [ ] {Specific, testable requirement 3}
+
+## Test Cases **[CONDITIONAL: Testing Task]**
+
+{Delete unless this is a testing task}
+
+### Test Case 1: {Test Case Name}
+- **Test ID**: TC-001
+- **Preconditions**: {What must be true before testing}
+- **Steps**: 
+  1. {Step 1}
+  2. {Step 2}
+  3. {Step 3}
+- **Expected Results**: {What should happen}
+- **Actual Results**: {To be filled during execution}
+- **Status**: {Pass/Fail/Blocked}
+
+### Test Case 2: {Test Case Name}
+- **Test ID**: TC-002
+- **Preconditions**: {What must be true before testing}
+- **Steps**: 
+  1. {Step 1}
+  2. {Step 2}
+- **Expected Results**: {What should happen}
+- **Actual Results**: {To be filled during execution}
+- **Status**: {Pass/Fail/Blocked}
+
+## Documentation Sections **[CONDITIONAL: Documentation Task]**
+
+{Delete unless this is a documentation task}
+
+### User Guide Content
+- **Feature Description**: {What this feature does and why it's useful}
+- **Prerequisites**: {What users need before using this feature}
+- **Step-by-Step Instructions**:
+  1. {Step 1 with screenshots/examples}
+  2. {Step 2 with screenshots/examples}
+  3. {Step 3 with screenshots/examples}
+
+### Troubleshooting Guide
+- **Common Issue 1**: {Problem description and solution}
+- **Common Issue 2**: {Problem description and solution}
+- **Error Messages**: {List of error messages and what they mean}
+
+### API Documentation **[CONDITIONAL: API Documentation]**
+- **Endpoint**: {API endpoint description}
+- **Parameters**: {Required and optional parameters}
+- **Example Request**: {Code example}
+- **Example Response**: {Expected response format}
+
+## Implementation Notes **[CONDITIONAL: Technical Task]**
+
+{Keep for technical tasks, delete for non-technical. Technical details, approach, or important considerations}
+
+### Technical Approach
+{How this will be implemented}
+
+### Dependencies
+{Other tasks or systems this depends on}
+
+### Risk Considerations
+{Technical risks and mitigation strategies}
+
+## Status Updates **[REQUIRED]**
+
+*To be added during implementation*

--- a/crates/cloacina/Cargo.toml
+++ b/crates/cloacina/Cargo.toml
@@ -23,15 +23,25 @@ sqlite = ["diesel/sqlite", "diesel/returning_clauses_for_sqlite_3_35", "deadpool
 auth = ["postgres"]
 macros = ["cloacina-macros"]
 kafka = ["rdkafka"]
+# CLOACI-I-0132 / T-0827 — constructor provider PACKAGING (assemble + sign + pack a
+# built constructor crate into a distributable `.cloacina` provider archive). This
+# is the build/distribute side and needs NO wasm runtime: it only pulls the
+# serde-only constructor-contract crate (for the manifest schema) on top of the
+# already-present fidius-core (pack/digest) + ed25519-dalek (signing). Crucially it
+# does NOT enable `fidius-host/wasm`, so a default + packaging build stays
+# wasmtime-free (`cargo tree -p cloacina -i wasmtime` is absent).
+constructor-packaging = ["dep:cloacina-constructor-contract"]
 # CLOACI-I-0132 / T-0823 — WASM task-constructor loader + executor bridge.
 # OFF by default: enabling it turns on fidius-host's `wasm` feature (→ wasmtime +
 # cranelift, ~55 crates) and pulls fidius-macro (for the host-side interface
 # descriptor) + the constructor contract crate. The default cloacina build pulls
-# NONE of this.
+# NONE of this. Implies `constructor-packaging` (the loader also resolves the
+# packaged provider form, T-0827).
 constructors-wasm = [
     "dep:fidius-macro",
     "dep:cloacina-constructor-contract",
     "fidius-host/wasm",
+    "constructor-packaging",
 ]
 
 [dependencies]
@@ -102,6 +112,10 @@ cel-interpreter = "0.10"
 [dev-dependencies]
 tracing-test = "0.2"
 tempfile = "3.2"
+# CLOACI-T-0827: signed-provider e2e test signs/verifies with the same Ed25519
+# scheme fidius uses, and repacks a tampered dir to prove the loader fails closed.
+ed25519-dalek = { version = "2.1" }
+fidius-core = "0.5.4"
 once_cell = "1.19.0"
 serial_test = "3.2.0"
 aquamarine = "0.6.0"

--- a/crates/cloacina/src/packaging/constructor_provider.rs
+++ b/crates/cloacina/src/packaging/constructor_provider.rs
@@ -1,0 +1,453 @@
+/*
+ *  Copyright 2026 Colliery Software
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+//! Constructor **provider package** assembly + packing (CLOACI-T-0827).
+//!
+//! Turns a built `#[constructor]` crate into a distributable, signable **fidius
+//! provider package** — the same machinery cloacina already uses to pack a
+//! workflow into a `.cloacina` archive ([`super::package_workflow`] →
+//! [`fidius_core::package::pack_package`]), reused for constructor providers
+//! rather than a parallel format.
+//!
+//! ## What a provider package is
+//!
+//! A provider package is an ordinary fidius `runtime = "wasm"` source package —
+//! a directory with a `package.toml` header that fidius understands — carrying:
+//!
+//!   * the constructor's `.wasm` **component** (built to `wasm32-wasip2`),
+//!   * `constructor.json`, the sidecar [`ConstructorManifest`] the loader
+//!     already reads (written here from the macro-generated
+//!     `__constructor_manifest()` — the step the macro itself cannot do), and
+//!   * `provider.json`, a small [`ProviderManifest`] index that names the
+//!     provider and lists its member constructors.
+//!
+//! It is packed (tar + bzip2) into a `<name>-<version>.cloacina` archive and may
+//! be **Ed25519-signed** (a `package.sig` over the package digest) reusing
+//! fidius's signing scheme verbatim, so `fidius_host::verify_package` /
+//! `fidius_core::package::package_digest` verify it unchanged.
+//!
+//! ## Providers carry N constructors (Airflow "provider" = package of operators)
+//!
+//! [`ProviderManifest`] is a `Vec<ProviderConstructorEntry>` so the format
+//! describes a multi-constructor provider. The packaging step here wires the
+//! **single-constructor** provider end-to-end (one component, one
+//! `constructor.json`, one provider entry) because a fidius `[wasm]` package
+//! binds exactly one `component`; packing N constructors into one archive (N
+//! components, or one multi-export component) is the noted follow-on — the data
+//! model is already N-shaped so that extension is additive.
+//!
+//! ## Gating
+//!
+//! Behind the default-OFF `constructor-packaging` feature, which pulls only the
+//! serde-only `cloacina-constructor-contract` crate. It deliberately does NOT
+//! enable `fidius-host/wasm`, so building the *packaging* tool does not drag in
+//! wasmtime — only the *loader* (`constructors-wasm`) does. Resolving a packed
+//! provider back to a runnable primitive lives in the loader
+//! (`registry::loader::constructor_loader::load_task_constructor_from_package`).
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use ed25519_dalek::{Signer, SigningKey};
+use serde::{Deserialize, Serialize};
+
+use cloacina_constructor_contract::{ConstructorManifest, PrimitiveKind};
+
+/// The sidecar manifest filename inside a provider package (one per constructor
+/// component — the file the loader reads). Mirrors
+/// `constructor_loader::CONSTRUCTOR_MANIFEST_FILE`.
+pub const CONSTRUCTOR_MANIFEST_FILE: &str = "constructor.json";
+
+/// The provider index filename inside a provider package.
+pub const PROVIDER_MANIFEST_FILE: &str = "provider.json";
+
+/// The archive extension cloacina packages use (vs fidius's default `fid`).
+pub const PROVIDER_EXTENSION: &str = "cloacina";
+
+/// The provider index written into a provider package as `provider.json`.
+///
+/// Names the provider and lists its member constructors. Single-constructor
+/// providers carry exactly one entry; the `Vec` is what makes the format
+/// N-capable (a "provider" being a package of constructors).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ProviderManifest {
+    /// Provider name (the fidius `[package].name` the loader matches on).
+    pub name: String,
+    /// Provider version (semver string).
+    pub version: String,
+    /// The member constructors this provider distributes.
+    pub constructors: Vec<ProviderConstructorEntry>,
+}
+
+/// One constructor member of a [`ProviderManifest`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ProviderConstructorEntry {
+    /// Constructor name (its `ConstructorManifest::name`).
+    pub name: String,
+    /// Which runtime primitive the constructor plugs into.
+    pub primitive_kind: PrimitiveKind,
+    /// The `.wasm` component filename inside the package implementing it.
+    pub component: String,
+    /// The sidecar manifest filename inside the package describing it.
+    pub manifest_file: String,
+}
+
+/// Inputs to [`package_constructor_provider`].
+#[derive(Debug, Clone)]
+pub struct ProviderPackageOptions {
+    /// The `#[constructor]` crate directory to package.
+    pub crate_dir: PathBuf,
+    /// Output archive path. `None` → `<name>-<version>.cloacina` in the CWD.
+    pub output: Option<PathBuf>,
+    /// Ed25519 secret-key file (32 raw bytes) to sign the package with. `None`
+    /// produces an unsigned provider.
+    pub sign_key: Option<PathBuf>,
+    /// Host binary in the crate that prints the constructor manifest JSON to
+    /// stdout (the `__constructor_manifest()` emitter). Defaults to
+    /// `emit_manifest`.
+    pub manifest_bin: String,
+    /// Build the `wasm32-wasip2` component in release profile (default `true`).
+    pub release: bool,
+}
+
+impl ProviderPackageOptions {
+    /// Options for `crate_dir` with the conventional defaults
+    /// (`emit_manifest` bin, release build, unsigned, CWD output).
+    pub fn new(crate_dir: impl Into<PathBuf>) -> Self {
+        Self {
+            crate_dir: crate_dir.into(),
+            output: None,
+            sign_key: None,
+            manifest_bin: "emit_manifest".to_string(),
+            release: true,
+        }
+    }
+}
+
+/// What [`package_constructor_provider`] produced.
+#[derive(Debug, Clone)]
+pub struct ProviderPackageResult {
+    /// Path to the packed `.cloacina` provider archive.
+    pub archive: PathBuf,
+    /// Whether the archive carries a `package.sig` (was signed).
+    pub signed: bool,
+    /// The provider name (fidius package name).
+    pub provider_name: String,
+    /// Names of the constructors the provider carries.
+    pub constructors: Vec<String>,
+}
+
+/// Errors assembling/packing a constructor provider package.
+#[derive(Debug, thiserror::Error)]
+pub enum ProviderPackageError {
+    /// The crate directory or an expected build artifact was missing/unreadable.
+    #[error("{0}")]
+    Io(String),
+    /// `cargo build`/`cargo run` failed.
+    #[error("build step failed: {0}")]
+    Build(String),
+    /// The emitted manifest JSON did not parse as a `ConstructorManifest`.
+    #[error("constructor manifest parse failed: {0}")]
+    Manifest(String),
+    /// The Ed25519 secret key was missing or not exactly 32 bytes.
+    #[error("signing key error: {0}")]
+    SigningKey(String),
+    /// The underlying fidius pack step failed.
+    #[error("pack failed: {0}")]
+    Pack(String),
+}
+
+/// Build, assemble, (optionally sign,) and pack a `#[constructor]` crate into a
+/// distributable provider package.
+///
+/// Steps, mirroring `package_workflow` but for a constructor component:
+/// 1. `cargo build --lib --target wasm32-wasip2` → the `.wasm` component.
+/// 2. `cargo run --bin <manifest_bin>` → the constructor's manifest JSON, parsed
+///    into a [`ConstructorManifest`] (this is the packaging step writing
+///    `constructor.json`, which the macro cannot do itself).
+/// 3. Stage `package.toml` (`runtime = "wasm"`), the component, `constructor.json`,
+///    and `provider.json` into a temp package dir.
+/// 4. If `sign_key` is set, write a `package.sig` (Ed25519 over the package
+///    digest) reusing fidius's signing scheme.
+/// 5. [`fidius_core::package::pack_package`] → the `.cloacina` archive.
+pub fn package_constructor_provider(
+    opts: &ProviderPackageOptions,
+) -> Result<ProviderPackageResult, ProviderPackageError> {
+    let crate_dir = &opts.crate_dir;
+    if !crate_dir.join("Cargo.toml").exists() {
+        return Err(ProviderPackageError::Io(format!(
+            "no Cargo.toml in constructor crate dir {}",
+            crate_dir.display()
+        )));
+    }
+
+    // 1. Build the wasm component.
+    let wasm = build_wasm_component(crate_dir, opts.release)?;
+
+    // 2. Emit + parse the constructor manifest.
+    let manifest_json = emit_manifest_json(crate_dir, &opts.manifest_bin)?;
+    let manifest = ConstructorManifest::from_json(&manifest_json)
+        .map_err(|e| ProviderPackageError::Manifest(e.to_string()))?;
+
+    // 3. Stage the provider package directory.
+    let staging = tempfile::TempDir::new()
+        .map_err(|e| ProviderPackageError::Io(format!("create staging dir: {e}")))?;
+    let pkg_dir = staging.path();
+
+    // Component filename: keep the built artifact's own name so it is stable +
+    // recognizable inside the archive.
+    let component_file = wasm
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "constructor.wasm".to_string());
+
+    std::fs::copy(&wasm, pkg_dir.join(&component_file))
+        .map_err(|e| ProviderPackageError::Io(format!("copy wasm component: {e}")))?;
+
+    // The sidecar manifest the loader reads (verbatim emitter output).
+    std::fs::write(pkg_dir.join(CONSTRUCTOR_MANIFEST_FILE), &manifest_json)
+        .map_err(|e| ProviderPackageError::Io(format!("write constructor.json: {e}")))?;
+
+    // The N-capable provider index (single entry today).
+    let provider_name = manifest.name.clone();
+    let provider = ProviderManifest {
+        name: provider_name.clone(),
+        version: manifest.version.clone(),
+        constructors: vec![ProviderConstructorEntry {
+            name: manifest.name.clone(),
+            primitive_kind: manifest.primitive_kind,
+            component: component_file.clone(),
+            manifest_file: CONSTRUCTOR_MANIFEST_FILE.to_string(),
+        }],
+    };
+    let provider_json = serde_json::to_string_pretty(&provider)
+        .map_err(|e| ProviderPackageError::Manifest(format!("serialize provider.json: {e}")))?;
+    std::fs::write(pkg_dir.join(PROVIDER_MANIFEST_FILE), provider_json)
+        .map_err(|e| ProviderPackageError::Io(format!("write provider.json: {e}")))?;
+
+    // The fidius wasm package header. `interface` / `interface_version` come from
+    // the constructor manifest so the loader's descriptor + version gate line up.
+    let package_toml = render_package_toml(&manifest, &component_file);
+    std::fs::write(pkg_dir.join("package.toml"), package_toml)
+        .map_err(|e| ProviderPackageError::Io(format!("write package.toml: {e}")))?;
+
+    // 4. Optional signing — must happen before packing (the .sig is archived).
+    let signed = if let Some(key_path) = &opts.sign_key {
+        sign_package_dir(pkg_dir, key_path)?;
+        true
+    } else {
+        false
+    };
+
+    // 5. Pack via fidius (same path as workflow packaging).
+    let result = fidius_core::package::pack_package(pkg_dir, opts.output.as_deref())
+        .map_err(|e| ProviderPackageError::Pack(e.to_string()))?;
+
+    Ok(ProviderPackageResult {
+        archive: result.path,
+        signed,
+        provider_name,
+        constructors: provider.constructors.into_iter().map(|c| c.name).collect(),
+    })
+}
+
+/// Render the fidius `package.toml` header for a constructor provider.
+fn render_package_toml(manifest: &ConstructorManifest, component_file: &str) -> String {
+    format!(
+        "# Generated by cloacina constructor packaging (CLOACI-T-0827).\n\
+         [package]\n\
+         name = \"{name}\"\n\
+         version = \"{version}\"\n\
+         interface = \"{interface}\"\n\
+         interface_version = {iface_version}\n\
+         extension = \"{ext}\"\n\
+         runtime = \"wasm\"\n\n\
+         [metadata]\n\
+         category = \"constructor\"\n\
+         primitive_kind = \"{primitive}\"\n\n\
+         [wasm]\n\
+         component = \"{component}\"\n",
+        name = manifest.name,
+        version = manifest.version,
+        interface = manifest.interface,
+        iface_version = manifest.interface_version,
+        ext = PROVIDER_EXTENSION,
+        primitive = primitive_kind_str(manifest.primitive_kind),
+        component = component_file,
+    )
+}
+
+fn primitive_kind_str(kind: PrimitiveKind) -> &'static str {
+    match kind {
+        PrimitiveKind::Task => "task",
+        PrimitiveKind::Trigger => "trigger",
+        PrimitiveKind::Accumulator => "accumulator",
+        PrimitiveKind::Reactor => "reactor",
+    }
+}
+
+/// `cargo build --lib --target wasm32-wasip2 [--release]` in `crate_dir`, then
+/// locate the produced `.wasm` component.
+fn build_wasm_component(crate_dir: &Path, release: bool) -> Result<PathBuf, ProviderPackageError> {
+    let mut cmd = Command::new("cargo");
+    cmd.arg("build")
+        .arg("--lib")
+        .arg("--target")
+        .arg("wasm32-wasip2")
+        .current_dir(crate_dir);
+    let profile = if release {
+        cmd.arg("--release");
+        "release"
+    } else {
+        "debug"
+    };
+
+    let status = cmd
+        .status()
+        .map_err(|e| ProviderPackageError::Build(format!("spawn cargo build: {e}")))?;
+    if !status.success() {
+        return Err(ProviderPackageError::Build(format!(
+            "cargo build --target wasm32-wasip2 failed with status {status}"
+        )));
+    }
+
+    let out_dir = crate_dir.join("target").join("wasm32-wasip2").join(profile);
+
+    // Prefer the artifact named after the crate; fall back to the sole `.wasm`.
+    let preferred = crate_name(crate_dir).map(|n| out_dir.join(format!("{n}.wasm")));
+    if let Some(p) = &preferred {
+        if p.exists() {
+            return Ok(p.clone());
+        }
+    }
+
+    let mut wasms: Vec<PathBuf> = std::fs::read_dir(&out_dir)
+        .map_err(|e| ProviderPackageError::Io(format!("read {}: {e}", out_dir.display())))?
+        .flatten()
+        .map(|e| e.path())
+        .filter(|p| p.extension().and_then(|x| x.to_str()) == Some("wasm"))
+        .collect();
+    wasms.sort();
+    match wasms.len() {
+        0 => Err(ProviderPackageError::Build(format!(
+            "build succeeded but no .wasm component found in {}",
+            out_dir.display()
+        ))),
+        1 => Ok(wasms.pop().unwrap()),
+        _ => Err(ProviderPackageError::Build(format!(
+            "multiple .wasm components in {} ({:?}); name the lib to match the crate",
+            out_dir.display(),
+            wasms
+        ))),
+    }
+}
+
+/// Best-effort crate name (`[package].name`, `-`→`_`) for artifact matching.
+fn crate_name(crate_dir: &Path) -> Option<String> {
+    let toml = std::fs::read_to_string(crate_dir.join("Cargo.toml")).ok()?;
+    let value: toml::Value = toml.parse().ok()?;
+    let name = value.get("package")?.get("name")?.as_str()?;
+    Some(name.replace('-', "_"))
+}
+
+/// Run the crate's manifest-emitter host binary and capture its stdout JSON.
+fn emit_manifest_json(
+    crate_dir: &Path,
+    manifest_bin: &str,
+) -> Result<String, ProviderPackageError> {
+    let out = Command::new("cargo")
+        .args(["run", "--quiet", "--bin", manifest_bin])
+        .current_dir(crate_dir)
+        .output()
+        .map_err(|e| {
+            ProviderPackageError::Build(format!("spawn cargo run --bin {manifest_bin}: {e}"))
+        })?;
+    if !out.status.success() {
+        return Err(ProviderPackageError::Build(format!(
+            "`cargo run --bin {manifest_bin}` failed: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        )));
+    }
+    String::from_utf8(out.stdout)
+        .map_err(|e| ProviderPackageError::Manifest(format!("manifest stdout not UTF-8: {e}")))
+}
+
+/// Sign a staged package directory in place, reusing fidius's scheme: an Ed25519
+/// signature over [`fidius_core::package::package_digest`], written to
+/// `package.sig`. This is byte-compatible with `fidius_host::verify_package`, so
+/// we are reusing fidius's signing/verification rather than rolling our own.
+fn sign_package_dir(pkg_dir: &Path, key_path: &Path) -> Result<(), ProviderPackageError> {
+    let key_bytes: [u8; 32] = std::fs::read(key_path)
+        .map_err(|e| ProviderPackageError::SigningKey(format!("read {}: {e}", key_path.display())))?
+        .try_into()
+        .map_err(|_| {
+            ProviderPackageError::SigningKey("secret key must be exactly 32 bytes".to_string())
+        })?;
+    let signing_key = SigningKey::from_bytes(&key_bytes);
+
+    let digest = fidius_core::package::package_digest(pkg_dir)
+        .map_err(|e| ProviderPackageError::Pack(format!("compute package digest: {e}")))?;
+    let signature = signing_key.sign(&digest);
+
+    std::fs::write(pkg_dir.join("package.sig"), signature.to_bytes())
+        .map_err(|e| ProviderPackageError::Io(format!("write package.sig: {e}")))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn provider_manifest_round_trips() {
+        let p = ProviderManifest {
+            name: "prefix".into(),
+            version: "0.1.0".into(),
+            constructors: vec![ProviderConstructorEntry {
+                name: "prefix".into(),
+                primitive_kind: PrimitiveKind::Task,
+                component: "prefix.wasm".into(),
+                manifest_file: CONSTRUCTOR_MANIFEST_FILE.into(),
+            }],
+        };
+        let s = serde_json::to_string_pretty(&p).unwrap();
+        let back: ProviderManifest = serde_json::from_str(&s).unwrap();
+        assert_eq!(p, back);
+        assert_eq!(back.constructors[0].primitive_kind, PrimitiveKind::Task);
+    }
+
+    #[test]
+    fn package_toml_has_wasm_runtime_and_component() {
+        let manifest = ConstructorManifest {
+            name: "prefix".into(),
+            version: "0.1.0".into(),
+            primitive_kind: PrimitiveKind::Task,
+            interface: "task-constructor".into(),
+            interface_version: 1,
+            params: vec![],
+            dependencies: vec![],
+            description: None,
+            author: None,
+        };
+        let toml = render_package_toml(&manifest, "prefix.wasm");
+        assert!(toml.contains("runtime = \"wasm\""));
+        assert!(toml.contains("component = \"prefix.wasm\""));
+        assert!(toml.contains("interface = \"task-constructor\""));
+        assert!(toml.contains("extension = \"cloacina\""));
+        // Parses as valid TOML.
+        let _: toml::Value = toml.parse().expect("rendered package.toml is valid TOML");
+    }
+}

--- a/crates/cloacina/src/packaging/mod.rs
+++ b/crates/cloacina/src/packaging/mod.rs
@@ -20,6 +20,11 @@
 //! into distributable fidius source archives. These functions can be used by CLI
 //! tools, tests, or other applications that need to package workflows.
 
+/// Constructor **provider package** assembly + packing (CLOACI-T-0827).
+/// Default-OFF behind the `constructor-packaging` feature (serde-only contract
+/// crate; no wasm runtime).
+#[cfg(feature = "constructor-packaging")]
+pub mod constructor_provider;
 pub mod manifest_schema;
 pub mod platform;
 pub mod types;

--- a/crates/cloacina/src/registry/loader/constructor_loader.rs
+++ b/crates/cloacina/src/registry/loader/constructor_loader.rs
@@ -299,6 +299,82 @@ pub fn load_task_constructor<C: Serialize>(
 }
 
 // ===========================================================================
+// Packed provider resolution (CLOACI-T-0827)
+// ===========================================================================
+
+/// Unpack a packed **provider package** archive (a `.cloacina`/`.fid` produced by
+/// [`crate::packaging::constructor_provider::package_constructor_provider`]) into
+/// `dest` and, when `verify_keys` is non-empty, verify its Ed25519 `package.sig`
+/// against those trusted keys. Returns the unpacked package directory (which
+/// contains `package.toml`, the `constructor.json` sidecar, and the `.wasm`
+/// component).
+///
+/// Fails closed at every stage:
+///   * a structurally-hostile archive (path traversal, absolute path, symlink,
+///     hardlink, size/ratio bomb, or no `package.toml`) is rejected by
+///     [`fidius_core::package::unpack_package`];
+///   * with `verify_keys` supplied, a missing or non-verifying signature — which
+///     is exactly what tampering with the component or manifest after signing
+///     produces (the digest no longer matches) — is a hard error via
+///     [`fidius_host::package::verify_package`].
+///
+/// An empty `verify_keys` skips signature checking (the unsigned/dev flow); the
+/// structural archive checks still apply.
+pub fn unpack_provider_archive(
+    archive: impl AsRef<Path>,
+    dest: impl AsRef<Path>,
+    verify_keys: &[ed25519_dalek::VerifyingKey],
+) -> Result<std::path::PathBuf, LoaderError> {
+    let archive = archive.as_ref();
+    let dest = dest.as_ref();
+
+    let pkg_dir = fidius_core::package::unpack_package(archive, dest).map_err(|e| {
+        LoaderError::Validation {
+            reason: format!("unpack provider package '{}': {e}", archive.display()),
+        }
+    })?;
+
+    if !verify_keys.is_empty() {
+        fidius_host::package::verify_package(&pkg_dir, verify_keys).map_err(|e| {
+            LoaderError::Validation {
+                reason: format!("verify provider signature for '{}': {e}", pkg_dir.display()),
+            }
+        })?;
+    }
+
+    Ok(pkg_dir)
+}
+
+/// Load a WASM **task** constructor from a packed provider archive and return it
+/// as a runnable [`Task`].
+///
+/// The packaged analogue of [`load_task_constructor`]: it unpacks (and, with
+/// `verify_keys`, verifies the signature of) the provider archive into `dest`,
+/// then resolves `package_name` out of the unpacked tree exactly as the loose-dir
+/// loader does (the unpacked package dir lives under `dest`, and fidius matches
+/// the package by its `[package].name`, not its directory name). `config` binds
+/// the constructor's per-instance configuration once at load.
+///
+/// Fails closed if the archive is hostile/unsigned-when-required, the package is
+/// missing, the manifest is unreadable or not a `Task`, or the interface version
+/// doesn't match the contract.
+pub fn load_task_constructor_from_package<C: Serialize>(
+    archive: impl AsRef<Path>,
+    dest: impl AsRef<Path>,
+    package_name: &str,
+    config: &C,
+    verify_keys: &[ed25519_dalek::VerifyingKey],
+) -> Result<Arc<dyn Task>, LoaderError> {
+    let dest = dest.as_ref();
+    // Unpack (+ verify) first; this is the seam that rejects a tampered or
+    // unsigned-but-required archive before any wasm is loaded.
+    let _pkg_dir = unpack_provider_archive(archive, dest, verify_keys)?;
+    // `dest` is the fidius search path; the package resolves by name out of the
+    // freshly-unpacked `<name>-<version>/` directory it contains.
+    load_task_constructor(dest, package_name, config)
+}
+
+// ===========================================================================
 // TRIGGER primitive (CLOACI-T-0824)
 // ===========================================================================
 

--- a/crates/cloacina/src/registry/loader/mod.rs
+++ b/crates/cloacina/src/registry/loader/mod.rs
@@ -34,6 +34,7 @@ pub use task_registrar::TaskRegistrar;
 
 #[cfg(feature = "constructors-wasm")]
 pub use constructor_loader::{
-    load_constructor, load_task_constructor, load_trigger_constructor, ConstructorBinding,
-    TriggerBinding, WasmTaskConstructor, WasmTriggerConstructor,
+    load_constructor, load_task_constructor, load_task_constructor_from_package,
+    load_trigger_constructor, unpack_provider_archive, ConstructorBinding, TriggerBinding,
+    WasmTaskConstructor, WasmTriggerConstructor,
 };

--- a/crates/cloacina/tests/constructor_provider_package_wasm.rs
+++ b/crates/cloacina/tests/constructor_provider_package_wasm.rs
@@ -1,0 +1,210 @@
+/*
+ *  Copyright 2026 Colliery Software
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+//! CLOACI-T-0827 — end-to-end: a `#[constructor]`-authored crate is packaged into
+//! a **signed fidius provider package**, and the loader resolves the constructor
+//! **from the packed archive** (unpack → verify signature → `load_wasm_configured`)
+//! to run as a cloacina [`Task`].
+//!
+//! This is the packaged counterpart to `constructor_macro_wasm.rs` (which loads
+//! the same fixture from a loose dir). The proof:
+//!   1. `package_constructor_provider` builds the fixture to a `wasm32-wasip2`
+//!      component, emits `constructor.json` from `__constructor_manifest()`,
+//!      assembles a `runtime = "wasm"` provider package, Ed25519-signs it, and
+//!      packs it into a `.cloacina` archive;
+//!   2. `load_task_constructor_from_package` unpacks + verifies the signature and
+//!      loads the constructor → `Arc<dyn Task>`;
+//!   3. running it with `Context { name: "world" }` yields `result == "hello, world"`.
+//! Plus fail-closed paths: a wrong verifying key, a tampered package, and a
+//! missing `constructor.json` are all rejected.
+//!
+//! Feature-gated (`constructors-wasm`, which pulls wasmtime + implies
+//! `constructor-packaging`). Excluded from the default build.
+#![cfg(feature = "constructors-wasm")]
+
+use std::path::PathBuf;
+
+use ed25519_dalek::SigningKey;
+use serde::Serialize;
+
+use cloacina::packaging::constructor_provider::{
+    package_constructor_provider, ProviderPackageOptions,
+};
+use cloacina::registry::loader::{load_task_constructor_from_package, unpack_provider_archive};
+use cloacina::Context;
+
+/// Per-instance config the loader binds once at load (serde-compatible with the
+/// macro-generated guest `__PrefixConfig { prefix }`).
+#[derive(Serialize)]
+struct Config {
+    prefix: String,
+}
+
+fn fixture_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../examples/constructor-contract/task-constructor-macro-fixture")
+}
+
+/// A deterministic Ed25519 keypair for the test (no OsRng needed). Writes the
+/// 32-byte secret to `dir/key.secret` and returns (secret_path, verifying_key).
+fn write_test_key(dir: &std::path::Path) -> (PathBuf, ed25519_dalek::VerifyingKey) {
+    let signing = SigningKey::from_bytes(&[7u8; 32]);
+    let verifying = signing.verifying_key();
+    let secret_path = dir.join("key.secret");
+    std::fs::write(&secret_path, signing.to_bytes()).unwrap();
+    (secret_path, verifying)
+}
+
+/// Package the fixture into a signed `.cloacina` provider archive once.
+fn signed_archive(work: &std::path::Path) -> (PathBuf, ed25519_dalek::VerifyingKey) {
+    let (key_path, vk) = write_test_key(work);
+    let out = work.join("prefix-provider.cloacina");
+
+    let opts = ProviderPackageOptions {
+        crate_dir: fixture_dir(),
+        output: Some(out.clone()),
+        sign_key: Some(key_path),
+        manifest_bin: "emit_manifest".to_string(),
+        release: true,
+    };
+    let result = package_constructor_provider(&opts).expect("package_constructor_provider");
+
+    assert!(result.signed, "archive should be signed");
+    assert_eq!(result.provider_name, "prefix");
+    assert_eq!(result.constructors, vec!["prefix".to_string()]);
+    assert!(out.exists(), "archive written to {}", out.display());
+    (out, vk)
+}
+
+#[tokio::test]
+async fn signed_provider_loads_from_package_and_runs_as_task() {
+    let work = tempfile::TempDir::new().unwrap();
+    let (archive, vk) = signed_archive(work.path());
+
+    let dest = work.path().join("unpacked");
+    let task = load_task_constructor_from_package(
+        &archive,
+        &dest,
+        "prefix",
+        &Config {
+            prefix: "hello, ".into(),
+        },
+        &[vk],
+    )
+    .expect("load_task_constructor_from_package (signed, verified)");
+
+    assert_eq!(task.id(), "prefix");
+
+    let mut ctx = Context::new();
+    ctx.insert("name", serde_json::json!("world")).unwrap();
+    let out = task.execute(ctx).await.expect("constructor task execute");
+
+    assert_eq!(
+        out.get("result"),
+        Some(&serde_json::json!("hello, world")),
+        "constructor loaded FROM THE SIGNED PACKAGE produces result = prefix + name"
+    );
+    assert_eq!(out.get("name"), Some(&serde_json::json!("world")));
+}
+
+#[tokio::test]
+async fn wrong_verifying_key_fails_closed() {
+    let work = tempfile::TempDir::new().unwrap();
+    let (archive, _vk) = signed_archive(work.path());
+
+    // A different key never signed this package.
+    let wrong = SigningKey::from_bytes(&[9u8; 32]).verifying_key();
+    let dest = work.path().join("unpacked-wrong");
+
+    let err = load_task_constructor_from_package(
+        &archive,
+        &dest,
+        "prefix",
+        &Config { prefix: "x".into() },
+        &[wrong],
+    )
+    .err()
+    .expect("loading with a non-signing key must fail closed");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("signature") || msg.contains("verify"),
+        "error should be a signature-verification failure, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn tampered_package_fails_signature_verification() {
+    let work = tempfile::TempDir::new().unwrap();
+    let (archive, vk) = signed_archive(work.path());
+
+    // Unpack WITHOUT verifying, tamper a packaged file, then REPACK it (carrying
+    // the original, now-stale `package.sig`).
+    let dest = work.path().join("unpacked-tamper");
+    let pkg_dir = unpack_provider_archive(&archive, &dest, &[]).expect("unpack (no verify)");
+
+    let manifest = pkg_dir.join("constructor.json");
+    let mut content = std::fs::read_to_string(&manifest).unwrap();
+    content.push_str("\n");
+    content.push_str("{\"tampered\":true}");
+    std::fs::write(&manifest, content).unwrap();
+
+    let tampered = work.path().join("tampered.cloacina");
+    fidius_core::package::pack_package(&pkg_dir, Some(&tampered)).expect("repack tampered dir");
+
+    // Loading the tampered archive with the original key must fail closed: the
+    // recomputed digest no longer matches the carried signature.
+    let dest2 = work.path().join("unpacked-tamper-load");
+    let err = load_task_constructor_from_package(
+        &tampered,
+        &dest2,
+        "prefix",
+        &Config { prefix: "x".into() },
+        &[vk],
+    )
+    .err()
+    .expect("tampered package must fail signature verification");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("signature") || msg.contains("verify"),
+        "tamper should surface a signature-verification error, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn missing_constructor_manifest_fails_closed() {
+    let work = tempfile::TempDir::new().unwrap();
+    let (archive, _vk) = signed_archive(work.path());
+
+    // Unpack, delete the sidecar manifest, then load through the loose-dir path
+    // the package loader delegates to: a provider without its `constructor.json`
+    // must not load.
+    let dest = work.path().join("unpacked-nomanifest");
+    let pkg_dir = unpack_provider_archive(&archive, &dest, &[]).expect("unpack");
+    std::fs::remove_file(pkg_dir.join("constructor.json")).unwrap();
+
+    let err = cloacina::registry::loader::load_task_constructor(
+        &dest,
+        "prefix",
+        &Config { prefix: "x".into() },
+    )
+    .err()
+    .expect("missing constructor.json must fail closed");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("constructor.json") || msg.to_lowercase().contains("manifest"),
+        "error should mention the missing manifest, got: {msg}"
+    );
+}

--- a/crates/cloacinactl/Cargo.toml
+++ b/crates/cloacinactl/Cargo.toml
@@ -21,7 +21,10 @@ sqlite = ["cloacina/sqlite"]
 kafka = ["cloacina/kafka"]
 
 [dependencies]
-cloacina = { version = "0.9.0", path = "../cloacina", default-features = false }
+# `constructor-packaging` gives `cloacinactl constructor package` the provider
+# assembly/sign/pack path (CLOACI-T-0827). It is wasmtime-free (serde-only
+# contract crate) — it does NOT pull `constructors-wasm`, so the CLI stays light.
+cloacina = { version = "0.9.0", path = "../cloacina", default-features = false, features = ["constructor-packaging"] }
 cloacina-client = { workspace = true }
 cloacina-workflow-plugin = { version = "0.9.0", path = "../cloacina-workflow-plugin" }
 clap.workspace = true

--- a/crates/cloacinactl/src/main.rs
+++ b/crates/cloacinactl/src/main.rs
@@ -33,8 +33,8 @@ mod shared;
 use shared::error::CliError;
 
 use nouns::{
-    accumulator, compiler, daemon, execution, graph, key, package, reactor, server, tenant,
-    trigger, workflow,
+    accumulator, compiler, constructor, daemon, execution, graph, key, package, reactor, server,
+    tenant, trigger, workflow,
 };
 
 /// cloacinactl — Cloacina task orchestration engine
@@ -121,6 +121,9 @@ enum Commands {
 
     /// Package — build, pack, upload, and inspect .cloacina archives
     Package(package::PackageCmd),
+
+    /// Constructor — package a #[constructor] crate into a signed provider archive
+    Constructor(constructor::ConstructorCmd),
 
     /// Workflow — named task DAGs registered in packages
     Workflow(workflow::WorkflowCmd),
@@ -256,6 +259,7 @@ async fn run() -> std::result::Result<(), CliError> {
         Commands::Reactor(cmd) => return cmd.run(&cli.globals).await,
         Commands::Accumulator(cmd) => return cmd.run(&cli.globals).await,
         Commands::Package(cmd) => return cmd.run(&cli.globals).await,
+        Commands::Constructor(cmd) => return cmd.run(&cli.globals).await,
         Commands::Workflow(cmd) => return cmd.run(&cli.globals).await,
         Commands::Execution(cmd) => return cmd.run(&cli.globals).await,
         Commands::Tenant(cmd) => return cmd.run(&cli.globals).await,

--- a/crates/cloacinactl/src/nouns/constructor/mod.rs
+++ b/crates/cloacinactl/src/nouns/constructor/mod.rs
@@ -1,0 +1,100 @@
+/*
+ *  Copyright 2026 Colliery Software
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+//! `cloacinactl constructor <verb>` — author-side distribution of `#[constructor]`
+//! crates as fidius **provider packages** (CLOACI-T-0827).
+//!
+//! `constructor package <crate-dir>` builds the crate to a `wasm32-wasip2`
+//! component, emits its `constructor.json` from the macro-generated
+//! `__constructor_manifest()`, assembles a fidius `runtime = "wasm"` provider
+//! package, optionally Ed25519-signs it, and packs it into a distributable
+//! `<name>-<version>.cloacina` archive — the constructor analogue of
+//! `cloacinactl package pack`.
+
+use std::path::PathBuf;
+
+use clap::{Args, Subcommand};
+
+use cloacina::packaging::constructor_provider::{
+    package_constructor_provider, ProviderPackageOptions,
+};
+
+use crate::shared::error::CliError;
+use crate::GlobalOpts;
+
+#[derive(Args)]
+pub struct ConstructorCmd {
+    #[command(subcommand)]
+    verb: ConstructorVerb,
+}
+
+#[derive(Subcommand)]
+enum ConstructorVerb {
+    /// Build + assemble + (optionally sign) + pack a `#[constructor]` crate into a
+    /// distributable `.cloacina` provider package.
+    Package {
+        /// The constructor crate directory (contains Cargo.toml + the
+        /// `#[constructor]` lib + a manifest-emitter bin).
+        crate_dir: PathBuf,
+        /// Output archive path (default: `<name>-<version>.cloacina` in the CWD).
+        #[arg(long)]
+        out: Option<PathBuf>,
+        /// Sign the package with this Ed25519 secret-key file (32 raw bytes).
+        #[arg(long = "sign-key")]
+        sign_key: Option<PathBuf>,
+        /// Host binary in the crate that prints the constructor manifest JSON
+        /// (the `__constructor_manifest()` emitter).
+        #[arg(long, default_value = "emit_manifest")]
+        manifest_bin: String,
+        /// Build the wasm component in debug profile (default is release).
+        #[arg(long)]
+        debug: bool,
+    },
+}
+
+impl ConstructorCmd {
+    pub async fn run(self, _globals: &GlobalOpts) -> Result<(), CliError> {
+        match self.verb {
+            ConstructorVerb::Package {
+                crate_dir,
+                out,
+                sign_key,
+                manifest_bin,
+                debug,
+            } => {
+                let opts = ProviderPackageOptions {
+                    crate_dir,
+                    output: out,
+                    sign_key,
+                    manifest_bin,
+                    release: !debug,
+                };
+                let result = package_constructor_provider(&opts)
+                    .map_err(|e| CliError::UserError(e.to_string()))?;
+
+                let signed = if result.signed { "signed" } else { "unsigned" };
+                eprintln!(
+                    "Packaged provider '{}' ({signed}) carrying {} constructor(s): {}",
+                    result.provider_name,
+                    result.constructors.len(),
+                    result.constructors.join(", "),
+                );
+                println!("{}", result.archive.display());
+                Ok(())
+            }
+        }
+    }
+}

--- a/crates/cloacinactl/src/nouns/mod.rs
+++ b/crates/cloacinactl/src/nouns/mod.rs
@@ -23,6 +23,7 @@ use crate::GlobalOpts;
 
 pub mod accumulator;
 pub mod compiler;
+pub mod constructor;
 pub mod daemon;
 pub mod execution;
 pub mod graph;


### PR DESCRIPTION
Turns a `#[constructor]` crate into a distributable, **signed fidius provider package** (`.wasm` + `constructor.json` + `package.toml` + an N-capable `provider.json` index), via the same fidius pack machinery as workflow packaging. Adds `cloacinactl constructor package`, and teaches the loader to load + signature-verify a constructor **from the packed archive** (fail-closed on wrong-key/tamper/missing-manifest).

Packaging tool is **wasmtime-free** (new default-OFF `constructor-packaging` feature pulls only the serde-only contract crate). Verified e2e: signed package → load-from-package → runs as a Task → `hello, world`; 4 e2e + 4 regression pass; cloacinactl --all-targets clean; fmt clean.

Deferred: remote registry/publish, key management, multi-constructor-per-archive, non-task-kind packaging.

https://claude.ai/code/session_01VWpWbgCzNdQkFT74S3wPRM