### PR TITLE
feat(constructors): thread reactor constructors through the CG scheduler (CLOACI-T-0830)

### DIFF
--- a/.metis/backlog/features/CLOACI-T-0830.md
+++ b/.metis/backlog/features/CLOACI-T-0830.md
@@ -4,15 +4,15 @@ level: task
 title: "Thread reactor constructors through the CG scheduler package-load path"
 short_code: "CLOACI-T-0830"
 created_at: 2026-06-29T12:35:51.298733+00:00
-updated_at: 2026-06-29T12:35:51.298733+00:00
+updated_at: 2026-06-29T15:11:13.112433+00:00
 parent: CLOACI-I-0132
 blocked_by: []
 archived: false
 
 tags:
   - "#task"
-  - "#phase/backlog"
   - "#feature"
+  - "#phase/completed"
 
 
 exit_criteria_met: false
@@ -73,11 +73,26 @@ Complete the reactor-constructor consumer path deferred from [[CLOACI-T-0828]]: 
 - **Benefits of Fixing**: {What improves after refactoring}
 - **Risk Assessment**: {Risks of not addressing this}
 
+## Acceptance Criteria
+
+## Acceptance Criteria
+
+## Acceptance Criteria
+
 ## Acceptance Criteria **[REQUIRED]**
 
-- [ ] {Specific, testable requirement 1}
-- [ ] {Specific, testable requirement 2}
-- [ ] {Specific, testable requirement 3}
+- [x] `ReactorDeclaration` carries a reactor-constructor reference
+  (`ReactorConstructorRef { from, constructor, config }`), populated by the
+  `#[reactor(from=.., constructor=.., config={..})]` authoring path via
+  `ReactorRegistration`.
+- [x] `scheduler.rs::load_reactor` loads the constructor (resolving `from` via the
+  T-0829 provider seam, binding config BY NAME) and installs it via
+  `Reactor::with_evaluator`; the resolved decider survives reactor restart.
+- [x] E2E (gated `constructors-wasm`): a graph declaring a reactor constructor loads +
+  fires via the scheduler — the WASM `evaluate` gates firing, config bound by name.
+- [x] Behind `constructors-wasm` (default OFF): default `cargo check -p cloacina` clean,
+  `cargo tree -p cloacina -i wasmtime` absent; the 44 CG unit tests stay green; the
+  non-constructor `Reactor::new` path is unchanged when no ref is present.
 
 ## Test Cases **[CONDITIONAL: Testing Task]**
 
@@ -142,4 +157,57 @@ Complete the reactor-constructor consumer path deferred from [[CLOACI-T-0828]]: 
 
 ## Status Updates **[REQUIRED]**
 
-*To be added during implementation*
+### 2026-06-29 — Implemented + tested (ready for review; not committed)
+
+**Gap closed:** a reactor authored as a WASM `#[constructor(kind = reactor)]` now
+fires via the CG scheduler's package-load path, not just a direct
+`Reactor::with_evaluator(...)` harness.
+
+**`ReactorDeclaration` change:** added `constructor: Option<ReactorConstructorRef>`.
+New `ReactorConstructorRef { from, constructor, config }` lives in the leaf crate
+`cloacina-computation-graph` (always compiled — only String/serde_json::Value, no
+wasmtime types) and is also carried on `ReactorRegistration`. Re-exported as
+`cloacina::ReactorConstructorRef`.
+
+**Authoring path chosen:** extended the `#[reactor]` macro with optional
+`from` / `constructor` / `config = { name = value }` (both-or-neither validation;
+`config` needs `constructor`). The macro lowers config to serde_json literals in the
+LIB inventory submission (packaged submission carries None — provider resolution is
+an embedded-host concern). Most consistent with T-0829: reuses its name-keyed config
++ provider resolution wholesale. Chose this over `constructor!(kind=reactor)` because
+a reactor is the scheduler's firing engine, not a runtime-registered DAG node — it
+needs the declaration→scheduler path (`#[reactor]`→`ReactorRegistration`→
+`dispatch_runtime_reactors_into_scheduler`).
+
+**Scheduler threading (`load_reactor`):** added a `constructor` param; calls the new
+feature-gated `load_reactor_constructor_node` (in `constructor_loader.rs`, reusing
+`bind_config_by_name` + `load_reactor_constructor`) on spawn_blocking → resolve ref →
+`Arc<dyn ReactorFireDecider>`, then `.with_evaluator(..)`. Resolved decider stored on
+`RunningGraph.evaluator` and re-applied on supervisor restart (no WASM re-load).
+Resolution runs before any spawn (bad ref fails the load cleanly). Feature-OFF build
+with a ref present fails closed. `load_graph` + `dispatch_runtime_reactors_into_scheduler`
+pass the ref through; `load_graph_split` / FFI `dispatch_package_reactors_into_scheduler`
+/ Python pass None.
+
+**E2E (`tests/constructor_reactor_scheduler_wasm.rs`, gated `constructors-wasm`):**
+stage `reactor-constructor-fixture` as a provider, build a declaration carrying the
+ref (gate=5.0 bound BY NAME), `load_graph`, push boundaries via the normal
+accumulator→reactor path: below-gate (1.0) does NOT fire, above-gate (9.0) DOES — the
+WASM `evaluate` gates firing through the scheduler. A second test proves a
+constructor-name mismatch fails the load closed.
+
+**Validation (all green):** `cargo check -p cloacina` clean + `cargo tree -p cloacina
+-i wasmtime` absent (present only with `--features constructors-wasm`); lib
+`computation_graph::` 44 passed; CG integration 45 passed; `cloacina-macros reactor`
+20 passed (5 new); e2e 2 passed; existing `constructor_reactor_wasm` 4 passed
+(no regression); `cargo fmt --all -- --check` exit 0; `cargo check -p cloacina-python`
+clean.
+
+**Deferred (reported, not faked):** threading the ref through the FFI
+`ReactorPackageMetadata` shape (Rust cdylib packaging) — needs new serialized fields
++ signing. Embedded/runtime inventory authoring path is complete; FFI packaged path
+dispatches as a native dirty-flag reactor for now.
+
+**Confirm:** `criteria` on a constructor-backed `ReactorDeclaration` is vestigial (the
+WASM `evaluate` replaces it). Kept required in the macro for minimal churn, documented
+as ignored-when-constructor-present. Flag if you'd prefer it optional.

--- a/crates/cloacina-computation-graph/src/lib.rs
+++ b/crates/cloacina-computation-graph/src/lib.rs
@@ -358,6 +358,36 @@ pub trait Reactor {
     const REACTION_MODE: ReactionMode;
 }
 
+/// A reference to a packaged WASM reactor **constructor** carried by a reactor
+/// declaration (CLOACI-T-0830).
+///
+/// When present, the reactor's firing decision is delegated to the named WASM
+/// constructor's `evaluate` (installed on the live `Reactor` via
+/// `with_evaluator`), REPLACING the built-in `WhenAny`/`WhenAll` dirty-flag
+/// criteria. The fields mirror the `constructor!(...)` consumer surface added for
+/// task/trigger in CLOACI-T-0829, so a reactor constructor is authored/resolved
+/// the same way:
+///   * `from` — the provider package, `"name[@version]"`, resolved against the
+///     T-0829 provider search path (`CLOACINA_PROVIDER_PATH` / `./providers` /
+///     the process override);
+///   * `constructor` — which constructor inside that provider (validated against
+///     the provider's `constructor.json` `name`);
+///   * `config` — the author's `config = { name = value }` kwargs as
+///     `(name, value)` pairs in WRITTEN order, bound BY NAME at load.
+///
+/// Resolution happens in the CG scheduler (`load_reactor`) behind the
+/// `constructors-wasm` feature; this type itself is always compiled (it carries
+/// only `String`/`serde_json::Value`, no wasmtime types).
+#[derive(Debug, Clone)]
+pub struct ReactorConstructorRef {
+    /// Provider package reference, `"name[@version]"`.
+    pub from: String,
+    /// The constructor's `constructor.json` name inside the provider.
+    pub constructor: String,
+    /// Author config as `(name, value)` pairs in written order; bound by name.
+    pub config: Vec<(String, serde_json::Value)>,
+}
+
 /// Runtime-side description of a reactor.
 ///
 /// Populated by the `#[reactor]` macro's emitted inventory entry.
@@ -366,6 +396,11 @@ pub struct ReactorRegistration {
     pub name: String,
     pub accumulator_names: Vec<String>,
     pub reaction_mode: ReactionMode,
+    /// Optional packaged WASM reactor-constructor reference (CLOACI-T-0830).
+    /// `Some(..)` makes the WASM guest's `evaluate` the reactor's firing
+    /// criteria; `None` is the native dirty-flag reactor. Defaults to `None`
+    /// so every pre-existing construction site stays valid.
+    pub constructor: Option<ReactorConstructorRef>,
 }
 
 pub type ReactorConstructor = Box<dyn Fn() -> ReactorRegistration + Send + Sync>;

--- a/crates/cloacina-macros/src/reactor_attr.rs
+++ b/crates/cloacina-macros/src/reactor_attr.rs
@@ -37,7 +37,7 @@ use proc_macro2::Span;
 use quote::{format_ident, quote};
 use syn::parse::{Parse, ParseStream};
 use syn::punctuated::Punctuated;
-use syn::{parse2, Ident, ItemStruct, LitStr, Token};
+use syn::{parse2, Expr, Ident, ItemStruct, LitStr, Token};
 
 /// Parsed form of the `#[reactor(...)]` arguments.
 struct ReactorArgs {
@@ -46,6 +46,15 @@ struct ReactorArgs {
     criteria_mode: CriteriaMode,
     criteria_accumulators: Vec<Ident>,
     criteria_span: Span,
+    /// CLOACI-T-0830: optional packaged reactor-constructor reference. When
+    /// `from`/`constructor` are present, the reactor's firing decision is
+    /// delegated to the named WASM constructor's `evaluate` (resolved + installed
+    /// by the CG scheduler via `Reactor::with_evaluator`) instead of the built-in
+    /// `criteria`. `config = { name = value }` is bound BY NAME at load, exactly
+    /// as the T-0829 `constructor!(...)` consumer form does for task/trigger.
+    from: Option<LitStr>,
+    constructor: Option<LitStr>,
+    config: Vec<(String, Expr)>,
 }
 
 impl std::fmt::Debug for ReactorArgs {
@@ -93,6 +102,9 @@ impl Parse for ReactorArgs {
         let mut name: Option<LitStr> = None;
         let mut accumulators: Option<Vec<Ident>> = None;
         let mut criteria: Option<(CriteriaMode, Vec<Ident>, Span)> = None;
+        let mut from: Option<LitStr> = None;
+        let mut constructor: Option<LitStr> = None;
+        let mut config: Vec<(String, Expr)> = Vec::new();
 
         while !input.is_empty() {
             let key: Ident = input.parse()?;
@@ -178,12 +190,52 @@ impl Parse for ReactorArgs {
                     }
                     criteria = Some((mode, list, mode_span));
                 }
+                "from" => {
+                    if from.is_some() {
+                        return Err(syn::Error::new(key.span(), "duplicate 'from' field"));
+                    }
+                    let lit: LitStr = input.parse()?;
+                    if lit.value().is_empty() {
+                        return Err(syn::Error::new(
+                            lit.span(),
+                            "reactor 'from' provider cannot be empty",
+                        ));
+                    }
+                    from = Some(lit);
+                }
+                "constructor" => {
+                    if constructor.is_some() {
+                        return Err(syn::Error::new(key.span(), "duplicate 'constructor' field"));
+                    }
+                    let lit: LitStr = input.parse()?;
+                    if lit.value().is_empty() {
+                        return Err(syn::Error::new(
+                            lit.span(),
+                            "reactor 'constructor' name cannot be empty",
+                        ));
+                    }
+                    constructor = Some(lit);
+                }
+                "config" => {
+                    // `config = { key = expr, … }` — bound BY NAME at load.
+                    let content;
+                    syn::braced!(content in input);
+                    while !content.is_empty() {
+                        let ckey: Ident = content.parse()?;
+                        content.parse::<Token![=]>()?;
+                        let cval: Expr = content.parse()?;
+                        config.push((ckey.to_string(), cval));
+                        if !content.is_empty() {
+                            content.parse::<Token![,]>()?;
+                        }
+                    }
+                }
                 other => {
                     return Err(syn::Error::new(
                         key.span(),
                         format!(
                             "unknown field '{}' in #[reactor(...)] — expected 'name', \
-                             'accumulators', or 'criteria'",
+                             'accumulators', 'criteria', 'from', 'constructor', or 'config'",
                             other
                         ),
                     ));
@@ -228,12 +280,31 @@ impl Parse for ReactorArgs {
             }
         }
 
+        // CLOACI-T-0830: `from`/`constructor` are both-or-neither, and `config`
+        // only makes sense when a constructor is named.
+        if from.is_some() != constructor.is_some() {
+            return Err(syn::Error::new(
+                Span::call_site(),
+                "#[reactor] reactor-constructor reference requires BOTH 'from' and \
+                 'constructor' (e.g. from = \"acme/gate@0.1\", constructor = \"gate\")",
+            ));
+        }
+        if constructor.is_none() && !config.is_empty() {
+            return Err(syn::Error::new(
+                Span::call_site(),
+                "#[reactor] 'config' is only valid alongside a 'constructor' reference",
+            ));
+        }
+
         Ok(ReactorArgs {
             name,
             accumulators,
             criteria_mode,
             criteria_accumulators,
             criteria_span,
+            from,
+            constructor,
+            config,
         })
     }
 }
@@ -303,6 +374,29 @@ fn reactor_impl(
     let _ = parsed.criteria_span;
     let _ = parsed.criteria_accumulators;
 
+    // CLOACI-T-0830: build the optional reactor-constructor reference token for
+    // the LIB (embedded) inventory submission. The scheduler resolves it against
+    // the T-0829 provider search path and installs the WASM `evaluate` as the
+    // reactor's firing decider. Only emitted in lib mode — provider resolution is
+    // an embedded-host concern (behind `constructors-wasm`), not a packaged-cdylib
+    // one, so the packaged submission always carries `None`. `config` values are
+    // lowered to `serde_json` literals and bound BY NAME at load (T-0829).
+    let lib_constructor_ref = match (&parsed.from, &parsed.constructor) {
+        (Some(from_lit), Some(ctor_lit)) => {
+            let cfg_pairs = parsed.config.iter().map(|(k, v)| {
+                quote! { (#k.to_string(), ::cloacina::serde_json::json!(#v)) }
+            });
+            quote! {
+                ::std::option::Option::Some(#cg_path::ReactorConstructorRef {
+                    from: #from_lit.to_string(),
+                    constructor: #ctor_lit.to_string(),
+                    config: ::std::vec![ #(#cfg_pairs),* ],
+                })
+            }
+        }
+        _ => quote! { ::std::option::Option::None },
+    };
+
     let auto_register_ident = format_ident!(
         "_auto_register_reactor_{}",
         reactor_name_str.replace('-', "_")
@@ -333,6 +427,7 @@ fn reactor_impl(
                     name: #reactor_name_lit.to_string(),
                     accumulator_names: vec![#(#accumulator_strs.to_string()),*],
                     reaction_mode: #cg_path::ReactionMode::#mode_variant,
+                    constructor: #lib_constructor_ref,
                 },
             }
         }
@@ -345,6 +440,7 @@ fn reactor_impl(
                     name: #reactor_name_lit.to_string(),
                     accumulator_names: vec![#(#accumulator_strs.to_string()),*],
                     reaction_mode: #cg_path::ReactionMode::#mode_variant,
+                    constructor: ::std::option::Option::None,
                 },
             }
         }
@@ -486,6 +582,85 @@ mod tests {
         assert!(out.contains("\"alpha\""));
         assert!(out.contains("\"beta\""));
         assert!(out.contains("WhenAny"));
+    }
+
+    // -----------------------------------------------------------------------
+    // CLOACI-T-0830: reactor-constructor reference (from/constructor/config)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn parse_reactor_constructor_ref() {
+        let args = quote! {
+            name = "gate",
+            accumulators = [x],
+            criteria = when_any(x),
+            from = "acme/gate@0.1",
+            constructor = "gate",
+            config = { gate = 5.0 },
+        };
+        let parsed: ReactorArgs = syn::parse2(args).unwrap();
+        assert_eq!(parsed.from.as_ref().unwrap().value(), "acme/gate@0.1");
+        assert_eq!(parsed.constructor.as_ref().unwrap().value(), "gate");
+        assert_eq!(parsed.config.len(), 1);
+        assert_eq!(parsed.config[0].0, "gate");
+    }
+
+    #[test]
+    fn error_from_without_constructor() {
+        let args = quote! {
+            name = "gate",
+            accumulators = [x],
+            criteria = when_any(x),
+            from = "acme/gate@0.1",
+        };
+        let err = syn::parse2::<ReactorArgs>(args).unwrap_err();
+        assert!(err.to_string().contains("BOTH 'from' and 'constructor'"));
+    }
+
+    #[test]
+    fn error_config_without_constructor() {
+        let args = quote! {
+            name = "gate",
+            accumulators = [x],
+            criteria = when_any(x),
+            config = { gate = 5.0 },
+        };
+        let err = syn::parse2::<ReactorArgs>(args).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("'config' is only valid alongside a 'constructor'"));
+    }
+
+    #[test]
+    fn impl_emits_constructor_ref() {
+        let args = quote! {
+            name = "gate",
+            accumulators = [x],
+            criteria = when_any(x),
+            from = "acme/gate@0.1",
+            constructor = "gate",
+            config = { gate = 5.0 },
+        };
+        let input = quote! { pub struct Gate; };
+        let out = reactor_impl(args, input).unwrap().to_string();
+        assert!(out.contains("ReactorConstructorRef"));
+        assert!(out.contains("\"acme/gate@0.1\""));
+        // The packaged submission always carries None for the ref.
+        assert!(out.contains("None"));
+    }
+
+    #[test]
+    fn impl_no_constructor_ref_when_absent() {
+        let args = quote! {
+            name = "rx",
+            accumulators = [alpha],
+            criteria = when_any(alpha),
+        };
+        let input = quote! { pub struct Rx; };
+        let out = reactor_impl(args, input).unwrap().to_string();
+        assert!(!out.contains("ReactorConstructorRef"));
+        // Both submissions emit `constructor: None`.
+        assert!(out.contains("constructor"));
     }
 
     #[test]

--- a/crates/cloacina-python/src/computation_graph.rs
+++ b/crates/cloacina-python/src/computation_graph.rs
@@ -882,6 +882,9 @@ pub fn build_python_graph_declaration(
             criteria,
             strategy: InputStrategy::Latest,
             graph_fn,
+            // CLOACI-T-0830: the Python CG path doesn't author WASM reactor
+            // constructors — native dirty-flag firing only.
+            constructor: None,
         },
         tenant_id,
         // T-0544 M5: thread the reactor name from the `@cloaca.reactor`

--- a/crates/cloacina-python/src/reactor.rs
+++ b/crates/cloacina-python/src/reactor.rs
@@ -132,6 +132,9 @@ pub fn reactor(
                 name: reg_name.clone(),
                 accumulator_names: reg_accs.clone(),
                 reaction_mode: reg_mode,
+                // CLOACI-T-0830: the Python reactor path doesn't (yet) author
+                // WASM reactor constructors — native dirty-flag firing only.
+                constructor: None,
             });
 
             tracing::debug!(

--- a/crates/cloacina/src/computation_graph/packaging_bridge.rs
+++ b/crates/cloacina/src/computation_graph/packaging_bridge.rs
@@ -225,6 +225,11 @@ pub fn build_declaration_from_ffi(
             criteria,
             strategy,
             graph_fn,
+            // CLOACI-T-0830: the FFI/cdylib packaged path doesn't yet carry a
+            // reactor-constructor reference through `GraphPackageMetadata`
+            // (deferred — see `dispatch_package_reactors_into_scheduler`). Native
+            // dirty-flag firing only for this path.
+            constructor: None,
         },
         tenant_id: None, // Set by the reconciler based on package ownership
         // Propagate the explicit reactor name from the FFI metadata
@@ -687,6 +692,11 @@ pub async fn dispatch_runtime_reactors_into_scheduler(
                 strategy,
                 tenant_id.clone(),
                 vec![],
+                // CLOACI-T-0830: carry the reactor-constructor reference from the
+                // runtime registration (populated by `#[reactor(from=.., …)]`)
+                // into the scheduler, which resolves + installs the WASM
+                // `evaluate` as the reactor's firing decider.
+                registration.constructor.clone(),
             )
             .await?;
 
@@ -767,6 +777,11 @@ pub async fn dispatch_package_reactors_into_scheduler(
                 strategy,
                 tenant_id.clone(),
                 vec![],
+                // CLOACI-T-0830: threading a reactor-constructor reference through
+                // the FFI `ReactorPackageMetadata` shape is deferred (it needs new
+                // serialized fields + signing). Rust cdylib packages dispatch as
+                // native dirty-flag reactors for now.
+                None,
             )
             .await?;
 

--- a/crates/cloacina/src/computation_graph/scheduler.rs
+++ b/crates/cloacina/src/computation_graph/scheduler.rs
@@ -30,7 +30,7 @@ use tracing::{error, info, warn};
 use super::accumulator::{health_channel, shutdown_signal, AccumulatorHealth};
 use super::reactor::{
     reactor_health_channel, CompiledGraphFn, InputStrategy, ReactionCriteria, Reactor,
-    ReactorHandle,
+    ReactorFireDecider, ReactorHandle,
 };
 use super::registry::{AccumulatorAuthPolicy, EndpointRegistry, ReactorAuthPolicy};
 use super::types::{GraphResult, InputCache, SourceName};
@@ -105,11 +105,22 @@ pub trait AccumulatorFactory: Send + Sync {
 #[derive(Clone)]
 pub struct ReactorDeclaration {
     /// Reaction criteria (when_any / when_all).
+    ///
+    /// Ignored at runtime when `constructor` is `Some(..)` — a reactor
+    /// constructor's WASM `evaluate` replaces the dirty-flag criteria.
     pub criteria: ReactionCriteria,
     /// Input strategy (latest / sequential).
     pub strategy: InputStrategy,
     /// The compiled graph function.
     pub graph_fn: CompiledGraphFn,
+    /// Optional packaged WASM reactor-constructor reference (CLOACI-T-0830).
+    ///
+    /// `Some(..)` makes the named constructor's WASM `evaluate` the reactor's
+    /// firing decision: [`load_reactor`](ComputationGraphScheduler::load_reactor)
+    /// resolves it against the T-0829 provider search path and installs it via
+    /// [`Reactor::with_evaluator`], replacing the built-in `criteria`. `None`
+    /// (the default for every existing path) is the native dirty-flag reactor.
+    pub constructor: Option<cloacina_computation_graph::ReactorConstructorRef>,
 }
 
 /// Status of a managed computation graph.
@@ -213,6 +224,53 @@ fn dummy_graph_fn() -> CompiledGraphFn {
     Arc::new(|_cache: InputCache| Box::pin(async move { GraphResult::completed(vec![]) }))
 }
 
+/// Resolve a [`ReactorConstructorRef`](cloacina_computation_graph::ReactorConstructorRef)
+/// into a live firing decider (CLOACI-T-0830).
+///
+/// `None` ref → `None` decider (the native dirty-flag reactor). `Some(ref)` loads
+/// the named WASM reactor constructor through the T-0829 provider seam — resolving
+/// `from` against the provider search path, binding `config` BY NAME, and validating
+/// the resolved `constructor` name — and returns it as an
+/// `Arc<dyn ReactorFireDecider>` ready for [`Reactor::with_evaluator`]. The load is
+/// blocking (builds a `PluginHost`, loads + configures the wasmtime component), so it
+/// runs on `spawn_blocking`.
+///
+/// Behind the default-OFF `constructors-wasm` feature: a ref present in a build that
+/// lacks the feature fails closed with a clear error rather than silently ignoring the
+/// author's firing logic.
+async fn resolve_reactor_evaluator(
+    constructor: &Option<cloacina_computation_graph::ReactorConstructorRef>,
+) -> Result<Option<Arc<dyn ReactorFireDecider>>, String> {
+    let Some(cref) = constructor else {
+        return Ok(None);
+    };
+
+    #[cfg(feature = "constructors-wasm")]
+    {
+        let cref = cref.clone();
+        let decider = tokio::task::spawn_blocking(move || {
+            crate::registry::loader::constructor_loader::load_reactor_constructor_node(
+                &cref.from,
+                &cref.constructor,
+                cref.config,
+            )
+        })
+        .await
+        .map_err(|e| format!("reactor constructor load task join failed: {e}"))?
+        .map_err(|e| format!("reactor constructor load failed: {e}"))?;
+        Ok(Some(decider))
+    }
+
+    #[cfg(not(feature = "constructors-wasm"))]
+    {
+        Err(format!(
+            "reactor declares constructor '{}' from provider '{}', but this build lacks \
+             the 'constructors-wasm' feature required to load WASM reactor constructors",
+            cref.constructor, cref.from
+        ))
+    }
+}
+
 /// Subscribers bound to a single reactor instance.
 ///
 /// Today every reactor has exactly one subscriber (the bundled-form graph
@@ -311,6 +369,12 @@ struct RunningGraph {
     failure_counts: HashMap<String, u32>,
     /// Timestamp of last successful operation per component (for failure count reset).
     last_success: HashMap<String, std::time::Instant>,
+    /// Resolved reactor-constructor firing decider (CLOACI-T-0830). `Some(..)`
+    /// when this reactor was loaded with a [`ReactorConstructorRef`]: the WASM
+    /// `evaluate` was resolved ONCE at load and is shared (it is `Send + Sync`)
+    /// so the supervisor reuses it on restart instead of re-loading the
+    /// component. `None` is the native dirty-flag reactor.
+    evaluator: Option<Arc<dyn ReactorFireDecider>>,
 }
 
 /// Maximum consecutive failures before a component is permanently abandoned.
@@ -429,6 +493,11 @@ impl ComputationGraphScheduler {
         strategy: InputStrategy,
         tenant_id: Option<String>,
         register_aliases: Vec<String>,
+        // CLOACI-T-0830: optional packaged reactor-constructor reference. When
+        // `Some(..)`, the named WASM constructor's `evaluate` becomes the
+        // reactor's firing decider (via `Reactor::with_evaluator`), replacing
+        // the `criteria`. Resolved once here and reused across restarts.
+        constructor: Option<cloacina_computation_graph::ReactorConstructorRef>,
     ) -> Result<(), String> {
         // Idempotent path: matching contract → no-op.
         {
@@ -441,6 +510,7 @@ impl ComputationGraphScheduler {
                         criteria: criteria.clone(),
                         strategy: strategy.clone(),
                         graph_fn: dummy_graph_fn(),
+                        constructor: constructor.clone(),
                     },
                     tenant_id: tenant_id.clone(),
                     reactor_name: Some(reactor_name.clone()),
@@ -455,6 +525,12 @@ impl ComputationGraphScheduler {
                 return Ok(());
             }
         }
+
+        // CLOACI-T-0830: resolve the reactor-constructor reference (if any) into a
+        // live firing decider BEFORE we spawn anything, so a bad constructor ref
+        // fails the load cleanly instead of leaving a half-wired reactor running.
+        // The resolved decider is reused on restart (stored on `RunningGraph`).
+        let evaluator = resolve_reactor_evaluator(&constructor).await?;
 
         let (shutdown_tx, shutdown_rx) = shutdown_signal();
         let stored_shutdown_rx = shutdown_rx.clone();
@@ -544,6 +620,13 @@ impl ComputationGraphScheduler {
         .with_accumulator_health(acc_health_rxs)
         .with_tenant_id(tenant_id.clone());
 
+        // CLOACI-T-0830: a resolved reactor-constructor decider replaces the
+        // built-in WhenAny/WhenAll criteria — the WASM guest's `evaluate` decides
+        // firing. The native path leaves `evaluator` as `None` (unchanged).
+        if let Some(ref ev) = evaluator {
+            reactor = reactor.with_evaluator(ev.clone());
+        }
+
         if let Some(ref dal) = self.dal {
             reactor = reactor.with_dal(dal.clone());
         }
@@ -604,6 +687,11 @@ impl ComputationGraphScheduler {
                 criteria,
                 strategy,
                 graph_fn: dummy_graph_fn(),
+                // Preserve the constructor ref on the anchor for fidelity; the
+                // restart path reuses the already-resolved `evaluator` rather
+                // than re-resolving from this, but keeping it keeps the anchor an
+                // honest record of how the reactor was declared (CLOACI-T-0830).
+                constructor,
             },
             tenant_id,
             reactor_name: Some(reactor_name.clone()),
@@ -623,6 +711,7 @@ impl ComputationGraphScheduler {
             endpoint_registry_keys,
             failure_counts: HashMap::new(),
             last_success: HashMap::new(),
+            evaluator,
         };
 
         self.reactors.write().await.insert(reactor_name, running);
@@ -746,6 +835,7 @@ impl ComputationGraphScheduler {
             decl.reactor.strategy.clone(),
             decl.tenant_id.clone(),
             vec![name.clone()],
+            decl.reactor.constructor.clone(),
         )
         .await?;
 
@@ -798,6 +888,9 @@ impl ComputationGraphScheduler {
                 criteria: reactor.reaction_mode.into(),
                 strategy: InputStrategy::Latest,
                 graph_fn,
+                // Split-form (`#[computation_graph(trigger = reactor(T))]`) does
+                // not author WASM reactor constructors — native firing only.
+                constructor: None,
             },
             tenant_id,
             // Split-form callers carry an explicit reactor identity. Multiple
@@ -1181,6 +1274,13 @@ impl ComputationGraphScheduler {
                 .with_expected_sources(expected_sources)
                 .with_accumulator_health(restart_acc_health_rxs)
                 .with_tenant_id(running.declaration.tenant_id.clone());
+                // CLOACI-T-0830: re-install the reactor-constructor decider on
+                // restart. The decider was resolved once at load and is shared
+                // (`Arc<dyn ReactorFireDecider>`, `Send + Sync`), so the restart
+                // reuses it rather than re-loading the WASM component.
+                if let Some(ref ev) = running.evaluator {
+                    reactor = reactor.with_evaluator(ev.clone());
+                }
                 if let Some(ref dal) = self.dal {
                     reactor = reactor.with_dal(dal.clone());
                 }
@@ -1570,6 +1670,7 @@ mod tests {
                 criteria: ReactionCriteria::WhenAny,
                 strategy: InputStrategy::Latest,
                 graph_fn,
+                constructor: None,
             },
             tenant_id: None,
             reactor_name: None,
@@ -1614,6 +1715,7 @@ mod tests {
                 criteria: ReactionCriteria::WhenAny,
                 strategy: InputStrategy::Latest,
                 graph_fn,
+                constructor: None,
             },
             tenant_id: None,
             reactor_name: None,
@@ -1652,6 +1754,7 @@ mod tests {
                 criteria: ReactionCriteria::WhenAny,
                 strategy: InputStrategy::Latest,
                 graph_fn,
+                constructor: None,
             },
             tenant_id: None,
             reactor_name: None,

--- a/crates/cloacina/src/lib.rs
+++ b/crates/cloacina/src/lib.rs
@@ -556,7 +556,7 @@ pub use database::connection::Database;
 // Re-export key types for convenience
 pub use cloacina_computation_graph::{
     Graph, ReactionMode as ComputationReactionMode, Reactor, ReactorConstructor,
-    ReactorRegistration,
+    ReactorConstructorRef, ReactorRegistration,
 };
 pub use computation_graph::ComputationGraphRegistration;
 pub use computation_graph::{TriggerlessGraph, TriggerlessGraphFn, TriggerlessGraphRegistration};

--- a/crates/cloacina/src/registry/loader/constructor_loader.rs
+++ b/crates/cloacina/src/registry/loader/constructor_loader.rs
@@ -877,12 +877,15 @@ pub fn load_accumulator_constructor<C: Serialize>(
 // `process`), so — like task/trigger — the blocking wasmtime `evaluate` runs on
 // `spawn_blocking`.
 //
-// DEFERRED (reported, not faked): threading a `WasmReactorConstructor` through
-// the CG SCHEDULER's package-load path (`scheduler.rs` builds `Reactor::new`
-// from a `ReactorDeclaration`; nothing in the declaration/packaging types yet
-// carries a reactor-constructor reference). The seam + bridge are proven against
-// `Reactor` directly; the scheduler/declaration/packaging wiring is the
-// remaining lift.
+// CLOACI-T-0830 (done): the reactor constructor is now threaded through the CG
+// SCHEDULER's package-load path. `ReactorDeclaration` carries an optional
+// `ReactorConstructorRef` (from/constructor/config); `scheduler.rs::load_reactor`
+// resolves it via [`load_reactor_constructor_node`] (below) and installs the
+// loaded `WasmReactorConstructor` on the live `Reactor` via `with_evaluator`. The
+// `#[reactor(from = .., constructor = .., config = { .. })]` authoring form
+// populates the ref (carried on `ReactorRegistration`), and the resolved decider
+// is reused across reactor restarts. Threading the ref through the FFI
+// `ReactorPackageMetadata` (Rust cdylib packaging) remains a documented follow-on.
 
 /// Host-side re-declaration of the REACTOR-constructor interface (CLOACI-T-0828).
 /// Same trait shape the guest implements; the fidius macro emits the matching
@@ -1474,4 +1477,97 @@ pub fn load_constructor_node(
         inner: task,
         dependencies,
     }))
+}
+
+// ===========================================================================
+// Reactor-constructor consumer surface — CG scheduler load path (CLOACI-T-0830)
+// ===========================================================================
+//
+// A reactor is NOT a `Runtime` constructor (task/trigger) or a DAG node — it is
+// the CG SCHEDULER's firing engine. So a packaged reactor constructor is consumed
+// differently from the `constructor!(...)` node form: instead of producing an
+// `Arc<dyn Task>` for the workflow DAG, it produces an `Arc<dyn ReactorFireDecider>`
+// that the scheduler installs on the live `Reactor` via `with_evaluator`.
+//
+// This is the runtime half of the `#[reactor(from = .., constructor = .., config =
+// { .. })]` authoring form: the CG scheduler (`load_reactor`) calls this to resolve
+// the declaration's `ReactorConstructorRef`. It reuses the SAME T-0829 provider
+// resolution (`provider_search_path`/`provider_package_name`) and name-keyed config
+// binding (`bind_config_by_name`) as the task/trigger node form, so a reactor
+// constructor is authored and resolved exactly like the others.
+
+/// Resolve + load a packaged WASM **reactor** constructor as a firing decider for
+/// the CG scheduler (the runtime half of the `#[reactor(from = .., constructor =
+/// .., config = { .. })]` authoring form — CLOACI-T-0830).
+///
+/// Resolves `from` against the [`provider_search_path`], reads the resolved
+/// constructor's manifest to learn its `#[config]` schema, binds the author's
+/// `config = { name = value }` kwargs BY NAME ([`bind_config_by_name`], reordered
+/// into the guest's declaration order), loads the named reactor constructor via
+/// [`load_reactor_constructor`] (binding the reordered config once), validates the
+/// resolved constructor's name matches `constructor_name`, and returns it as an
+/// `Arc<dyn ReactorFireDecider>` ready for
+/// [`Reactor::with_evaluator`](crate::computation_graph::reactor::Reactor::with_evaluator).
+///
+/// `config` is the author's `config = { … }` entries as `(name, value)` pairs in
+/// WRITTEN order; the reorder/coerce is identical to [`load_constructor_node`] (the
+/// task/trigger node form) so config binds by NAME, not written order.
+///
+/// Fails closed (a clear [`LoaderError`]) if the provider is missing, the manifest
+/// is unreadable / not a `Reactor`, the interface version mismatches, a config kwarg
+/// is unknown / duplicated / missing / mistyped, or the resolved constructor name
+/// does not match `constructor_name`.
+pub fn load_reactor_constructor_node(
+    from: &str,
+    constructor_name: &str,
+    config: Vec<(String, serde_json::Value)>,
+) -> Result<Arc<dyn ReactorFireDecider>, LoaderError> {
+    let search_path = provider_search_path();
+    let package_name = provider_package_name(from);
+
+    // Peek the manifest to learn the constructor's #[config] schema, so we can bind
+    // `config = { name = value }` by NAME before the positional bincode load.
+    let host = PluginHost::builder()
+        .search_path(&search_path)
+        .build()
+        .map_err(|e| LoaderError::LibraryLoad {
+            path: search_path.display().to_string(),
+            error: format!("build plugin host: {e}"),
+        })?;
+    let dir = host
+        .find_wasm_package(package_name)
+        .map_err(|e| LoaderError::Validation {
+            reason: format!(
+                "resolve reactor constructor (from = '{from}', constructor = '{constructor_name}'): \
+                 locate provider package '{package_name}' in provider search path '{}': {e}",
+                search_path.display()
+            ),
+        })?;
+    let manifest = read_constructor_manifest(&dir)?;
+
+    // Reuse the T-0829 name-keyed config binding (node_id = the constructor name,
+    // since a reactor has no separate DAG node id).
+    let ordered_config =
+        bind_config_by_name(constructor_name, from, constructor_name, &manifest, config)?;
+
+    let reactor_constructor = load_reactor_constructor(&search_path, package_name, &ordered_config)
+        .map_err(|e| LoaderError::Validation {
+            reason: format!(
+                "resolve reactor constructor (from = '{from}', constructor = \
+                     '{constructor_name}') in provider search path '{}': {e}",
+                search_path.display()
+            ),
+        })?;
+
+    if reactor_constructor.name() != constructor_name {
+        return Err(LoaderError::Validation {
+            reason: format!(
+                "reactor constructor: provider '{from}' (package '{package_name}') carries \
+                 constructor '{}', but the reactor declared constructor = '{constructor_name}'",
+                reactor_constructor.name()
+            ),
+        });
+    }
+
+    Ok(Arc::new(reactor_constructor) as Arc<dyn ReactorFireDecider>)
 }

--- a/crates/cloacina/src/registry/loader/mod.rs
+++ b/crates/cloacina/src/registry/loader/mod.rs
@@ -34,9 +34,9 @@ pub use task_registrar::TaskRegistrar;
 
 #[cfg(feature = "constructors-wasm")]
 pub use constructor_loader::{
-    clear_provider_search_path, load_constructor, load_constructor_node, load_task_constructor,
-    load_task_constructor_from_package, load_trigger_constructor, provider_search_path,
-    set_provider_search_path, unpack_provider_archive, ConstructorBinding, ConstructorNode,
-    TriggerBinding, WasmTaskConstructor, WasmTriggerConstructor, DEFAULT_PROVIDER_DIR,
-    PROVIDER_PATH_ENV,
+    clear_provider_search_path, load_constructor, load_constructor_node,
+    load_reactor_constructor_node, load_task_constructor, load_task_constructor_from_package,
+    load_trigger_constructor, provider_search_path, set_provider_search_path,
+    unpack_provider_archive, ConstructorBinding, ConstructorNode, TriggerBinding,
+    WasmTaskConstructor, WasmTriggerConstructor, DEFAULT_PROVIDER_DIR, PROVIDER_PATH_ENV,
 };

--- a/crates/cloacina/src/registry/reconciler/loading.rs
+++ b/crates/cloacina/src/registry/reconciler/loading.rs
@@ -2152,6 +2152,7 @@ mod tests {
                 name: "py_reactor".to_string(),
                 accumulator_names: vec!["src_a".to_string(), "src_b".to_string()],
                 reaction_mode: cloacina_computation_graph::ReactionMode::WhenAny,
+                constructor: None,
             }
         });
 
@@ -2180,6 +2181,7 @@ mod tests {
                 name: "preexisting".to_string(),
                 accumulator_names: vec!["x".to_string()],
                 reaction_mode: cloacina_computation_graph::ReactionMode::WhenAny,
+                constructor: None,
             }
         });
 
@@ -2203,6 +2205,7 @@ mod tests {
                 name: "py_reactor".to_string(),
                 accumulator_names: vec!["topic_a".to_string()],
                 reaction_mode: cloacina_computation_graph::ReactionMode::WhenAll,
+                constructor: None,
             }
         });
 
@@ -2477,6 +2480,7 @@ mod tests {
                 InputStrategy::Latest,
                 Some("public".to_string()),
                 vec![],
+                None,
             )
             .await
             .expect("publishing reactor should load");
@@ -2803,6 +2807,7 @@ mod tests {
                 name: "ephemeral_rx".to_string(),
                 accumulator_names: vec!["alpha".to_string()],
                 reaction_mode: cloacina_computation_graph::ReactionMode::WhenAny,
+                constructor: None,
             }
         });
         assert!(

--- a/crates/cloacina/tests/constructor_reactor_scheduler_wasm.rs
+++ b/crates/cloacina/tests/constructor_reactor_scheduler_wasm.rs
@@ -1,0 +1,310 @@
+/*
+ *  Copyright 2026 Colliery Software
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+//! CLOACI-T-0830 — end-to-end: a reactor authored as a WASM **constructor** fires
+//! via the CG SCHEDULER's package-load path, not just via a direct
+//! `Reactor::with_evaluator(...)` harness (that direct seam is proven in
+//! `constructor_reactor_wasm.rs`).
+//!
+//! Proves the gap T-0830 closed:
+//!   1. a `ComputationGraphDeclaration` carries a `ReactorConstructorRef`
+//!      (`from`/`constructor`/`config`) on its `ReactorDeclaration`;
+//!   2. `ComputationGraphScheduler::load_graph` resolves that ref against the
+//!      T-0829 provider search path, binds `config` BY NAME, and installs the WASM
+//!      guest's `evaluate` as the reactor's firing decider (`with_evaluator`);
+//!   3. boundaries pushed through the normal accumulator → reactor path fire the
+//!      graph ONLY when the WASM guest says so (the gate config decides), with the
+//!      built-in WhenAny/WhenAll criteria fully replaced.
+//!
+//! Reuses the `reactor-constructor-fixture` (a `#[constructor(kind = reactor)]`
+//! gate: fire when boundary `x.value >= gate`).
+//!
+//! Feature-gated (`constructors-wasm`, which pulls wasmtime). Excluded from the
+//! default build.
+#![cfg(feature = "constructors-wasm")]
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::{Arc, OnceLock};
+use std::time::Duration;
+
+use tokio::sync::{mpsc, watch};
+use tokio::task::JoinHandle;
+
+use cloacina::cloacina_computation_graph::ReactorConstructorRef;
+use cloacina::computation_graph::reactor::{CompiledGraphFn, InputStrategy, ReactionCriteria};
+use cloacina::computation_graph::registry::EndpointRegistry;
+use cloacina::computation_graph::scheduler::{
+    AccumulatorDeclaration, AccumulatorFactory, AccumulatorSpawnConfig,
+    ComputationGraphDeclaration, ComputationGraphScheduler, ReactorDeclaration,
+};
+use cloacina::computation_graph::types::{GraphResult, InputCache, SourceName};
+use cloacina::computation_graph::Accumulator;
+use cloacina::registry::loader::constructor_loader::{
+    clear_provider_search_path, set_provider_search_path,
+};
+
+// ---------------------------------------------------------------------------
+// Fixture build + staging (mirrors constructor_reactor_wasm.rs)
+// ---------------------------------------------------------------------------
+
+const PROVIDER_PACKAGE: &str = "reactor-constructor-pkg";
+
+fn fixture_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../examples/constructor-contract/reactor-constructor-fixture")
+}
+
+fn component() -> &'static [u8] {
+    static BYTES: OnceLock<Vec<u8>> = OnceLock::new();
+    BYTES.get_or_init(|| {
+        let fixture = fixture_dir();
+        let status = Command::new("cargo")
+            .args(["build", "--lib", "--target", "wasm32-wasip2", "--release"])
+            .current_dir(&fixture)
+            .status()
+            .expect("spawn cargo build --target wasm32-wasip2");
+        assert!(
+            status.success(),
+            "reactor-constructor-fixture wasm build failed"
+        );
+        std::fs::read(fixture.join("target/wasm32-wasip2/release/reactor_constructor_fixture.wasm"))
+            .expect("read built wasm component")
+    })
+}
+
+fn macro_manifest_json() -> &'static str {
+    static JSON: OnceLock<String> = OnceLock::new();
+    JSON.get_or_init(|| {
+        let out = Command::new("cargo")
+            .args(["run", "--quiet", "--bin", "emit_manifest"])
+            .current_dir(fixture_dir())
+            .output()
+            .expect("spawn cargo run --bin emit_manifest");
+        assert!(
+            out.status.success(),
+            "emit_manifest failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        String::from_utf8(out.stdout).expect("emit_manifest stdout is UTF-8")
+    })
+}
+
+/// Stage the built component + sidecar manifest as a provider package under
+/// `root/reactor-constructor-pkg/`, the layout the provider search path expects.
+fn stage(root: &Path) {
+    let dir = root.join(PROVIDER_PACKAGE);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("reactor_constructor_fixture.wasm"), component()).unwrap();
+    std::fs::write(
+        dir.join("package.toml"),
+        "[package]\nname = \"reactor-constructor-pkg\"\nversion = \"0.1.0\"\n\
+         interface = \"reactor-constructor\"\ninterface_version = 1\nruntime = \"wasm\"\n\n\
+         [metadata]\ncategory = \"constructor\"\n\n\
+         [wasm]\ncomponent = \"reactor_constructor_fixture.wasm\"\n",
+    )
+    .unwrap();
+    std::fs::write(dir.join("constructor.json"), macro_manifest_json()).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// A minimal passthrough accumulator factory: raw event bytes → boundary frame.
+// The reactor's `should_fire` decodes `bincode(json_bytes)` boundary frames, so
+// emitting the raw JSON bytes is exactly what the WASM `evaluate` expects.
+// ---------------------------------------------------------------------------
+
+struct PassthroughFactory;
+
+impl AccumulatorFactory for PassthroughFactory {
+    fn spawn(
+        &self,
+        name: String,
+        boundary_tx: mpsc::Sender<(SourceName, Vec<u8>)>,
+        shutdown_rx: watch::Receiver<bool>,
+        config: AccumulatorSpawnConfig,
+    ) -> (mpsc::Sender<Vec<u8>>, JoinHandle<()>) {
+        use cloacina::computation_graph::accumulator::{
+            accumulator_runtime, AccumulatorContext, AccumulatorRuntimeConfig, BoundarySender,
+        };
+
+        let (socket_tx, socket_rx) = mpsc::channel(64);
+
+        struct Passthrough;
+        #[async_trait::async_trait]
+        impl Accumulator for Passthrough {
+            type Output = Vec<u8>;
+            fn process(&mut self, event: Vec<u8>) -> Option<Vec<u8>> {
+                Some(event)
+            }
+        }
+
+        let sender = BoundarySender::new(boundary_tx, SourceName::new(&name));
+        let ctx = AccumulatorContext {
+            output: sender,
+            name: name.clone(),
+            shutdown: shutdown_rx,
+            checkpoint: None,
+            health: config.health_tx,
+        };
+
+        let handle = tokio::spawn(accumulator_runtime(
+            Passthrough,
+            ctx,
+            socket_rx,
+            AccumulatorRuntimeConfig::default(),
+        ));
+        (socket_tx, handle)
+    }
+}
+
+/// Drive a graph whose reactor is a WASM `#[constructor(kind = reactor)]` gate,
+/// loaded + fired entirely through the scheduler. `gate` is bound BY NAME via the
+/// declaration's `config`; the graph fires only when the guest's `evaluate` says so.
+#[tokio::test]
+async fn reactor_constructor_fires_via_scheduler() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    stage(tmp.path());
+    set_provider_search_path(tmp.path());
+
+    let registry = EndpointRegistry::new();
+    let scheduler = ComputationGraphScheduler::new(registry.clone());
+
+    let fire_count = Arc::new(AtomicU32::new(0));
+    let fire_count_inner = fire_count.clone();
+    let graph_fn: CompiledGraphFn = Arc::new(move |_cache: InputCache| {
+        let fc = fire_count_inner.clone();
+        Box::pin(async move {
+            fc.fetch_add(1, Ordering::SeqCst);
+            GraphResult::completed(vec![])
+        })
+    });
+
+    let decl = ComputationGraphDeclaration {
+        name: "t0830_reactor_constructor_graph".to_string(),
+        accumulators: vec![AccumulatorDeclaration {
+            name: "x".to_string(),
+            factory: Arc::new(PassthroughFactory),
+        }],
+        reactor: ReactorDeclaration {
+            // criteria is vestigial here — the WASM evaluate replaces it.
+            criteria: ReactionCriteria::WhenAny,
+            strategy: InputStrategy::Latest,
+            graph_fn,
+            // The T-0830 reactor-constructor reference: gate = 5.0, bound BY NAME.
+            constructor: Some(ReactorConstructorRef {
+                from: PROVIDER_PACKAGE.to_string(),
+                constructor: "gate".to_string(),
+                config: vec![("gate".to_string(), serde_json::json!(5.0))],
+            }),
+        },
+        tenant_id: None,
+        reactor_name: None,
+        topology: None,
+    };
+
+    scheduler
+        .load_graph(decl)
+        .await
+        .expect("load_graph with reactor constructor should resolve + install the WASM evaluator");
+
+    // Below the gate (1.0) → the WASM guest holds → no fire.
+    registry
+        .send_to_accumulator(
+            "x",
+            serde_json::to_vec(&serde_json::json!({ "value": 1.0 })).unwrap(),
+        )
+        .await
+        .unwrap();
+    tokio::time::sleep(Duration::from_millis(250)).await;
+    assert_eq!(
+        fire_count.load(Ordering::SeqCst),
+        0,
+        "below-gate boundary must NOT fire the graph (WASM evaluate gates it)"
+    );
+
+    // Above the gate (9.0) → the WASM guest fires → graph runs via the scheduler.
+    registry
+        .send_to_accumulator(
+            "x",
+            serde_json::to_vec(&serde_json::json!({ "value": 9.0 })).unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let mut fired = false;
+    for _ in 0..50 {
+        if fire_count.load(Ordering::SeqCst) >= 1 {
+            fired = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    assert!(
+        fired,
+        "above-gate boundary should fire the graph via the scheduler-installed WASM evaluator"
+    );
+
+    clear_provider_search_path();
+}
+
+/// A reactor constructor whose declared name doesn't match the provider's
+/// `constructor.json` name fails the load closed — the author asked for a
+/// constructor the provider does not carry.
+#[tokio::test]
+async fn reactor_constructor_name_mismatch_fails_closed() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    stage(tmp.path());
+    set_provider_search_path(tmp.path());
+
+    let registry = EndpointRegistry::new();
+    let scheduler = ComputationGraphScheduler::new(registry.clone());
+
+    let graph_fn: CompiledGraphFn =
+        Arc::new(|_c: InputCache| Box::pin(async move { GraphResult::completed(vec![]) }));
+
+    let decl = ComputationGraphDeclaration {
+        name: "t0830_mismatch_graph".to_string(),
+        accumulators: vec![AccumulatorDeclaration {
+            name: "x".to_string(),
+            factory: Arc::new(PassthroughFactory),
+        }],
+        reactor: ReactorDeclaration {
+            criteria: ReactionCriteria::WhenAny,
+            strategy: InputStrategy::Latest,
+            graph_fn,
+            constructor: Some(ReactorConstructorRef {
+                from: PROVIDER_PACKAGE.to_string(),
+                constructor: "not_the_gate".to_string(),
+                config: vec![("gate".to_string(), serde_json::json!(5.0))],
+            }),
+        },
+        tenant_id: None,
+        reactor_name: None,
+        topology: None,
+    };
+
+    let err = scheduler
+        .load_graph(decl)
+        .await
+        .expect_err("a constructor-name mismatch must fail the load closed");
+    assert!(
+        err.contains("not_the_gate") || err.contains("gate"),
+        "error should name the requested/resolved constructor, got: {err}"
+    );
+
+    clear_provider_search_path();
+}

--- a/crates/cloacina/tests/integration/computation_graph.rs
+++ b/crates/cloacina/tests/integration/computation_graph.rs
@@ -418,6 +418,7 @@ async fn test_computation_graph_scheduler_end_to_end() {
             criteria: ReactionCriteria::WhenAny,
             strategy: InputStrategy::Latest,
             graph_fn,
+            constructor: None,
         },
         tenant_id: None,
         reactor_name: None,
@@ -1883,6 +1884,7 @@ mod resilience_tests {
                 criteria: ReactionCriteria::WhenAny,
                 strategy: InputStrategy::Latest,
                 graph_fn,
+                constructor: None,
             },
             tenant_id: None,
             reactor_name: None,
@@ -2179,6 +2181,7 @@ async fn test_cloaci_t_0538_split_form_scheduler_end_to_end() {
         name: "cloaci_t_0538_reactor_split".to_string(),
         accumulator_names: vec!["alpha".to_string()],
         reaction_mode: ComputationReactionMode::WhenAny,
+        constructor: None,
     };
 
     scheduler
@@ -2272,6 +2275,7 @@ async fn test_cloaci_t_0538_split_missing_accumulator_fails() {
         name: "cloaci_t_0538_broken_reactor".to_string(),
         accumulator_names: vec!["alpha".to_string()],
         reaction_mode: ComputationReactionMode::WhenAny,
+        constructor: None,
     };
 
     let result = scheduler
@@ -2334,6 +2338,7 @@ async fn test_cloaci_t_0544_two_graphs_share_one_reactor_via_split_form() {
         name: "cloaci_t_0544_shared_reactor".to_string(),
         accumulator_names: vec!["alpha".to_string()],
         reaction_mode: ComputationReactionMode::WhenAny,
+        constructor: None,
     };
 
     let accs = || {
@@ -2433,6 +2438,7 @@ async fn test_cloaci_t_0544_contract_mismatch_rejected() {
         name: "cloaci_t_0544_clash".to_string(),
         accumulator_names: vec!["alpha".to_string()],
         reaction_mode: ComputationReactionMode::WhenAny,
+        constructor: None,
     };
     scheduler
         .load_graph_split(
@@ -2453,6 +2459,7 @@ async fn test_cloaci_t_0544_contract_mismatch_rejected() {
         name: "cloaci_t_0544_clash".to_string(),
         accumulator_names: vec!["alpha".to_string()],
         reaction_mode: ComputationReactionMode::WhenAll,
+        constructor: None,
     };
     let err = scheduler
         .load_graph_split(
@@ -2543,6 +2550,7 @@ async fn test_cloaci_t_0544_dispatch_is_concurrent() {
         name: "cloaci_t_0544_concurrent_reactor".to_string(),
         accumulator_names: vec!["alpha".to_string()],
         reaction_mode: ComputationReactionMode::WhenAny,
+        constructor: None,
     };
     let accs = || {
         vec![AccumulatorDeclaration {
@@ -2621,6 +2629,7 @@ async fn test_cloaci_t_0545_load_reactor_then_bind_graph() {
             cloacina::computation_graph::reactor::InputStrategy::Latest,
             None,
             vec![],
+            None,
         )
         .await
         .expect("load_reactor should spawn the reactor with empty subscribers");
@@ -2650,6 +2659,7 @@ async fn test_cloaci_t_0545_load_reactor_then_bind_graph() {
             cloacina::computation_graph::reactor::InputStrategy::Latest,
             None,
             vec![],
+            None,
         )
         .await
         .expect("idempotent load_reactor should succeed when contract matches");
@@ -2666,6 +2676,7 @@ async fn test_cloaci_t_0545_load_reactor_then_bind_graph() {
             cloacina::computation_graph::reactor::InputStrategy::Latest,
             None,
             vec![],
+            None,
         )
         .await
         .expect_err("contract mismatch should reject");
@@ -2764,6 +2775,7 @@ async fn test_cloaci_t_0544_unbind_keeps_reactor_running() {
         name: "cloaci_t_0544_unbind_reactor".to_string(),
         accumulator_names: vec!["alpha".to_string()],
         reaction_mode: ComputationReactionMode::WhenAny,
+        constructor: None,
     };
     let accs = || {
         vec![AccumulatorDeclaration {
@@ -2837,6 +2849,7 @@ async fn test_cloaci_t_0544_unload_reactor_rejects_with_subscribers() {
         name: "cloaci_t_0544_busy_reactor".to_string(),
         accumulator_names: vec!["alpha".to_string()],
         reaction_mode: ComputationReactionMode::WhenAny,
+        constructor: None,
     };
     let accs = || {
         vec![AccumulatorDeclaration {
@@ -2902,6 +2915,7 @@ async fn test_cloaci_t_0538_runtime_reactor_registry_shape() {
             name: "cloaci_t_0538_reactor_split".to_string(),
             accumulator_names: vec!["alpha".to_string()],
             reaction_mode: cloacina::ComputationReactionMode::WhenAny,
+            constructor: None,
         }
     });
 


### PR DESCRIPTION
A reactor authored as `#[constructor(kind=reactor)]` now fires via the CG scheduler's package-load path (completing the T-0828 `with_evaluator` seam). `ReactorDeclaration` carries an optional `ReactorConstructorRef{from,constructor,config}`; `#[reactor]` accepts `from`/`constructor`/`config={k=v}` (name-keyed, via T-0829); `scheduler.rs::load_reactor` resolves the ref → `with_evaluator`, re-applied across supervisor restarts.

Proven by a gated e2e (fires only above the WASM-evaluated gate; name-mismatch fails closed). Default lib + all-targets + constructors-wasm all-targets all clean; wasmtime absent by default; 44 CG + 45 integration + 20 macro + 2 e2e + 4 regression pass.

Deferred → T-0832 (packaged path): the FFI cdylib packaging + Python + split-form carrying the ref; the embedded/runtime path is complete.

https://claude.ai/code/session_01VWpWbgCzNdQkFT74S3wPRM