### PR TITLE
docs(constructors): capability/egress model — ADR A-0009 + spec S-0014

### DIFF
--- a/.metis/adrs/CLOACI-A-0009.md
+++ b/.metis/adrs/CLOACI-A-0009.md
@@ -1,0 +1,80 @@
+---
+id: 001-constructor-capabilities-tenant
+level: adr
+title: "Constructor capabilities: tenant-granted at construction time, default-closed"
+number: 1
+short_code: "CLOACI-A-0009"
+created_at: 2026-06-29T16:10:54.220882+00:00
+updated_at: 2026-06-29T16:18:58.499237+00:00
+decision_date: 2026-06-29
+decision_maker: dylan.storey
+parent: 
+archived: false
+
+tags:
+  - "#adr"
+  - "#phase/decided"
+
+
+exit_criteria_met: false
+initiative_id: NULL
+---
+
+# ADR-1: Constructor capabilities: tenant-granted at construction time, default-closed
+
+## Context **[REQUIRED]**
+
+Constructors ([[CLOACI-I-0132]]) run as sandboxed WASM components (WASI, deny-by-default). The genuinely useful ones — HTTP fetch, database queries (TCP), file I/O, reading env/secrets — all require **host capabilities** the sandbox denies by default. Constructors are also potentially **third-party** (provider packages). We need a model for **who decides** what a given constructor *instance* may access, and **how that's enforced**, without trusting the constructor code itself.
+
+fidius already enforces a **two-key gate** for egress: a capability is reachable only if (1) the wasm component *imports* it (`wasi:http`, `wasi:sockets`) **and** (2) the host supplies a policy that authorizes it (`EgressPolicy::authorize` for HTTP, `EgressPolicy::authorize_tcp` for TCP by host:port; both default-deny). Filesystem and env are the host-built WASI `WasiCtx` (preopened dirs, explicit env vars). The open question is the **policy layer above fidius**: who authors the authorization, at what point, and with what default.
+
+## Decision **[REQUIRED]**
+
+**Capabilities are granted by the tenant at construction/definition time, default-closed.**
+
+- The grant is written into the **workflow definition**, alongside the constructor instantiation — a `grants = { http=[…], tcp=[…], fs=[…], env=[…] }` on `constructor!` / `#[constructor]` / `#[reactor]`. The **tenant** authors it; it is reviewed as part of the tenant's existing workflow **review/promotion** process.
+- A constructor **cannot grant itself access.** The most it can do is *import* a capability type, which is **structurally visible in its wasm** and therefore auditable. The tenant authorizes the **specifics** (which host:port, path, env key).
+- **Default-closed / fail-closed**: absent a grant, the capability is denied (fidius already default-denies TCP/UDP; cloacina supplies a deny-all policy until a grant says otherwise).
+- Cloacina **translates** an approved grant into a fidius `EgressPolicy` (`authorize`/`authorize_tcp`) plus a scoped `WasiCtx` (preopens/env) at load — riding fidius's two-key enforcement rather than inventing a parallel one.
+- **Globs are permitted** in the grant grammar (`http=["*"]`) for unconstrained "use at your own risk" cases; cloacina's own **core constructors follow strict least-access by convention** (their docs/examples grant the minimum).
+- A tenant-wide **"blanket policy"** is explicitly deferred to the future secrets/variables work.
+
+## Alternatives Analysis **[CONDITIONAL: Complex Decision]**
+
+| Option | Pros | Cons | Risk Level | Implementation Cost |
+|--------|------|------|------------|-------------------|
+| **Tenant-granted at construction time (CHOSEN)** | Untrusted code can't self-grant; explicit, reviewable, least-privilege per instance; maps directly onto fidius's two-key gate; default-closed | Tenant must know what to grant (mitigated by structural import visibility + docs); grants restated per workflow until a blanket policy exists | Low | Low–Medium |
+| Constructor self-declares needs + host allow-list intersect | Self-documenting | Bases enforcement partly on an *untrusted* self-declaration; redundant (imports already reveal capability types); a malicious manifest could over-ask to social-engineer a grant | Medium | Medium |
+| Global/deployment-wide policy only | Central, one place | Too coarse; no per-instance least-privilege; premature without the secrets/variables surface | Medium | Medium |
+| Trust constructors / no capability gate | Simplest | Defeats the sandbox — arbitrary third-party code gets ambient host access | High | Low |
+
+## Rationale **[REQUIRED]**
+
+- The constructor is **untrusted** (third-party providers). It must never be the *basis* of its own authorization. The **tenant** — who owns the deployment and the promotion process — is the right authority.
+- fidius **already** enforces a two-key gate; tenant construction-time grants simply *are* the host-policy key, so this reuses existing enforcement instead of building a second one.
+- Capability **types** are already structurally evident from the wasm imports (auditable), so a self-declared manifest field would be redundant for *enforcement* — it survives at most as advisory docs.
+- **Default-closed + tenant review** delivers least-privilege with a human checkpoint, without per-object authZ machinery — consistent with "tenant is the isolation boundary" ([[CLOACI-I-0118]] / the tenant-isolation principle).
+
+## Consequences **[REQUIRED]**
+
+### Positive
+- Untrusted constructors **cannot widen their own access**; grants are explicit, least-privilege, and reviewed at promotion.
+- Reuses fidius's two-key enforcement — no parallel security mechanism.
+- Capability use is **auditable from the wasm** (imports) and from the workflow source (grants).
+
+### Negative
+- The tenant must **author grants** (an ergonomics/learning cost — mitigated by deriving hints from the component's imports and by core-constructor docs).
+- **No central policy yet** — every workflow restates its grants until the future blanket policy lands.
+
+### Neutral
+- **Globs are allowed** (the yolo path): the safety story for broad grants lives in *convention + review*, not the type system.
+- A tenant-wide **blanket policy** + secrets-backed env values are deferred to the secrets/variables work.
+
+## Review Schedule **[CONDITIONAL: Temporary Decision]**
+
+### Review Triggers
+- The secrets/variables work lands (introduces the tenant-wide blanket policy + secret-backed env).
+- Per-object authZ is ever reconsidered (currently a permanent non-goal).
+
+### Scheduled Review
+- **Review Criteria**: whether construction-time grants + review remain sufficient as constructor usage and provider count grow.

--- a/.metis/backlog/features/CLOACI-T-0834.md
+++ b/.metis/backlog/features/CLOACI-T-0834.md
@@ -1,12 +1,12 @@
 ---
-id: seed-built-in-operators-one-per
+id: constructor-capability-layer
 level: task
-title: "Seed built-in constructors (one per primitive: task/trigger/accumulator/reactor)"
-short_code: "CLOACI-T-0825"
-created_at: 2026-06-28T23:57:44.661370+00:00
-updated_at: 2026-06-28T23:57:44.661370+00:00
+title: "Constructor capability layer: grants to fidius EgressPolicy + WasiCtx, default-closed + load-time lint"
+short_code: "CLOACI-T-0834"
+created_at: 2026-06-29T16:17:54.400032+00:00
+updated_at: 2026-06-29T16:17:54.400032+00:00
 parent: CLOACI-I-0132
-blocked_by: ["CLOACI-T-0834"]
+blocked_by: ["CLOACI-S-0014"]
 archived: false
 
 tags:
@@ -19,7 +19,7 @@ exit_criteria_met: false
 initiative_id: NULL
 ---
 
-# Seed built-in constructors (one per primitive: task/trigger/accumulator/reactor)
+# Constructor capability layer: grants to fidius EgressPolicy + WasiCtx, default-closed + load-time lint
 
 *This template includes sections for various types of tasks. Delete sections that don't apply to your specific use case.*
 
@@ -29,9 +29,15 @@ initiative_id: NULL
 
 ## Objective **[REQUIRED]**
 
-Ship a **seed built-in library**: >=1 constructor per primitive — e.g. an http-poll **trigger**, a windowed **accumulator**, a **reactor** with firing criteria, and a shell/http **task** — authored via the macros, compiled to WASM components.
+Implement the constructor capability & egress layer specified in [[CLOACI-S-0014]] (decision [[CLOACI-A-0009]]): tenant-authored, default-closed capability grants at construction time, enforced via fidius.
 
-**AC:** each ships as a loadable constructor, instantiable with config, runnable end-to-end in a sample workflow; covered by tests. Blocked by CLOACI-T-0824.
+**Scope:**
+- **Grant grammar + syntax** — a `grants = { http=[host:port|url], tcp=[host:port], fs=[paths], env=[keys] }` form, **identical** across `constructor!`, `#[constructor]`, `#[reactor]` (and structured so the Python/cloaca path mirrors it). Globs allowed.
+- **Carry grants** from the consumer site through the declaration/manifest to the loader.
+- **Translate + enforce** — cloacina builds a fidius `EgressPolicy` (`authorize` from http, `authorize_tcp` from tcp) + a scoped WASI `WasiCtx` (preopens from fs, env from env) and supplies it at `load_wasm_configured`. Default-closed: no grant -> deny.
+- **Load-time capability lint (v1)** — inspect the component's imports (`wasi:http` / `wasi:sockets` / fs / env) vs the grants; warn (or fail) on an imported capability with no matching grant. Decided as v1 so we don't retrofit enforcement into the loader later.
+
+**AC:** a constructor granted `http`/`tcp`/`fs`/`env` reaches exactly the scoped targets and nothing else (fail-closed); a constructor importing a capability with no grant is denied at runtime + flagged at load; the `grants` syntax is identical on all Rust surfaces. Gates [[CLOACI-T-0825]] (seed library). First step: confirm fidius-host's `WasiCtx` fs/env surface.
 
 ## Backlog Item Details **[CONDITIONAL: Backlog Item]**
 

--- a/.metis/specifications/CLOACI-S-0014/specification.md
+++ b/.metis/specifications/CLOACI-S-0014/specification.md
@@ -1,0 +1,95 @@
+---
+id: constructor-capability-and-egress
+level: specification
+title: "Constructor capability and egress model"
+short_code: "CLOACI-S-0014"
+created_at: 2026-06-29T16:11:01.810350+00:00
+updated_at: 2026-06-29T16:11:01.810350+00:00
+parent: CLOACI-I-0132
+blocked_by: []
+archived: false
+
+tags:
+  - "#specification"
+  - "#phase/discovery"
+
+
+exit_criteria_met: false
+initiative_id: NULL
+---
+
+# Constructor capability and egress model
+
+## Overview **[REQUIRED]**
+
+How a **tenant** grants a constructor *instance* scoped access to host capabilities (HTTP, TCP, filesystem, env) **at construction time**, how cloacina translates those grants to fidius/WASI enforcement, and the default-closed / fail-closed guarantees. Implements the decision in [[CLOACI-A-0009]]. This is the layer that turns constructors from pure-compute-only into the genuinely useful set (http fetch, db query, file/env) without trusting constructor code.
+
+## System Context **[CONDITIONAL: System-Level Spec]**
+
+### Actors
+- **Constructor author**: writes the constructor logic; *may import* capability types (`wasi:http`, `wasi:sockets`) — structurally visible in the wasm. **Does not grant access.**
+- **Tenant workflow author**: writes `grants = {…}` at the constructor instantiation; reviewed via the tenant's promotion process.
+- **Cloacina loader**: reads grants, validates, translates to a fidius `EgressPolicy` + scoped `WasiCtx`, loads the constructor.
+- **fidius / WASI runtime**: enforces (two-key: component imports + host policy).
+
+### External Systems
+- **fidius-host**: `EgressPolicy::authorize` (HTTP, per-request), `EgressPolicy::authorize_tcp` (TCP, per-connect by host:port; default-deny), the `WasiCtx` builder (preopens, env). Supplied via `PluginHost::builder().egress(..)` / `from_component_bytes_with_egress`.
+- **The constructor wasm component**: its imports declare which capability *types* it can use.
+
+### Boundaries
+In scope: the grant grammar, the cloacina→fidius translation, enforcement, the v1 capability vocabulary. Out of scope: secrets storage/injection (future), a tenant-wide blanket policy (future), per-object authZ (permanent non-goal).
+
+## Requirements **[REQUIRED]**
+
+### Functional Requirements
+
+| ID | Requirement | Rationale |
+|----|-------------|-----------|
+| REQ-1.1.1 | A constructor instance receives a capability **only** via the tenant's `grants` at construction time; absent a grant it is denied (default-closed). | Untrusted code can't self-grant ([[CLOACI-A-0009]]). |
+| REQ-1.1.2 | Grant grammar: `http`, `tcp`, `fs`, `env`, each a list of scoped patterns (`host:port` / URL, `host:port`, path, key). **Globs allowed** (`http=["*"]`). | Cover the near-term need; globs = use-at-your-own-risk. |
+| REQ-1.2.1 | Translate `http` → `EgressPolicy::authorize` (match request host/path vs allowed patterns); `tcp` → `authorize_tcp` (match host:port); `fs` → `WasiCtx` preopened dirs; `env` → `WasiCtx` env vars. | Ride fidius's two-key enforcement. |
+| REQ-1.2.2 | Enforcement is fidius **two-key**: a capability is reachable only if the component imports it AND the grant authorizes it; either missing → deny. | Belt-and-suspenders default-closed. |
+| REQ-1.3.1 | Cloacina can inspect a component's imports and SHOULD emit a **load-time lint** when a constructor imports a capability with no matching grant (advisory; runtime still fails closed). | Usability — surface "this needs http you didn't grant" early. |
+| REQ-1.3.2 | Core/built-in constructors are authored + documented with **strict least-access** example grants. | Convention sets the norm; broad grants are the exception. |
+
+### Non-Functional Requirements
+
+| ID | Requirement | Rationale |
+|----|-------------|-----------|
+| NFR-1.1.1 | Untrusted constructor code **cannot widen its own access** — enforcement is host-side. | Core security property. |
+| NFR-1.1.2 | **Fail-closed**: any ungranted capability access denies at runtime. | No silent ambient access. |
+| NFR-1.1.3 | Grants are **auditable** in the workflow source (reviewed at promotion) and capability *types* auditable from the wasm imports. | Review is the trust anchor. |
+
+## Architecture Framing **[CONDITIONAL: System-Level Spec]**
+
+### Decision Area: Gating authority + default
+- **Context**: who authorizes a constructor's host access, and what's the default.
+- **Constraints**: fidius two-key (imports + host policy); TCP/UDP default-deny; HTTP per-request; WASI `WasiCtx` for fs/env.
+- **Required Capabilities**: per-instance, tenant-authored, default-closed grants translated to fidius.
+- **ADR**: [[CLOACI-A-0009]].
+
+## Decision Log **[CONDITIONAL: Has ADRs]**
+
+| ADR | Title | Status | Summary |
+|-----|-------|--------|---------|
+| CLOACI-A-0009 | Constructor capabilities: tenant-granted at construction time, default-closed | draft | Tenant grants at construction; constructor can't self-grant; default-closed; translated to fidius EgressPolicy + WasiCtx. |
+
+## Constraints **[CONDITIONAL: Has Constraints]**
+
+### Technical Constraints
+- fidius two-key model: component must import the capability AND the host policy must authorize.
+- `EgressPolicy::authorize` (HTTP) + `authorize_tcp` (TCP host:port); TCP/UDP default-deny.
+- Filesystem + env via the host-built WASI `WasiCtx` (preopens + explicit env).
+- **Open**: confirm fidius-host exposes the `WasiCtx` fs/env configuration surface (http/tcp confirmed).
+
+## Open Items
+
+**Resolved (2026-06-29, design review):**
+- **Load-time capability lint → IN v1.** Inspect the component's imports vs the grants at load and warn on any imported capability with no matching grant. Chosen deliberately for v1: deferring it risks coding the loader into a corner that's hard to retrofit enforcement into later.
+- **`grants` syntax → consistent everywhere.** Identical look/feel across `constructor!`, `#[constructor]`, `#[reactor]`, and the Python/cloaca path — non-negotiable.
+- **Sequencing → capability layer before ALL seeds.** The seed library ([[CLOACI-T-0825]]) is gated on this layer (not just the networked seeds).
+
+**Remaining:**
+- Verify fidius-host exposes the `WasiCtx` fs/env knobs (preopens, env) — expected available (~95%); confirm in code (http/tcp confirmed present).
+- `udp` — deferred unless a concrete need appears.
+- Secrets-backed `env` values + the tenant-wide **blanket policy** — deferred to the secrets/variables work (this spec assumes literal/env-sourced values for now).


### PR DESCRIPTION
Captures the converged design for constructor host-capability gating.

**ADR CLOACI-A-0009 (decided):** capabilities are tenant-granted at construction time, default-closed. A constructor can't self-grant — it only *imports* a capability type (structurally visible/auditable); the tenant authorizes the specifics. Rides fidius's two-key gate; trust anchor = tenant review/promotion. Alternatives (self-declare / global-only / no-gate) and consequences documented.

**Spec CLOACI-S-0014 (under I-0132):** the `grants = { http, tcp, fs, env }` grammar (consistent across all surfaces, globs allowed), the cloacina→fidius translation (`EgressPolicy` + scoped `WasiCtx`), two-key enforcement, and a v1 load-time capability lint.

**CLOACI-T-0834:** the implementation task — gates CLOACI-T-0825 (seed library).

https://claude.ai/code/session_01VWpWbgCzNdQkFT74S3wPRM