### PR TITLE
feat(I-0132): initiative completion — seed library, version pins, recompile signal, packaged-Python + fleet constructor execution

### DIFF
--- a/.metis/backlog/features/CLOACI-T-0825.md
+++ b/.metis/backlog/features/CLOACI-T-0825.md
@@ -1,18 +1,18 @@
 ---
-id: seed-built-in-operators-one-per
+id: seed-built-in-constructors-one-per
 level: task
 title: "Seed built-in constructors (one per primitive: task/trigger/accumulator/reactor)"
 short_code: "CLOACI-T-0825"
 created_at: 2026-06-28T23:57:44.661370+00:00
-updated_at: 2026-06-28T23:57:44.661370+00:00
+updated_at: 2026-07-05T01:26:06.416792+00:00
 parent: CLOACI-I-0132
-blocked_by: ["CLOACI-T-0834"]
+blocked_by: [CLOACI-T-0834]
 archived: false
 
 tags:
   - "#task"
-  - "#phase/backlog"
   - "#feature"
+  - "#phase/completed"
 
 
 exit_criteria_met: false
@@ -39,7 +39,7 @@ Ship a **seed built-in library**: >=1 constructor per primitive — e.g. an http
 
 ### Type
 - [ ] Bug - Production issue that needs fixing
-- [ ] Feature - New functionality or enhancement  
+- [ ] Feature - New functionality or enhancement
 - [ ] Tech Debt - Code improvement or refactoring
 - [ ] Chore - Maintenance or setup work
 
@@ -51,7 +51,7 @@ Ship a **seed built-in library**: >=1 constructor per primitive — e.g. an http
 
 ### Impact Assessment **[CONDITIONAL: Bug]**
 - **Affected Users**: {Number/percentage of users affected}
-- **Reproduction Steps**: 
+- **Reproduction Steps**:
   1. {Step 1}
   2. {Step 2}
   3. {Step 3}
@@ -67,6 +67,12 @@ Ship a **seed built-in library**: >=1 constructor per primitive — e.g. an http
 - **Benefits of Fixing**: {What improves after refactoring}
 - **Risk Assessment**: {Risks of not addressing this}
 
+## Acceptance Criteria
+
+## Acceptance Criteria
+
+## Acceptance Criteria
+
 ## Acceptance Criteria **[REQUIRED]**
 
 - [ ] {Specific, testable requirement 1}
@@ -80,7 +86,7 @@ Ship a **seed built-in library**: >=1 constructor per primitive — e.g. an http
 ### Test Case 1: {Test Case Name}
 - **Test ID**: TC-001
 - **Preconditions**: {What must be true before testing}
-- **Steps**: 
+- **Steps**:
   1. {Step 1}
   2. {Step 2}
   3. {Step 3}
@@ -91,7 +97,7 @@ Ship a **seed built-in library**: >=1 constructor per primitive — e.g. an http
 ### Test Case 2: {Test Case Name}
 - **Test ID**: TC-002
 - **Preconditions**: {What must be true before testing}
-- **Steps**: 
+- **Steps**:
   1. {Step 1}
   2. {Step 2}
 - **Expected Results**: {What should happen}
@@ -136,4 +142,13 @@ Ship a **seed built-in library**: >=1 constructor per primitive — e.g. an http
 
 ## Status Updates **[REQUIRED]**
 
-*To be added during implementation*
+### 2026-07-04 — DONE (branch feat/i0132-completion, commit 3ede7654)
+Seed library shipped under `examples/constructor-contract/` — one provider per primitive, each a single-member A-0011 suite (multi-kind-per-component stays the noted fidius unknown):
+- **task**: `cloacina-provider-fs` (`read_file`/`write_file`) — pre-existing from T-0834, counts as the task seed; e2e-proven by `constructor_provider_package_wasm` + fs-grant-demo + the live stack.
+- **trigger**: `cloacina-provider-sensor` / `file_present` — the Airflow-FileSensor analog; fires when a configured path exists INSIDE the sandbox, so it's grant-gated (no `fs` grant → the path is invisible → fails closed by never firing).
+- **accumulator**: `cloacina-provider-extract` / `extract` — projects a configured field from each event into the boundary; buffers events without it.
+- **reactor**: `cloacina-provider-quorum` / `quorum` — fires when ≥ `required` boundaries are held (N-of-M criteria).
+
+**Design constraint discovered**: the authoring model REBUILDS the instance from bound config per call (config_binds in the macro), so seed accumulators must be STATELESS transforms — cross-event windowing (count windows etc.) needs runtime-held state and is a follow-on. The originally-sketched "http-poll trigger / shell task" need wasi-http/exec surfaces — the fs/file-based seeds exercise the same grant machinery without new host surface.
+
+**Tests**: `constructor_seed_library_wasm.rs` packages all three via the real `package_constructor_provider` path and drives poll/ingest/evaluate through wasmtime — 3/3 green, including the sensor's default-closed no-grant case. AC met: loadable, config-instantiable, end-to-end runnable, tested (the task member additionally runs in real workflows via fs-grant-demo + the demo stack).

--- a/.metis/backlog/features/CLOACI-T-0831.md
+++ b/.metis/backlog/features/CLOACI-T-0831.md
@@ -4,15 +4,15 @@ level: task
 title: "Python (cloaca) constructor consumption surface"
 short_code: "CLOACI-T-0831"
 created_at: 2026-06-29T14:00:00.846110+00:00
-updated_at: 2026-06-29T14:00:00.846110+00:00
+updated_at: 2026-07-05T02:24:36.661698+00:00
 parent: CLOACI-I-0132
-blocked_by: ["CLOACI-T-0829"]
+blocked_by: [CLOACI-T-0829]
 archived: false
 
 tags:
   - "#task"
-  - "#phase/backlog"
   - "#feature"
+  - "#phase/completed"
 
 
 exit_criteria_met: false
@@ -68,6 +68,12 @@ NOTE: execution is ALREADY language-agnostic — the Rust runtime runs the WASM 
 - **Current Problems**: {What's difficult/slow/buggy now}
 - **Benefits of Fixing**: {What improves after refactoring}
 - **Risk Assessment**: {Risks of not addressing this}
+
+## Acceptance Criteria
+
+## Acceptance Criteria
+
+## Acceptance Criteria
 
 ## Acceptance Criteria **[REQUIRED]**
 
@@ -163,3 +169,6 @@ Recon: the Python import happens in `loading.rs` Python branch via `runtime.load
 (1) `pack_providers_from_specs` ✅ (synthesized scratch project, specs verbatim — version/path/git uniform). (2) `CloacinaMetadata.providers: HashMap<String, ProviderDep>` ✅ (untagged Version|Detailed{version/path/git/tag/branch/rev} + `to_toml_value()`; re-exported; all struct literals patched). (3) compiler python arm ✅ (reads `[metadata.providers]` from the untyped manifest via serde → packs → `store_package_providers`; unbundleable fails the build). (4) reconciler ✅ — step-5b's fetch/unpack/set extracted into shared `stage_bundled_providers()` (returns count; fail-closed when bundled-but-no-feature); the PYTHON branch stages providers BEFORE `load_workflow_package` so `cloaca.constructor()` resolves during import. (5) tests ✅: provider_bundle 7/7 (new: from-specs path resolution + unknown-spec fail-closed), reconciler 25/25 (Step 5b through the shared helper), cloaca 3/3.
 
 **REMAINING for full T-0831 close:** the LIVE packaged-Python demo through a real server (docker demo lane: compiler image needs the wasm32-wasip2 target; a Python `.cloacina` with `[metadata.providers]` + `cloaca.constructor` → compile → load → execute). Same live-verification bucket as the Rust compiler-service check in T-0836. Everything below it is code-complete + test-verified.
+
+### 2026-07-04 — 🏁 LIVE PACKAGED-PYTHON DEMO VERIFIED — CLOSING (branch feat/i0132-completion, commit 9d44c461)
+New demo fixture `examples/fixtures/demo-constructor-py` (package.toml with `[metadata.providers] cloacina-provider-fs = { path = __WORKSPACE__/... }` + module-level `cloaca.constructor(id="py_reader", from_="cloacina-provider-fs@0.1.0", ...grants={"fs":["ro:/etc"]})` + downstream `@cloaca.task py_summarize`); `pack_python_ws` pack-script variant rewrites the placeholder. **Verified on a VIRGIN demo stack (fresh images, stock fleet executor):** build `success` + `package_providers` row (85KB) → server Python load ("Unpacked 1 bundled provider(s)" → "Python workflow imported: 2 tasks") → execution `Completed` **on an agent** (T-0838's Python path staged the bundle before the import) with final context `{"py_sandbox_read_hostname":"f0be3e01f257","py_sandbox_read_bytes":13}` — the AGENT container's hostname read inside the WASM sandbox through the grant. AC fully met: a Python workflow references a packaged constructor (name-keyed config + deps) and runs end-to-end, embedded AND packaged, server AND fleet. COMPLETE.

--- a/.metis/backlog/features/CLOACI-T-0833.md
+++ b/.metis/backlog/features/CLOACI-T-0833.md
@@ -4,15 +4,15 @@ level: task
 title: "Version pinning for constructor provider resolution (from = name@version)"
 short_code: "CLOACI-T-0833"
 created_at: 2026-06-29T14:00:01.127657+00:00
-updated_at: 2026-06-29T14:00:01.127657+00:00
+updated_at: 2026-07-05T01:25:29.541513+00:00
 parent: CLOACI-I-0132
-blocked_by: ["CLOACI-T-0829"]
+blocked_by: [CLOACI-T-0829]
 archived: false
 
 tags:
   - "#task"
-  - "#phase/backlog"
   - "#feature"
+  - "#phase/completed"
 
 
 exit_criteria_met: false
@@ -41,7 +41,7 @@ The Rust consumer surface ([[CLOACI-T-0829]]) resolves `from` against one provid
 
 ### Type
 - [ ] Bug - Production issue that needs fixing
-- [ ] Feature - New functionality or enhancement  
+- [ ] Feature - New functionality or enhancement
 - [ ] Tech Debt - Code improvement or refactoring
 - [ ] Chore - Maintenance or setup work
 
@@ -53,7 +53,7 @@ The Rust consumer surface ([[CLOACI-T-0829]]) resolves `from` against one provid
 
 ### Impact Assessment **[CONDITIONAL: Bug]**
 - **Affected Users**: {Number/percentage of users affected}
-- **Reproduction Steps**: 
+- **Reproduction Steps**:
   1. {Step 1}
   2. {Step 2}
   3. {Step 3}
@@ -69,6 +69,12 @@ The Rust consumer surface ([[CLOACI-T-0829]]) resolves `from` against one provid
 - **Benefits of Fixing**: {What improves after refactoring}
 - **Risk Assessment**: {Risks of not addressing this}
 
+## Acceptance Criteria
+
+## Acceptance Criteria
+
+## Acceptance Criteria
+
 ## Acceptance Criteria **[REQUIRED]**
 
 - [ ] {Specific, testable requirement 1}
@@ -82,7 +88,7 @@ The Rust consumer surface ([[CLOACI-T-0829]]) resolves `from` against one provid
 ### Test Case 1: {Test Case Name}
 - **Test ID**: TC-001
 - **Preconditions**: {What must be true before testing}
-- **Steps**: 
+- **Steps**:
   1. {Step 1}
   2. {Step 2}
   3. {Step 3}
@@ -93,7 +99,7 @@ The Rust consumer surface ([[CLOACI-T-0829]]) resolves `from` against one provid
 ### Test Case 2: {Test Case Name}
 - **Test ID**: TC-002
 - **Preconditions**: {What must be true before testing}
-- **Steps**: 
+- **Steps**:
   1. {Step 1}
   2. {Step 2}
 - **Expected Results**: {What should happen}
@@ -138,4 +144,5 @@ The Rust consumer surface ([[CLOACI-T-0829]]) resolves `from` against one provid
 
 ## Status Updates **[REQUIRED]**
 
-*To be added during implementation*
+### 2026-07-04 — DONE (branch feat/i0132-completion, commit 9170c1a8)
+`@version` pins are now ENFORCED at load at both consumer entry points (`load_constructor_node` + `load_reactor_constructor_node`): after `find_wasm_package` resolves the provider dir, `enforce_version_pin` compares the pin against the resolved `provider.json` version — exact or SEGMENT-prefix match ("0.1" matches 0.1.x, NOT 0.10.x; same semantics as the build-side bundle filter in `provider_bundle::resolve_provider_crate`, so a ref that bundled also loads). Mismatch fails closed naming BOTH versions. Unit tests (parse + boundary) + wasm-lane behavioral test (`version_pin_is_enforced_at_load` in constructor_workflow_node_wasm: exact/prefix/unpinned load, mismatch + 0.10-vs-0.1.x fail) — 4/4 green through wasmtime. Full semver-req operators (`^`, `~`, ranges) remain out of scope (segment-prefix covers the cargo-habit pins).

--- a/.metis/backlog/features/CLOACI-T-0835.md
+++ b/.metis/backlog/features/CLOACI-T-0835.md
@@ -4,15 +4,15 @@ level: task
 title: "Post-upgrade artifact recompile signal — cloacina tells the compiler to rebuild stale packaged artifacts after an ABI/interface-version bump"
 short_code: "CLOACI-T-0835"
 created_at: 2026-06-30T14:58:06.805614+00:00
-updated_at: 2026-06-30T14:58:06.805614+00:00
+updated_at: 2026-07-05T02:29:07.262135+00:00
 parent:
 blocked_by: []
 archived: false
 
 tags:
   - "#task"
-  - "#phase/backlog"
   - "#feature"
+  - "#phase/completed"
 
 
 exit_criteria_met: false
@@ -89,6 +89,12 @@ Captured during [[CLOACI-T-0832]] (the constructor FFI method bumps the `Cloacin
 - **Benefits of Fixing**: {What improves after refactoring}
 - **Risk Assessment**: {Risks of not addressing this}
 
+## Acceptance Criteria
+
+## Acceptance Criteria
+
+## Acceptance Criteria
+
 ## Acceptance Criteria **[REQUIRED]**
 
 - [ ] cloacina can enumerate registered/known packaged artifacts whose recorded interface-hash / ABI version is older than what the current build expects (the "stale set").
@@ -159,4 +165,7 @@ Captured during [[CLOACI-T-0832]] (the constructor FFI method bumps the `Cloacin
 
 ## Status Updates **[REQUIRED]**
 
-*To be added during implementation*
+### 2026-07-04 — DONE (branch feat/i0132-completion, commit 73b6de29) — shipped as AUTOMATIC self-healing
+Chose the strongest of the sketched shapes: fully automatic, no operator command needed. The reconciler already retries every registered `success` package each tick — so detection rides the load failure itself: when a load fails with a STALE-ARTIFACT error (fidius "incompatible ABI version" / "interface hash mismatch" — `is_stale_artifact_error`), the reconciler calls the new `WorkflowRegistry::request_recompile(package_id)` (default-false trait seam; unified-DB override flips `build_status` success/failed → `pending`, never stomping an in-flight `building` claim). The compiler claims + rebuilds from retained source; the next reconcile tick loads the fresh artifact. A once-per-package-per-process guard prevents ping-pong when the rebuilt artifact is still stale (e.g. the COMPILER is the outdated side).
+
+**AC disposition:** enumerate-stale = the reconciler's tick IS the sweep (every stale package trips the classifier within one interval — no schema change needed since the recorded-hash comparison already happens at load) ✓ · concrete signal = automatic `pending` flip (stronger than the sketched one-command CLI) ✓ · clear UX = a WARN naming the package + "requested a recompile from retained source; it will reload once the compiler rebuilds it" ✓ · documented in the reconciler code + this task (the T-0832 release note references the interface bump) ✓. Motivated live: the 2026-07-04 demo volume had 10 packages at fidius ABI 200 vs the host's 500 — exactly the mystery-failure pile this closes. Classifier unit-tested; cloacina + server + agent check clean.

--- a/.metis/initiatives/CLOACI-I-0132/initiative.md
+++ b/.metis/initiatives/CLOACI-I-0132/initiative.md
@@ -4,14 +4,14 @@ level: initiative
 title: "Constructors — reusable polyglot configured-instance factories for cloacina primitives (task/trigger/accumulator/reactor)"
 short_code: "CLOACI-I-0132"
 created_at: 2026-06-28T23:53:34.203685+00:00
-updated_at: 2026-07-04T03:34:53.522551+00:00
+updated_at: 2026-07-05T02:29:13.556221+00:00
 parent: CLOACI-V-0001
 blocked_by: []
 archived: false
 
 tags:
   - "#initiative"
-  - "#phase/active"
+  - "#phase/completed"
 
 
 exit_criteria_met: false
@@ -157,3 +157,12 @@ constructor). Sketch:
 **Landmark:** the full packaged chain verified LIVE on the demo stack 7/7 — author → compile-time provider discovery+bundling → hermetic store → server resolution → grant-gated sandboxed execution (`constructor_demo` Completed). Both Rust (`constructor!`) and Python (`cloaca.constructor()`) consumer surfaces shipped. All on branch `feat/i0132-constructors` (~35 commits, in review).
 **REMAINING:** T-0825 (seed built-in provider library) · T-0831 (packaged-Python live demo; embedded surface DONE) · T-0833 (semver version pinning) · T-0835 (post-ABI-bump recompile signal — freshly motivated by the live stale-artifact episode) · **T-0838** (fleet/agent constructor execution — live finding #4).
 **ADRs decided:** A-0009 (capabilities) · A-0010 (Cargo distribution) · A-0011 (suites). Spec S-0015 drafting → should advance with T-0836 done.
+
+## Status (2026-07-04 — INITIATIVE COMPLETE: the last five tasks landed on feat/i0132-completion)
+- **T-0833** — `@version` pins ENFORCED at load (segment-prefix semantics matching the build side).
+- **T-0825** — seed provider library: fs (task) · sensor/file_present (trigger, grant-gated) · extract (accumulator) · quorum (reactor); wasm lane test 3/3.
+- **T-0835** — stale-artifact recompile signal: the reconciler flips ABI/interface-mismatched packages back to `pending` for the compiler to rebuild from retained source (self-healing; once-per-package-per-process guard).
+- **T-0831** — packaged-Python LIVE: `demo-constructor-py` (`[metadata.providers]` + module-level `cloaca.constructor`) built, bundled, loaded, and **Completed on the fleet**.
+- **T-0838** — agents execute constructor nodes: `GET /v1/agent/providers/{digest}` + agent-side Step-5b twin (Rust + Python paths, fail-closed both ways).
+
+**FINAL LIVE PROOF (virgin stack, fresh images, STOCK fleet executor):** all 17 packages built clean; `constructor_demo` (Rust) AND `constructor_demo_py` both **Completed with execution on agents** — both final contexts carry the AGENT container's own hostname read inside the WASM sandbox through the `ro:/etc` grant. Every REQ (001–007) and NFR (001–004) is implemented, tested, and live-verified in both languages, embedded + server + fleet. All child tasks completed.

--- a/.metis/initiatives/CLOACI-I-0132/tasks/CLOACI-T-0838.md
+++ b/.metis/initiatives/CLOACI-I-0132/tasks/CLOACI-T-0838.md
@@ -4,14 +4,14 @@ level: task
 title: "Fleet/agent constructor execution — ship provider bundles to agents + resolve constructor nodes in the agent load path"
 short_code: "CLOACI-T-0838"
 created_at: 2026-07-04T03:30:18.377372+00:00
-updated_at: 2026-07-04T03:30:18.377372+00:00
+updated_at: 2026-07-05T02:23:51.960824+00:00
 parent: CLOACI-I-0132
 blocked_by: []
 archived: false
 
 tags:
   - "#task"
-  - "#phase/todo"
+  - "#phase/completed"
 
 
 exit_criteria_met: false
@@ -40,12 +40,16 @@ The demo works only with the in-process executor (`default`) via a compose overr
 3. **Fail-closed parity** — an agent handed a constructor-bearing package without its bundles must refuse the load with the same clear error the server gives, not a mystery "task not registered".
 4. **Verification** — the demo stack with `CLOACINA_DEFAULT_EXECUTOR=fleet` (the compose default, no override) runs `constructor_demo` to completion on an agent; e2e fleet lane covers it.
 
+## Acceptance Criteria
+
+## Acceptance Criteria
+
 ## Acceptance Criteria **[REQUIRED]**
 
-- [ ] Agents receive (or fetch) the provider bundles for constructor-bearing packages
-- [ ] The agent load path resolves + registers `constructor!` nodes (Step-5b parity), grants enforced identically
-- [ ] Missing bundles fail the agent load closed with a named error
-- [ ] `constructor_demo` completes on the demo stack with the stock fleet executor (no compose override)
+- [x] Agents receive (or fetch) the provider bundles for constructor-bearing packages
+- [x] The agent load path resolves + registers `constructor!` nodes (Step-5b parity), grants enforced identically
+- [x] Missing bundles fail the agent load closed with a named error
+- [x] `constructor_demo` completes on the demo stack with the stock fleet executor (no compose override)
 
 ## Test Cases **[CONDITIONAL: Testing Task]**
 
@@ -110,4 +114,10 @@ The demo works only with the in-process executor (`default`) via a compose overr
 
 ## Status Updates **[REQUIRED]**
 
-*To be added during implementation*
+### 2026-07-04 — DONE + LIVE-VERIFIED ON THE FLEET (branch feat/i0132-completion, commit e68b1ce9)
+Chose the endpoint option (content-addressed, mirrors the artifact fetch):
+- **Server**: `GET /v1/agent/providers/{digest}` (routes/agent.rs `fetch_providers`, authz + router entries) — resolves digest → (name, version) via new DAL `get_package_name_version_by_content_hash`, returns the `package_providers` archives base64-JSON.
+- **Agent Rust path** (`load_rust_cdylib`): after `register_package_tasks`, extract the cdylib's constructor decls (FFI idx 10); when present → `stage_agent_providers` (fetch, unpack, `set_provider_search_path`; ZERO providers clears the path for hermeticity) → fail closed if decls>0 but staged==0 → `resolve_agent_constructor_nodes` (the Step-5b twin: JSON-decode config values, `GrantSpec::from_pairs`, `load_constructor_node` in spawn_blocking, `runtime.register_task` under the dispatched namespace).
+- **Agent Python path** (`load_python_package`): stage bundles BEFORE the module import so `cloaca.constructor(...)` resolves during load.
+
+**LIVE VERIFICATION (fresh stack, stock fleet executor, no override):** `constructor_demo` (rust 0.1.2) AND `constructor_demo_py` both **Completed** with execution on agents — agent-1 logs show both loads ("registered 1 tasks for demo-constructor-rust" + "Python workflow imported: 2 tasks for demo-constructor-py"), and the clincher: both final contexts carry the AGENT container's own hostname (`f0be3e01f257`) read from ITS `/etc/hostname` inside the WASM sandbox through the `ro:/etc` grant. All four ACs met.

--- a/crates/cloacina-agent/src/main.rs
+++ b/crates/cloacina-agent/src/main.rs
@@ -708,6 +708,184 @@ async fn load_rust_cdylib(
         registered = ?registered.iter().map(|n| n.to_string()).collect::<Vec<_>>(),
         "cdylib registered"
     );
+
+    // CLOACI-T-0838: resolve the package's `constructor!` node declarations —
+    // the agent twin of the reconciler's Step 5b. Fail closed both ways: decls
+    // with no bundled providers refuse the load (hermetic guarantee), and a
+    // node that can't resolve refuses rather than surfacing later as a mystery
+    // "task not registered".
+    let loader = cloacina::registry::loader::package_loader::PackageLoader::new().map_err(|e| {
+        cloacina::fleet::AgentOutcome::Refused {
+            reason: RefusalReason::RuntimeLoadFailed,
+            message: format!("package loader init: {}", e),
+        }
+    })?;
+    let decls = loader
+        .extract_constructor_metadata(&cdylib_bytes)
+        .await
+        .map_err(|e| cloacina::fleet::AgentOutcome::Refused {
+            reason: RefusalReason::RuntimeLoadFailed,
+            message: format!("extract constructor metadata: {}", e),
+        })?;
+    if !decls.is_empty() {
+        let staged =
+            stage_agent_providers(http, server, api_key, &packet.artifact.digest, cache_dir)
+                .await
+                .map_err(|e| cloacina::fleet::AgentOutcome::Refused {
+                    reason: RefusalReason::RuntimeLoadFailed,
+                    message: e,
+                })?;
+        if staged == 0 {
+            return Err(cloacina::fleet::AgentOutcome::Refused {
+                reason: RefusalReason::RuntimeLoadFailed,
+                message: format!(
+                    "package declares {} constructor node(s) but the server has NO bundled \
+                     providers for it — rebuild the package so the compiler bundles each \
+                     `from` provider (CLOACI-T-0836)",
+                    decls.len()
+                ),
+            });
+        }
+        // Namespace components come from the dispatched task's namespace so the
+        // registered nodes match what the scheduler will look up.
+        let ns = cloacina::parse_namespace(&packet.task_name).map_err(|e| {
+            cloacina::fleet::AgentOutcome::Failure {
+                message: format!("parse_namespace({}): {}", packet.task_name, e),
+                classification: cloacina::fleet::FailureClassification::Validation,
+            }
+        })?;
+        resolve_agent_constructor_nodes(decls, &ns.tenant_id, &ns.package_name, runtime)
+            .await
+            .map_err(|e| cloacina::fleet::AgentOutcome::Refused {
+                reason: RefusalReason::RuntimeLoadFailed,
+                message: e,
+            })?;
+    }
+    Ok(())
+}
+
+/// CLOACI-T-0838: fetch the package's bundled CONSTRUCTOR PROVIDERS from the
+/// server (`GET /v1/agent/providers/{digest}` — the fleet twin of the
+/// reconciler reading `package_providers`), unpack them under `cache_dir`, and
+/// point the process-global provider search path at them. Returns how many
+/// providers were staged. Zero providers CLEARS the search path (hermeticity:
+/// this package must not resolve against a previously-loaded package's
+/// bundle). The staged tree is left in place — loaded constructor nodes re-read
+/// their wasm components from it for the process lifetime.
+async fn stage_agent_providers(
+    http: &reqwest::Client,
+    server: &str,
+    api_key: &str,
+    digest: &str,
+    cache_dir: &std::path::Path,
+) -> std::result::Result<usize, String> {
+    use base64::Engine as _;
+
+    #[derive(serde::Deserialize)]
+    struct ProviderEntry {
+        name: String,
+        data: String,
+    }
+    #[derive(serde::Deserialize)]
+    struct ProvidersResponse {
+        providers: Vec<ProviderEntry>,
+    }
+
+    let url = format!("{}/v1/agent/providers/{}", server, digest);
+    let resp = http
+        .get(&url)
+        .bearer_auth(api_key)
+        .send()
+        .await
+        .map_err(|e| format!("providers fetch: {}", e))?;
+    if !resp.status().is_success() {
+        return Err(format!("providers fetch: HTTP {}", resp.status()));
+    }
+    let body: ProvidersResponse = resp
+        .json()
+        .await
+        .map_err(|e| format!("providers decode: {}", e))?;
+
+    if body.providers.is_empty() {
+        cloacina::registry::loader::clear_provider_search_path();
+        return Ok(0);
+    }
+
+    let providers_root = cache_dir.join(format!("providers-{}", digest));
+    std::fs::create_dir_all(&providers_root)
+        .map_err(|e| format!("create providers dir {:?}: {}", providers_root, e))?;
+    for entry in &body.providers {
+        let bytes = base64::engine::general_purpose::STANDARD
+            .decode(&entry.data)
+            .map_err(|e| format!("provider '{}' base64: {}", entry.name, e))?;
+        let archive_path = providers_root.join(format!("{}.cloacina", entry.name));
+        std::fs::write(&archive_path, bytes)
+            .map_err(|e| format!("stage provider '{}': {}", entry.name, e))?;
+        cloacina::registry::loader::unpack_provider_archive(&archive_path, &providers_root, &[])
+            .map_err(|e| format!("unpack provider '{}': {}", entry.name, e))?;
+    }
+    cloacina::registry::loader::set_provider_search_path(&providers_root);
+    Ok(body.providers.len())
+}
+
+/// CLOACI-T-0838: resolve each declared `constructor!` node against the staged
+/// provider bundles and register it into the per-package runtime — the agent
+/// twin of the reconciler's Step 5b (`step_load_constructor_nodes`). The
+/// namespace components (tenant/package/workflow) come from the declaration +
+/// the dispatched task's namespace, matching what the scheduler dispatches.
+async fn resolve_agent_constructor_nodes(
+    decls: Vec<cloacina::cloacina_workflow_plugin::ConstructorPackageMetadata>,
+    tenant: &str,
+    package_name: &str,
+    runtime: &Arc<cloacina::Runtime>,
+) -> std::result::Result<(), String> {
+    use cloacina::registry::loader::grants::GrantSpec;
+    use cloacina::registry::loader::load_constructor_node;
+    use cloacina::TaskNamespace;
+
+    for decl in decls {
+        let namespace = TaskNamespace::new(tenant, package_name, &decl.workflow, &decl.id);
+        let dependencies: Vec<TaskNamespace> = decl
+            .dependencies
+            .iter()
+            .map(|dep| TaskNamespace::new(tenant, package_name, &decl.workflow, dep))
+            .collect();
+        let grants = GrantSpec::from_pairs(decl.grants.clone());
+        // Config values crossed the FFI wire JSON-encoded (bincode can't carry
+        // `serde_json::Value`); parse each back before binding.
+        let config: Vec<(String, serde_json::Value)> = decl
+            .config
+            .iter()
+            .map(|(k, raw)| {
+                serde_json::from_str(raw)
+                    .map(|v| (k.clone(), v))
+                    .map_err(|e| {
+                        format!(
+                            "constructor node '{}': config value for '{}' is not valid JSON \
+                         ({raw}): {e}",
+                            decl.id, k
+                        )
+                    })
+            })
+            .collect::<Result<_, _>>()?;
+
+        let (node_id, from, constructor) = (decl.id.clone(), decl.from.clone(), decl.constructor);
+        // wasmtime compilation is blocking work; hop off the async executor.
+        let node = tokio::task::spawn_blocking(move || {
+            load_constructor_node(&node_id, &from, &constructor, config, dependencies, grants)
+        })
+        .await
+        .map_err(|e| format!("constructor node '{}' load join: {}", decl.id, e))?
+        .map_err(|e| {
+            format!(
+                "resolve constructor node '{}' (from = '{}'): {}",
+                decl.id, decl.from, e
+            )
+        })?;
+
+        runtime.register_task(namespace.clone(), move || node.clone());
+        debug!(namespace = %namespace, "registered packaged constructor node (agent)");
+    }
     Ok(())
 }
 
@@ -730,6 +908,19 @@ async fn load_python_package(
         .map_err(|e| cloacina::fleet::AgentOutcome::Refused {
             reason: RefusalReason::ArtifactFetchFailed,
             message: format!("python source fetch failed: {}", e),
+        })?;
+
+    // CLOACI-T-0838: stage the package's bundled constructor providers BEFORE
+    // the module import, so `cloaca.constructor(...)` calls resolve against
+    // them during load (the agent twin of the reconciler's Python branch).
+    // Zero providers clears the search path — an undeclared ref then fails the
+    // import with a clear "no such provider" instead of leaking to a
+    // previously-loaded package's bundle.
+    stage_agent_providers(http, server, api_key, digest, cache_dir)
+        .await
+        .map_err(|e| cloacina::fleet::AgentOutcome::Refused {
+            reason: RefusalReason::RuntimeLoadFailed,
+            message: e,
         })?;
 
     let staging = cache_dir.join(format!("pysrc-{}", digest));

--- a/crates/cloacina-server/src/lib.rs
+++ b/crates/cloacina-server/src/lib.rs
@@ -1660,6 +1660,10 @@ fn build_router(state: AppState) -> Router {
             "/agent/source/{digest}",
             axum::routing::get(crate::routes::agent::fetch_source),
         )
+        .route(
+            "/agent/providers/{digest}",
+            axum::routing::get(crate::routes::agent::fetch_providers),
+        )
         // All four agent endpoints authenticate with an API key (bearer) and
         // extract `Extension<AuthenticatedKey>`. The layer MUST be attached
         // here, before the merge into `auth_routes` below: `.route_layer` only

--- a/crates/cloacina-server/src/routes/agent.rs
+++ b/crates/cloacina-server/src/routes/agent.rs
@@ -313,6 +313,65 @@ pub async fn fetch_source(
     Ok(resp)
 }
 
+/// One bundled constructor provider in a [`AgentProvidersResponse`]
+/// (CLOACI-T-0838). `data` is the packed provider archive, base64-encoded.
+#[derive(serde::Serialize)]
+pub struct AgentProviderEntry {
+    pub name: String,
+    pub data: String,
+}
+
+/// Response body for `GET /v1/agent/providers/{digest}`.
+#[derive(serde::Serialize)]
+pub struct AgentProvidersResponse {
+    pub providers: Vec<AgentProviderEntry>,
+}
+
+/// `GET /v1/agent/providers/{digest}` — the bundled CONSTRUCTOR PROVIDERS for
+/// the package whose active build has `content_hash == digest`
+/// (CLOACI-T-0838). Agents fetch these alongside the artifact so their load
+/// path can resolve `constructor!` nodes exactly like the server's reconciler
+/// Step 5b: unpack the bundles, set the provider search path, load each node.
+/// Empty list = the package uses no constructors. Same content-addressed
+/// access model as `fetch_artifact`.
+pub async fn fetch_providers(
+    State(state): State<AppState>,
+    Extension(_auth): Extension<AuthenticatedKey>,
+    Path(digest): Path<String>,
+) -> Result<Json<AgentProvidersResponse>, ApiError> {
+    use base64::Engine as _;
+
+    let dal = cloacina::dal::DAL::new(state.database.clone());
+    let Some((package_name, version)) = dal
+        .workflow_packages()
+        .get_package_name_version_by_content_hash(&digest)
+        .await
+        .map_err(|e| ApiError::internal(format!("provider lookup failed: {}", e)))?
+    else {
+        return Err(ApiError::not_found(
+            "package_not_found",
+            format!("no successfully-built package with digest {}", digest),
+        ));
+    };
+
+    let rows = dal
+        .workflow_packages()
+        .get_providers_for_package(&package_name, &version, None)
+        .await
+        .map_err(|e| ApiError::internal(format!("provider fetch failed: {}", e)))?;
+
+    Ok(Json(AgentProvidersResponse {
+        providers: rows
+            .into_iter()
+            .map(|r| AgentProviderEntry {
+                name: r.provider_name,
+                data: base64::engine::general_purpose::STANDARD
+                    .encode(r.provider_data.into_inner()),
+            })
+            .collect(),
+    }))
+}
+
 /// `GET /v1/agents` — operator-facing snapshot of the execution-agent fleet
 /// roster (admin only). CLOACI-I-0124 / WS-0b. Per-replica: reflects the agents
 /// registered against *this* server instance.

--- a/crates/cloacina-server/src/routes/authz.rs
+++ b/crates/cloacina-server/src/routes/authz.rs
@@ -468,6 +468,11 @@ pub fn build_authz_table() -> AuthzTable {
     );
     add(
         Method::GET,
+        "/agent/providers/{digest}",
+        Access::any(Level::Read),
+    );
+    add(
+        Method::GET,
         "/health/accumulators",
         Access::any(Level::Read),
     );

--- a/crates/cloacina/src/dal/unified/workflow_packages.rs
+++ b/crates/cloacina/src/dal/unified/workflow_packages.rs
@@ -1464,6 +1464,59 @@ impl<'a> WorkflowPackagesDAL<'a> {
         );
         Ok(result.map(|b| b.into_inner()))
     }
+
+    /// Resolve a successfully-built package's `(package_name, version)` from its
+    /// content hash. CLOACI-T-0838: agents identify packages by artifact digest
+    /// (content-addressed), while `package_providers` is keyed by name+version —
+    /// this is the bridge the `/v1/agent/providers/{digest}` route uses.
+    pub async fn get_package_name_version_by_content_hash(
+        &self,
+        content_hash: &str,
+    ) -> Result<Option<(String, String)>, RegistryError> {
+        let content_hash = content_hash.to_string();
+        let result: Option<(String, String)> = crate::dispatch_backend!(
+            self.dal.backend(),
+            {
+                let conn = self
+                    .dal
+                    .database
+                    .get_postgres_connection()
+                    .await
+                    .map_err(|e| RegistryError::Database(e.to_string()))?;
+                conn.interact(move |conn| {
+                    workflow_packages::table
+                        .filter(workflow_packages::content_hash.eq(content_hash))
+                        .filter(workflow_packages::build_status.eq("success"))
+                        .select((workflow_packages::package_name, workflow_packages::version))
+                        .first::<(String, String)>(conn)
+                        .optional()
+                })
+                .await
+                .map_err(|e| RegistryError::Database(e.to_string()))?
+                .map_err(|e| RegistryError::Database(format!("Database error: {}", e)))?
+            },
+            {
+                let conn = self
+                    .dal
+                    .database
+                    .get_sqlite_connection()
+                    .await
+                    .map_err(|e| RegistryError::Database(e.to_string()))?;
+                conn.interact(move |conn| {
+                    workflow_packages::table
+                        .filter(workflow_packages::content_hash.eq(content_hash))
+                        .filter(workflow_packages::build_status.eq("success"))
+                        .select((workflow_packages::package_name, workflow_packages::version))
+                        .first::<(String, String)>(conn)
+                        .optional()
+                })
+                .await
+                .map_err(|e| RegistryError::Database(e.to_string()))?
+                .map_err(|e| RegistryError::Database(format!("Database error: {}", e)))?
+            }
+        );
+        Ok(result)
+    }
 }
 
 #[cfg(test)]

--- a/crates/cloacina/src/registry/loader/constructor_loader.rs
+++ b/crates/cloacina/src/registry/loader/constructor_loader.rs
@@ -1198,10 +1198,11 @@ pub fn load_reactor_constructor<C: Serialize>(
 //
 // This mirrors the embedded-first philosophy: no server, no registry service — a
 // constructor provider is resolved from a directory on disk, exactly as
-// [`load_task_constructor`] already does. An optional `@version` suffix is stripped
-// (version pinning is advisory today; honoring it is a noted follow-on), and
-// `constructor = "name"` selects WHICH constructor inside the provider — validated
-// against the loaded `constructor.json`'s `name` so an author mismatch fails closed.
+// [`load_task_constructor`] already does. An optional `@version` suffix is ENFORCED
+// against the resolved provider's `provider.json` version (exact or segment-prefix
+// match, T-0833), and `constructor = "name"` selects WHICH constructor inside the
+// provider — validated against the loaded manifest's `name` so an author mismatch
+// fails closed.
 
 /// Process-wide override for the provider search path the `constructor!` consumer
 /// form resolves `from = "..."` against. `None` falls back to
@@ -1251,6 +1252,40 @@ fn provider_package_name(from: &str) -> &str {
         Some((name, _ver)) => name,
         None => from,
     }
+}
+
+/// The optional `@version` pin from a `from = "name[@version]"` reference.
+fn provider_version_pin(from: &str) -> Option<&str> {
+    from.split_once('@').map(|(_name, ver)| ver)
+}
+
+/// True when the provider's actual `version` satisfies the author's pin: exact
+/// equality or a SEGMENT prefix ("0.1" matches 0.1.x but NOT 0.10.x — hence the
+/// trailing dot). Mirrors the build-side filter in
+/// `packaging::provider_bundle::resolve_provider_crate` so a ref that bundled
+/// also loads (CLOACI-T-0833).
+fn version_satisfies_pin(actual: &str, pin: &str) -> bool {
+    actual == pin || actual.starts_with(&format!("{pin}."))
+}
+
+/// Enforce a `from = "name@version"` pin against the RESOLVED provider's
+/// `provider.json` version (CLOACI-T-0833). No pin → no check. Fails closed
+/// with a clear error naming both versions on mismatch.
+fn enforce_version_pin(context: &str, from: &str, dir: &Path) -> Result<(), LoaderError> {
+    let Some(pin) = provider_version_pin(from) else {
+        return Ok(());
+    };
+    let provider = read_provider_manifest(dir)?;
+    if version_satisfies_pin(&provider.version, pin) {
+        return Ok(());
+    }
+    Err(LoaderError::Validation {
+        reason: format!(
+            "{context}: provider '{}' resolved at version {} but the reference \
+             pins @{pin} — restage the pinned provider version or update the pin",
+            provider.name, provider.version
+        ),
+    })
 }
 
 /// A workflow DAG node backed by a packaged WASM task constructor — the runtime
@@ -1585,6 +1620,8 @@ pub fn load_constructor_node(
                 search_path.display()
             ),
         })?;
+    // Honor the author's `@version` pin against the resolved provider (T-0833).
+    enforce_version_pin(&format!("constructor node '{node_id}'"), from, &dir)?;
     // Select the requested member from the provider suite (fails closed, naming the
     // available members, if `constructor` is not in this provider).
     let manifest = read_member_manifest(&dir, constructor_name)?;
@@ -1689,6 +1726,12 @@ pub fn load_reactor_constructor_node(
                 search_path.display()
             ),
         })?;
+    // Honor the author's `@version` pin against the resolved provider (T-0833).
+    enforce_version_pin(
+        &format!("reactor constructor '{constructor_name}'"),
+        from,
+        &dir,
+    )?;
     // Select the requested member from the provider suite (fails closed if absent).
     let manifest = read_member_manifest(&dir, constructor_name)?;
 
@@ -1716,4 +1759,28 @@ pub fn load_reactor_constructor_node(
     })?;
 
     Ok(Arc::new(reactor_constructor) as Arc<dyn ReactorFireDecider>)
+}
+
+#[cfg(test)]
+mod version_pin_tests {
+    use super::*;
+
+    #[test]
+    fn pin_parsing_splits_name_and_version() {
+        assert_eq!(provider_package_name("p@0.1.0"), "p");
+        assert_eq!(provider_package_name("p"), "p");
+        assert_eq!(provider_version_pin("p@0.1.0"), Some("0.1.0"));
+        assert_eq!(provider_version_pin("p"), None);
+    }
+
+    #[test]
+    fn pin_matching_requires_segment_boundary() {
+        assert!(version_satisfies_pin("0.1.0", "0.1.0"));
+        assert!(version_satisfies_pin("0.1.5", "0.1"));
+        assert!(version_satisfies_pin("1.2.0", "1"));
+        // "0.1" must NOT match the 0.10.x series (segment boundary).
+        assert!(!version_satisfies_pin("0.10.0", "0.1"));
+        assert!(!version_satisfies_pin("10.0.0", "1"));
+        assert!(!version_satisfies_pin("0.2.0", "0.1.0"));
+    }
 }

--- a/crates/cloacina/src/registry/reconciler/mod.rs
+++ b/crates/cloacina/src/registry/reconciler/mod.rs
@@ -283,6 +283,13 @@ pub struct RegistryReconciler {
     /// server mode had no cron registration at all). Closes the gap
     /// where packaged cron triggers never fired under cloacina-server.
     pub(super) cron_registrar: Option<Arc<dyn CronWorkflowRegistrar>>,
+
+    /// CLOACI-T-0835: packages this process already asked the compiler to
+    /// rebuild after a stale-artifact load failure. One request per package
+    /// per process — if the rebuilt artifact STILL fails (e.g. the compiler
+    /// itself is the stale side), we do not ping-pong the row back to
+    /// `pending` forever.
+    recompile_requested: std::sync::Mutex<std::collections::HashSet<WorkflowPackageId>>,
 }
 
 impl RegistryReconciler {
@@ -311,6 +318,7 @@ impl RegistryReconciler {
             interval,
             graph_scheduler: Arc::new(tokio::sync::RwLock::new(None)),
             cron_registrar: None,
+            recompile_requested: std::sync::Mutex::new(std::collections::HashSet::new()),
         })
     }
 
@@ -554,6 +562,38 @@ impl RegistryReconciler {
                             package_id, package_metadata.package_name, package_metadata.version, e
                         );
                         error!("{}", error_msg);
+
+                        // CLOACI-T-0835: a STALE-ARTIFACT failure (the cdylib
+                        // was built against an older plugin ABI / interface
+                        // version than this host expects) is fixable by a
+                        // rebuild from retained source — signal the compiler
+                        // by flipping the row back to `pending`. Once per
+                        // package per process, so a rebuild that comes back
+                        // still-stale doesn't ping-pong forever.
+                        if is_stale_artifact_error(&error_msg)
+                            && self.recompile_requested.lock().unwrap().insert(*package_id)
+                        {
+                            match self.registry.request_recompile(*package_id).await {
+                                Ok(true) => warn!(
+                                    "Package {} v{} has a STALE compiled artifact (ABI/interface \
+                                     mismatch) — requested a recompile from retained source; it \
+                                     will reload once the compiler rebuilds it",
+                                    package_metadata.package_name, package_metadata.version
+                                ),
+                                Ok(false) => debug!(
+                                    "Stale artifact for {} v{}, but this registry cannot \
+                                     schedule recompiles",
+                                    package_metadata.package_name, package_metadata.version
+                                ),
+                                Err(req_err) => warn!(
+                                    "Failed to request recompile for {} v{}: {}",
+                                    package_metadata.package_name,
+                                    package_metadata.version,
+                                    req_err
+                                ),
+                            }
+                        }
+
                         result.packages_failed.push((*package_id, error_msg));
 
                         if !self.config.continue_on_package_error {
@@ -620,9 +660,35 @@ impl RegistryReconciler {
     }
 }
 
+/// CLOACI-T-0835: does this load failure mean the compiled artifact is STALE
+/// (built against an older plugin ABI / interface version than this host
+/// expects) — i.e. a rebuild from source would fix it? Matches the two gates a
+/// version bump trips: fidius's ABI check ("incompatible ABI version") and its
+/// per-interface hash check ("interface hash mismatch"). Message-based because
+/// the typed fidius error is stringly-flattened by the loader layers; both
+/// strings are fidius-host error display texts, stable within a pinned fidius.
+fn is_stale_artifact_error(message: &str) -> bool {
+    message.contains("incompatible ABI version") || message.contains("interface hash mismatch")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn stale_artifact_classifier_matches_abi_and_interface_hash() {
+        assert!(is_stale_artifact_error(
+            "Failed to load library at /tmp/x.so: incompatible ABI version: got 200, expected 500"
+        ));
+        assert!(is_stale_artifact_error(
+            "interface hash mismatch: got 0xdead, expected 0xbeef"
+        ));
+        // Ordinary failures must NOT trigger a rebuild.
+        assert!(!is_stale_artifact_error("No space left on device"));
+        assert!(!is_stale_artifact_error(
+            "declares 1 constructor node(s) but has NO bundled providers"
+        ));
+    }
     use std::time::Duration;
     use uuid::Uuid;
 

--- a/crates/cloacina/src/registry/traits.rs
+++ b/crates/cloacina/src/registry/traits.rs
@@ -215,6 +215,22 @@ pub trait WorkflowRegistry: Send + Sync {
         let _ = (package_name, version);
         Ok(Vec::new())
     }
+
+    /// CLOACI-T-0835: ask the compiler to REBUILD this package from its
+    /// retained source, because its compiled artifact is stale (built against
+    /// an older plugin ABI / interface version than this host expects).
+    ///
+    /// Returns `true` when a rebuild was actually scheduled. Default impl: not
+    /// supported (`false`) — registries without a build pipeline (filesystem,
+    /// in-memory, mocks) can't recompile. The unified-DB registry overrides
+    /// this to flip `build_status` back to `pending` for the compiler to claim.
+    async fn request_recompile(
+        &self,
+        package_id: WorkflowPackageId,
+    ) -> Result<bool, RegistryError> {
+        let _ = package_id;
+        Ok(false)
+    }
 }
 
 /// Trait for binary storage backends.

--- a/crates/cloacina/src/registry/workflow_registry/database.rs
+++ b/crates/cloacina/src/registry/workflow_registry/database.rs
@@ -1817,6 +1817,76 @@ impl<S: RegistryStorage> WorkflowRegistryImpl<S> {
         Ok(())
     }
 
+    /// Flip a previously-built package back to `pending` so the compiler
+    /// rebuilds it from its retained source (CLOACI-T-0835 — the post-upgrade
+    /// recompile signal). Used by the reconciler when a load fails with a
+    /// STALE-ARTIFACT error (fidius ABI bump, `CloacinaPlugin` interface-hash
+    /// mismatch): the recorded artifact predates the host's expected ABI, and
+    /// only a rebuild fixes it.
+    ///
+    /// Guarded to `success`/`failed` rows only — an in-flight `building` claim
+    /// is never stomped. Returns `true` when the row was flipped.
+    pub async fn request_recompile(&self, package_id: Uuid) -> Result<bool, RegistryError> {
+        use crate::database::schema::unified::workflow_packages;
+        use crate::database::universal_types::UniversalUuid;
+
+        let pid = UniversalUuid(package_id);
+        let updated: usize = crate::dispatch_backend!(
+            self.database.backend(),
+            {
+                let conn = self
+                    .database
+                    .get_postgres_connection()
+                    .await
+                    .map_err(|e| RegistryError::Database(e.to_string()))?;
+                conn.interact(move |conn| {
+                    use diesel::prelude::*;
+                    diesel::update(
+                        workflow_packages::table
+                            .filter(workflow_packages::id.eq(pid))
+                            .filter(workflow_packages::build_status.eq_any(["success", "failed"])),
+                    )
+                    .set((
+                        workflow_packages::build_status.eq("pending"),
+                        workflow_packages::build_error.eq(None::<String>),
+                        workflow_packages::build_claimed_at
+                            .eq(None::<crate::database::universal_types::UniversalTimestamp>),
+                    ))
+                    .execute(conn)
+                })
+                .await
+                .map_err(|e| RegistryError::Database(e.to_string()))?
+                .map_err(|e| RegistryError::Database(format!("Database error: {}", e)))?
+            },
+            {
+                let conn = self
+                    .database
+                    .get_sqlite_connection()
+                    .await
+                    .map_err(|e| RegistryError::Database(e.to_string()))?;
+                conn.interact(move |conn| {
+                    use diesel::prelude::*;
+                    diesel::update(
+                        workflow_packages::table
+                            .filter(workflow_packages::id.eq(pid))
+                            .filter(workflow_packages::build_status.eq_any(["success", "failed"])),
+                    )
+                    .set((
+                        workflow_packages::build_status.eq("pending"),
+                        workflow_packages::build_error.eq(None::<String>),
+                        workflow_packages::build_claimed_at
+                            .eq(None::<crate::database::universal_types::UniversalTimestamp>),
+                    ))
+                    .execute(conn)
+                })
+                .await
+                .map_err(|e| RegistryError::Database(e.to_string()))?
+                .map_err(|e| RegistryError::Database(format!("Database error: {}", e)))?
+            }
+        );
+        Ok(updated > 0)
+    }
+
     /// Refresh `build_claimed_at` so the stale-build sweeper doesn't reset us.
     /// No-op if the row is no longer in `building` state.
     pub async fn heartbeat_build(&self, package_id: Uuid) -> Result<(), RegistryError> {

--- a/crates/cloacina/src/registry/workflow_registry/mod.rs
+++ b/crates/cloacina/src/registry/workflow_registry/mod.rs
@@ -692,6 +692,15 @@ impl<S: RegistryStorage + Send + Sync> WorkflowRegistry for WorkflowRegistryImpl
             .map(|r| (r.provider_name, r.provider_data.into_inner()))
             .collect())
     }
+
+    /// CLOACI-T-0835: flip the package back to `pending` so the compiler
+    /// rebuilds it from retained source (stale-artifact recompile signal).
+    async fn request_recompile(
+        &self,
+        package_id: crate::registry::types::WorkflowPackageId,
+    ) -> Result<bool, RegistryError> {
+        self.request_recompile(package_id).await
+    }
 }
 
 /// Unpack a `.cloacina` source archive in a temp dir and collect its UTF-8

--- a/crates/cloacina/tests/constructor_reactor_scheduler_wasm.rs
+++ b/crates/cloacina/tests/constructor_reactor_scheduler_wasm.rs
@@ -175,6 +175,7 @@ impl AccumulatorFactory for PassthroughFactory {
 /// loaded + fired entirely through the scheduler. `gate` is bound BY NAME via the
 /// declaration's `config`; the graph fires only when the guest's `evaluate` says so.
 #[tokio::test]
+#[serial_test::serial(provider_search_path)]
 async fn reactor_constructor_fires_via_scheduler() {
     let tmp = tempfile::TempDir::new().unwrap();
     stage(tmp.path());
@@ -266,6 +267,7 @@ async fn reactor_constructor_fires_via_scheduler() {
 /// `constructor.json` name fails the load closed — the author asked for a
 /// constructor the provider does not carry.
 #[tokio::test]
+#[serial_test::serial(provider_search_path)]
 async fn reactor_constructor_name_mismatch_fails_closed() {
     let tmp = tempfile::TempDir::new().unwrap();
     stage(tmp.path());

--- a/crates/cloacina/tests/constructor_seed_library_wasm.rs
+++ b/crates/cloacina/tests/constructor_seed_library_wasm.rs
@@ -1,0 +1,219 @@
+/*
+ *  Copyright 2026 Colliery Software
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+//! CLOACI-T-0825 — the SEED PROVIDER LIBRARY, one constructor per primitive,
+//! each packaged via the real `package_constructor_provider` path and loaded +
+//! invoked through the real kind loaders:
+//!
+//! - task: `cloacina-provider-fs` / `read_file`+`write_file` (covered end-to-end
+//!   by `constructor_provider_package_wasm` — not repeated here)
+//! - trigger: `cloacina-provider-sensor` / `file_present` (grant-gated file sensor)
+//! - accumulator: `cloacina-provider-extract` / `extract` (field projection)
+//! - reactor: `cloacina-provider-quorum` / `quorum` (N-of-M firing criteria)
+//!
+//! Feature-gated: only built/run with `--features constructors-wasm`.
+#![cfg(feature = "constructors-wasm")]
+
+use std::path::PathBuf;
+use std::sync::OnceLock;
+
+use cloacina::computation_graph::accumulator::Accumulator;
+use cloacina::packaging::constructor_provider::{
+    package_constructor_provider, ProviderPackageOptions,
+};
+use cloacina::registry::loader::constructor_loader::{
+    load_accumulator_constructor, load_reactor_constructor, load_trigger_constructor,
+    TriggerBinding,
+};
+use cloacina::registry::loader::grants::{translate, GrantSpec, ResolvedGrants};
+use cloacina::registry::loader::unpack_provider_archive;
+use cloacina::trigger::TriggerResult;
+use serde::Serialize;
+
+#[derive(Serialize)]
+struct SensorConfig {
+    path: String,
+}
+
+#[derive(Serialize)]
+struct ExtractConfig {
+    field: String,
+}
+
+#[derive(Serialize)]
+struct QuorumConfig {
+    required: i64,
+}
+
+fn examples_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../examples/constructor-contract")
+}
+
+fn stage_into(work: &tempfile::TempDir, providers: &std::path::Path, crate_name: &str) {
+    let archive = work.path().join(format!("{crate_name}.cloacina"));
+    let opts = ProviderPackageOptions {
+        crate_dir: examples_dir().join(crate_name),
+        output: Some(archive.clone()),
+        sign_key: None,
+        manifest_bin: "emit_manifest".to_string(),
+        release: true,
+    };
+    package_constructor_provider(&opts).expect("package_constructor_provider");
+    unpack_provider_archive(&archive, providers, &[]).expect("unpack provider archive");
+}
+
+/// Build + stage the three seed providers ONCE for the whole test binary.
+fn providers_dir() -> &'static PathBuf {
+    static PROVIDERS: OnceLock<(tempfile::TempDir, PathBuf)> = OnceLock::new();
+    &PROVIDERS
+        .get_or_init(|| {
+            let work = tempfile::TempDir::new().unwrap();
+            let providers = work.path().join("providers");
+            std::fs::create_dir_all(&providers).unwrap();
+            stage_into(&work, &providers, "cloacina-provider-sensor");
+            stage_into(&work, &providers, "cloacina-provider-extract");
+            stage_into(&work, &providers, "cloacina-provider-quorum");
+            (work, providers)
+        })
+        .1
+}
+
+/// The file sensor fires when the granted path exists, skips when it doesn't,
+/// and — default-closed — never fires without an fs grant even when the host
+/// file DOES exist.
+#[tokio::test]
+async fn file_present_trigger_is_grant_gated() {
+    let watched = tempfile::TempDir::new().unwrap();
+    let flag = watched.path().join("ready.flag");
+    let flag_str = flag.to_string_lossy().to_string();
+
+    let ro_grant = translate(&GrantSpec::from_lists(
+        vec![],
+        vec![],
+        vec![format!("ro:{}", watched.path().display())],
+        vec![],
+    ))
+    .expect("translate ro grant");
+
+    let load = |grants: &ResolvedGrants| {
+        load_trigger_constructor(
+            providers_dir(),
+            "cloacina-provider-sensor",
+            "file_present",
+            &SensorConfig {
+                path: flag_str.clone(),
+            },
+            TriggerBinding::default(),
+            grants,
+        )
+        .expect("load file_present")
+    };
+
+    // Granted + file absent → skip.
+    let trigger = load(&ro_grant);
+    let result = trigger.poll().await.expect("poll");
+    assert!(
+        matches!(result, TriggerResult::Skip),
+        "absent file must not fire, got {result:?}"
+    );
+
+    // Granted + file present → fire, carrying the path in the fire context.
+    std::fs::write(&flag, b"go").unwrap();
+    let result = trigger.poll().await.expect("poll");
+    assert!(result.should_fire(), "present file must fire");
+    let ctx = result.into_context().expect("fire carries a context");
+    assert_eq!(
+        ctx.get("path"),
+        Some(&serde_json::json!(flag_str)),
+        "fire context carries the sensed path"
+    );
+
+    // NO grant + file present → the sandbox can't see it → never fires
+    // (default-closed).
+    let denied = load(&ResolvedGrants::deny_all());
+    let result = denied.poll().await.expect("poll");
+    assert!(
+        matches!(result, TriggerResult::Skip),
+        "an ungranted sensor must fail closed by never firing, got {result:?}"
+    );
+}
+
+/// The extract accumulator projects the configured field into the boundary and
+/// buffers events that lack it.
+#[tokio::test]
+async fn extract_accumulator_projects_configured_field() {
+    let mut acc = load_accumulator_constructor(
+        providers_dir(),
+        "cloacina-provider-extract",
+        "extract",
+        &ExtractConfig {
+            field: "order_id".into(),
+        },
+        &ResolvedGrants::deny_all(),
+    )
+    .expect("load extract");
+    assert_eq!(acc.name(), "extract");
+
+    // Event carrying the field → boundary with JUST the projection.
+    let event = serde_json::json!({ "order_id": 42, "noise": "ignored" });
+    let boundary = acc
+        .process(serde_json::to_vec(&event).unwrap())
+        .expect("event with the field must emit a boundary");
+    let boundary: serde_json::Value = serde_json::from_slice(&boundary).unwrap();
+    assert_eq!(boundary, serde_json::json!({ "order_id": 42 }));
+
+    // Event without the field → buffered (no boundary).
+    let event = serde_json::json!({ "unrelated": true });
+    assert!(
+        acc.process(serde_json::to_vec(&event).unwrap()).is_none(),
+        "an event without the configured field must buffer"
+    );
+}
+
+/// The quorum reactor fires once the held-boundary count reaches `required`.
+#[tokio::test]
+async fn quorum_reactor_fires_at_the_configured_count() {
+    let load = |required: i64| {
+        load_reactor_constructor(
+            providers_dir(),
+            "cloacina-provider-quorum",
+            "quorum",
+            &QuorumConfig { required },
+            &ResolvedGrants::deny_all(),
+        )
+        .expect("load quorum")
+    };
+
+    let two_held = serde_json::json!({
+        "orders": { "value": 1 },
+        "payments": { "value": 2 },
+    })
+    .to_string();
+
+    // required = 2, held = 2 → fire, payload reports the quorum.
+    let outcome = load(2)
+        .evaluate(two_held.clone())
+        .await
+        .expect("evaluate quorum=2");
+    assert!(outcome.fire, "2-of-2 must fire");
+    let payload: serde_json::Value =
+        serde_json::from_str(&outcome.context_json.expect("fire carries a payload")).unwrap();
+    assert_eq!(payload.get("quorum").and_then(|v| v.as_i64()), Some(2));
+
+    // required = 3, held = 2 → hold.
+    let outcome = load(3).evaluate(two_held).await.expect("evaluate quorum=3");
+    assert!(!outcome.fire, "2-of-3 must hold");
+}

--- a/crates/cloacina/tests/constructor_workflow_node_wasm.rs
+++ b/crates/cloacina/tests/constructor_workflow_node_wasm.rs
@@ -302,3 +302,47 @@ fn config_kwarg_errors_are_clear() {
         "missing-field error must name the missing field: {msg}"
     );
 }
+
+/// T-0833: the `@version` pin is ENFORCED against the resolved provider's
+/// `provider.json` version — a matching pin loads, a mismatched pin fails
+/// closed naming BOTH versions, and a segment-prefix pin ("0.1") matches
+/// the 0.1.x series.
+#[test]
+fn version_pin_is_enforced_at_load() {
+    set_provider_search_path(providers_dir());
+
+    let unwrap_err = |r: Result<_, cloacina::registry::error::LoaderError>, what: &str| match r {
+        Ok(_) => panic!("{what}"),
+        Err(e) => e.to_string(),
+    };
+    let node = |from: &str| {
+        load_constructor_node(
+            "wrap",
+            from,
+            "affix",
+            vec![
+                ("prefix".to_string(), json!("hello, ")),
+                ("suffix".to_string(), json!("!")),
+            ],
+            vec![],
+            cloacina::registry::loader::grants::GrantSpec::default(),
+        )
+    };
+
+    // Exact pin and segment-prefix pin both load (the fixture is 0.1.0).
+    assert!(node("affix@0.1.0").is_ok(), "exact pin must load");
+    assert!(node("affix@0.1").is_ok(), "segment-prefix pin must load");
+    assert!(node("affix").is_ok(), "unpinned ref must load");
+
+    // A mismatched pin fails closed, naming both versions.
+    let msg = unwrap_err(node("affix@9.9.9"), "mismatched pin must fail closed");
+    assert!(
+        msg.contains("9.9.9") && msg.contains("0.1.0") && msg.contains("pins"),
+        "pin-mismatch error must name the pin and the resolved version: {msg}"
+    );
+
+    // "0.1" is a SEGMENT prefix — it must not be satisfied by e.g. 0.10.x, and
+    // conversely a "0.10" pin must not match the 0.1.x fixture.
+    let msg = unwrap_err(node("affix@0.10"), "0.10 pin must not match 0.1.x");
+    assert!(msg.contains("0.10"), "boundary error names the pin: {msg}");
+}

--- a/docker/pack-demo-fixtures.sh
+++ b/docker/pack-demo-fixtures.sh
@@ -61,6 +61,18 @@ pack_python() {
     tar -cjf "$OUT/$name.cloacina" -C "$stage" "$prefix"
 }
 
+# Like pack_python, but rewrites the __WORKSPACE__ placeholder in package.toml —
+# for Python packages whose [metadata.providers] path-dep constructor providers
+# from the workspace (CLOACI-T-0831).
+pack_python_ws() {
+    name="$1"; srcdir="$2"; ver="${3:-0.1.0}"; prefix="$name-$ver"
+    stage="/tmp/pystage-$name"; rm -rf "$stage"; mkdir -p "$stage/$prefix"
+    cp -R "$srcdir"/. "$stage/$prefix/"
+    sed "s|__WORKSPACE__|$WS|g" "$srcdir/package.toml" > "$stage/$prefix/package.toml"
+    echo "packing $name (python/ws) → $OUT/$name.cloacina"
+    tar -cjf "$OUT/$name.cloacina" -C "$stage" "$prefix"
+}
+
 # --- Executions: plain Rust task workflows (completed / failed / in-flight) ---
 pack_rust_ws demo-slow-rust
 pack_rust_ws demo-fail-rust
@@ -95,8 +107,14 @@ pack_rust_ws acme-fulfillment-rust
 #     cloacina-provider-fs's read_file member: the compiler discovers the
 #     `constructor!` from-ref, builds the provider to WASM, bundles it into
 #     package_providers; the server resolves it at load and executes it sandboxed
-#     with an fs grant (reads /etc/os-release). ---
+#     with an fs grant (reads /etc/hostname). ---
 pack_rust_ws demo-constructor-rust
+
+# --- Constructor provider (Python) — CLOACI-T-0831. The Python twin: the
+#     provider is declared in [metadata.providers] (no Cargo.toml to discover
+#     from), bundled the same way, and resolved at load for the module's
+#     cloaca.constructor(...) call. ---
+pack_python_ws demo-constructor-py "$WS/examples/fixtures/demo-constructor-py" 0.1.0
 
 # --- Kafka-sourced stream accumulator → reactor-bound CG (Rust) — CLOACI-T-0676 ---
 pack_rust_ws demo-kafka-stream-rust

--- a/docs/content/engine/constructors/_index.md
+++ b/docs/content/engine/constructors/_index.md
@@ -2,7 +2,6 @@
 title: "Constructors & Providers"
 description: "Reusable, WASM-sandboxed, parameterized factories that produce configured Cloacina primitives."
 weight: 45
-draft: true
 ---
 
 # Constructors & Providers
@@ -18,5 +17,24 @@ A **provider** is a *suite* of constructors: one crate compiles to one WASM
 component that may expose **N members**, indexed by a `provider.json`. A consumer
 selects a member with `constructor = "<name>"` and references the provider with
 `from = "<provider crate>"`.
+
+## How it flows
+
+Providers ride Cargo's dependency model — there is no separate provider registry
+to operate:
+
+1. **Author** a provider crate (`cloacina-provider-<name>`) with one or more
+   `#[constructor]` members and one `constructor_provider!` declaration.
+2. **Consume** it from a workflow: add the crate as an ordinary Cargo dependency
+   (Rust) or declare it in `[metadata.providers]` (Python), then reference a
+   member with `constructor!(from = "...", constructor = "...")` /
+   `cloaca.constructor(...)`.
+3. **Build**: the compiler discovers the reference, resolves the provider from
+   the dependency graph, builds it to a `wasm32-wasip2` component, and **bundles
+   it into the workflow package** — the deployed artifact is hermetic.
+4. **Run**: the server (or an execution agent — fleet dispatch is transparent)
+   unpacks the bundled provider at load, resolves the member, binds the
+   consumer's config, and executes it inside a WASI sandbox scoped exactly to
+   the consumer's grants.
 
 {{< toc-tree >}}

--- a/docs/content/engine/constructors/author-a-provider.md
+++ b/docs/content/engine/constructors/author-a-provider.md
@@ -2,7 +2,6 @@
 title: "Author a Constructor Provider"
 description: "How to write a provider crate that ships N constructor members in one WASM component, and consume them by name with capability grants."
 weight: 10
-draft: true
 ---
 
 # Author a Constructor Provider
@@ -90,7 +89,16 @@ The crate is a standalone `crate-type = ["cdylib", "rlib"]` package with a small
 `emit_manifest` host bin that prints `__provider_manifest()` — the packaging step
 reads it to write `provider.json`.
 
-## 3. Package the provider
+## 3. Distribute the provider
+
+**You usually don't package anything by hand.** A provider is distributed as an
+ordinary Cargo crate (crates.io, git, or a path). When a packaged workflow
+depends on it and references a member, the **compiler** resolves it from the
+dependency graph, builds it to `wasm32-wasip2`, and bundles it into the
+workflow package automatically — see
+[Consume a Constructor Provider]({{< ref "consume-a-provider.md" >}}).
+
+For the **embedded** path (no server/compiler), package it explicitly:
 
 ```bash
 cloacinactl constructor package ./cloacina-provider-fs --sign-key key.secret
@@ -98,7 +106,8 @@ cloacinactl constructor package ./cloacina-provider-fs --sign-key key.secret
 
 This builds the crate to `wasm32-wasip2`, emits `provider.json` (both members),
 assembles a `runtime = "wasm"` package, optionally Ed25519-signs it, and packs a
-`cloacina-provider-fs-0.1.0.cloacina` archive.
+`cloacina-provider-fs-0.1.0.cloacina` archive you can stage on a provider
+search path.
 
 ## 4. Consume a member with grants
 
@@ -138,6 +147,10 @@ constructor!(
 Both `read_file` and `write_file` resolve from the **same** provider package and
 component — one download, two members, coexisting independently.
 
+The `@0.1.0` suffix is an enforced version pin (exact or segment-prefix — `@0.1`
+matches 0.1.x but not 0.10.x); a mismatch fails at build and at load naming both
+versions.
+
 ## Worked example
 
 A complete, runnable example lives at
@@ -145,3 +158,8 @@ A complete, runnable example lives at
 suite) and `examples/constructor-contract/fs-grant-demo` (three workflows: a
 granted read, a denied read, and a granted write via the second member). Run it
 with `cargo run` in the demo crate.
+
+The [Seed Providers]({{< ref "seed-providers.md" >}}) — one canonical provider
+per primitive kind — are the reference implementations for authoring each kind
+(trigger: `cloacina-provider-sensor`, accumulator: `cloacina-provider-extract`,
+reactor: `cloacina-provider-quorum`).

--- a/docs/content/engine/constructors/author-a-provider.md
+++ b/docs/content/engine/constructors/author-a-provider.md
@@ -91,12 +91,18 @@ reads it to write `provider.json`.
 
 ## 3. Distribute the provider
 
-**You usually don't package anything by hand.** A provider is distributed as an
-ordinary Cargo crate (crates.io, git, or a path). When a packaged workflow
-depends on it and references a member, the **compiler** resolves it from the
-dependency graph, builds it to `wasm32-wasip2`, and bundles it into the
-workflow package automatically — see
+**You usually don't package the provider by hand.** A provider is distributed
+as an ordinary Cargo crate (crates.io, git, or a path). When a packaged
+workflow depends on it and references a member, the **compiler** resolves it
+from the dependency graph, builds it to `wasm32-wasip2`, and bundles it into
+the workflow package automatically — see
 [Consume a Constructor Provider]({{< ref "consume-a-provider.md" >}}).
+
+(To be clear: the **workflow** package itself is still packed and uploaded
+exactly as always — that remains the front door for distributing workflows.
+What the compiler removes is the *second* channel: hand-packaging providers
+and staging them on the server. The provider rides inside the workflow
+package.)
 
 For the **embedded** path (no server/compiler), package it explicitly:
 

--- a/docs/content/engine/constructors/consume-a-provider.md
+++ b/docs/content/engine/constructors/consume-a-provider.md
@@ -1,0 +1,135 @@
+---
+title: "Consume a Constructor Provider"
+description: "Wire a provider member into a packaged workflow — Rust or Python — and let the compiler bundle it hermetically."
+weight: 20
+---
+
+# Consume a Constructor Provider
+
+This guide covers the **consumer** side: referencing a provider member from a
+packaged workflow so it ships, loads, and runs with no operator staging. For
+authoring the provider itself, see
+[Author a Constructor Provider]({{< ref "author-a-provider.md" >}}).
+
+The contract in one sentence: **declare the provider as a dependency, reference
+a member by name, and the compiler bundles everything the deployed package
+needs.**
+
+## Rust: a Cargo dependency + `constructor!`
+
+The provider is an ordinary Cargo dependency of the workflow crate:
+
+```toml
+[dependencies]
+cloacina-provider-fs = "0.1"           # crates.io, or { path = ... } / { git = ... }
+```
+
+Inside a `#[workflow]`, a `constructor!(...)` node instantiates one member:
+
+```rust,ignore
+#[workflow(name = "constructor_demo")]
+pub mod constructor_demo {
+    use super::*;
+
+    constructor!(
+        id = "reader",
+        from = "cloacina-provider-fs@0.1.0",
+        constructor = "read_file",
+        config = { path = "/etc/hostname" },
+        grants = { fs = ["ro:/etc"] },
+    );
+
+    #[task(id = "summarize", dependencies = ["reader"])]
+    pub async fn summarize(context: &mut Context<serde_json::Value>) -> Result<(), TaskError> {
+        let contents = context.get("contents").and_then(|v| v.as_str()).unwrap_or("").to_string();
+        context.insert("bytes", serde_json::json!(contents.len()))?;
+        Ok(())
+    }
+}
+```
+
+At build time the compiler scans the source for `constructor!` /
+`#[reactor(... from = ...)]` references, resolves each named provider from the
+crate's **resolved Cargo graph**, builds it to a `wasm32-wasip2` component, and
+bundles the packed provider into the workflow package. A referenced provider
+that is **not** a dependency (or whose pinned version the graph doesn't
+provide) fails the build — never silently at load.
+
+## Python: `[metadata.providers]` + `cloaca.constructor`
+
+Python packages have no Cargo manifest, so the provider declaration lives in
+`package.toml` — this section is **authoritative** (the only source of provider
+dependencies for a Python package):
+
+```toml
+[metadata.providers]
+cloacina-provider-fs = "0.1.0"
+# or detailed specs, same shapes as Cargo dependencies:
+# cloacina-provider-fs = { path = "/workspace/providers/cloacina-provider-fs" }
+# cloacina-provider-fs = { git = "https://github.com/...", tag = "v0.1.0" }
+```
+
+The workflow module wires a member exactly like a task:
+
+```python
+import cloaca
+
+cloaca.constructor(
+    id="reader",
+    from_="cloacina-provider-fs@0.1.0",
+    constructor="read_file",
+    config={"path": "/etc/hostname"},
+    grants={"fs": ["ro:/etc"]},
+)
+
+@cloaca.task(dependencies=["reader"])
+def summarize(context):
+    contents = context.get("contents") or ""
+    context.set("bytes", len(contents))
+    return context
+```
+
+The compiler synthesizes a scratch Cargo project from the declared specs,
+builds each provider to wasm, and bundles it — the same hermetic result as the
+Rust path. A `cloaca.constructor` reference to a provider **missing** from
+`[metadata.providers]` fails at load with "no such provider" (it never resolves
+against another package's bundle).
+
+## Version pins
+
+The optional `@version` suffix on `from` is **enforced**, at build time and at
+load, with segment-prefix semantics:
+
+| Pin | Matches | Does not match |
+| --- | --- | --- |
+| `@0.1.0` | exactly 0.1.0 | 0.1.1 |
+| `@0.1` | 0.1.x | 0.10.x |
+| `@1` | 1.x.y | 10.x.y |
+
+A mismatch is a clear error naming both the pinned and the resolved version.
+Full semver operators (`^`, `~`, ranges) are not supported; pin a segment
+prefix instead.
+
+## What happens at load and run
+
+- The server's reconciler unpacks the package's bundled providers and resolves
+  each declared node **before** the workflow assembles — a package that
+  declares constructor nodes but carries no bundles refuses to load
+  (fail-closed, hermetic).
+- Execution agents do the same: they fetch the bundles from the server
+  (content-addressed, alongside the artifact) and resolve nodes in their own
+  load path — **fleet dispatch is transparent** to constructor workflows.
+- The node executes inside a WASI sandbox scoped to the consumer's `grants` —
+  see [Capability Grants]({{< ref "grants.md" >}}). With no grant, the sandbox
+  reaches nothing.
+- After a Cloacina upgrade that bumps the plugin ABI, previously-compiled
+  packages are detected as stale at load and automatically recompiled from
+  retained source — no manual rebuild sweep.
+
+## Embedded (no server)
+
+Embedded runners resolve `from` against a provider **search path** instead of a
+bundle: the process-wide override (`set_provider_search_path`), else
+`CLOACINA_PROVIDER_PATH`, else `./providers`. Stage provider packages there
+(e.g. via `cloacinactl constructor package` + unpack). The runnable
+`examples/constructor-contract/fs-grant-demo` shows the full embedded flow.

--- a/docs/content/engine/constructors/grants.md
+++ b/docs/content/engine/constructors/grants.md
@@ -1,0 +1,56 @@
+---
+title: "Capability Grants"
+description: "The default-closed grants grammar — what a constructor's sandbox may reach, decided by the consumer."
+weight: 30
+---
+
+# Capability Grants
+
+A constructor executes inside a WASI sandbox that can reach **nothing** by
+default — no filesystem, no network, no environment. The **consumer** (not the
+author) widens it, per instance, with `grants`. The same constructor code can
+therefore be run wide-open by one workflow and fully sealed by another.
+
+The grammar is identical on every consumer surface — Rust `constructor!`,
+Rust `#[reactor(constructor = ...)]`, and Python `cloaca.constructor(...)`:
+
+```rust,ignore
+grants = {
+    fs   = ["ro:/data", "rw:/scratch"],
+    env  = ["API_REGION"],
+    http = ["api.example.com", "*.internal:8443"],
+    tcp  = ["db.internal:5432"],
+}
+```
+
+```python
+grants={"fs": ["ro:/data"], "env": ["API_REGION"]}
+```
+
+## The four kinds
+
+| Kind | Pattern | Effect |
+| --- | --- | --- |
+| `fs` | `ro:<path>` / `rw:<path>` | Pre-opens the directory read-only / read-write. Everything outside stays invisible. |
+| `env` | `<NAME>` | Passes the **host's** value of that variable through by name (skipped silently if unset). Literal values are not supported. |
+| `http` | `<host>[:port][/path-glob]`, `*` globs | Grants the http capability plus a per-request egress policy matching host/port/path. |
+| `tcp` | `<host>:<port>`, `*:<port>`, `*` | Grants raw sockets plus a per-connection policy. A DNS host is resolved once at load and matched by `(ip, port)`. |
+
+## Semantics worth knowing
+
+- **Default-closed, fail-closed.** No grant → deny. A malformed grant aborts
+  the load rather than silently widening access.
+- **Symlinks cannot escape.** A path inside a granted tree that symlinks
+  outside it is refused by the sandbox (`Operation not permitted`). Grant the
+  real target, or point at a regular file — e.g. prefer `/etc/hostname` over
+  `/etc/os-release`, which is a symlink into `/usr/lib` on Debian images.
+- **Denial surfaces at the operation**, not at load: an ungranted read fails
+  inside the member (a task node fails, a trigger simply never fires) with the
+  WASI error naming the path.
+- **Load-time lint.** If the provider package declares a capability intent the
+  consumer didn't grant, the loader logs a warning at load — the mismatch will
+  deny at runtime, so it's surfaced early rather than as a mystery failure.
+
+The runnable `examples/constructor-contract/fs-grant-demo` demonstrates all
+three outcomes side by side: a granted read, the same read denied without the
+grant, and a granted write through a second suite member.

--- a/docs/content/engine/constructors/seed-providers.md
+++ b/docs/content/engine/constructors/seed-providers.md
@@ -1,0 +1,47 @@
+---
+title: "Seed Providers"
+description: "The built-in provider library — one canonical constructor per primitive kind."
+weight: 40
+---
+
+# Seed Providers
+
+Cloacina ships a small library of canonical providers — one per primitive kind —
+under `examples/constructor-contract/`. They are real, runnable building blocks
+and double as the reference implementations for authoring each kind.
+
+| Provider | Kind | Member(s) | Config | What it does |
+| --- | --- | --- | --- | --- |
+| `cloacina-provider-fs` | task | `read_file`, `write_file` | `path` | Reads/writes a file through the sandbox. `write_file` takes its `contents` as a required runtime param from the upstream context. |
+| `cloacina-provider-sensor` | trigger | `file_present` | `path` | The classic file sensor: fires when the path exists **inside the sandbox**, skips otherwise. Without an `fs` grant the path is invisible — the sensor fails closed by never firing. |
+| `cloacina-provider-extract` | accumulator | `extract` | `field` | Projects the configured field out of each event into the boundary; events without it buffer. The everyday map/filter from an event stream into boundaries. |
+| `cloacina-provider-quorum` | reactor | `quorum` | `required` | Fires the graph when at least `required` boundaries are held — N-of-M firing criteria. `required = 1` is "fire on anything". |
+
+Example — the fs task member in a workflow:
+
+```rust,ignore
+constructor!(
+    id = "reader",
+    from = "cloacina-provider-fs@0.1.0",
+    constructor = "read_file",
+    config = { path = "/etc/hostname" },
+    grants = { fs = ["ro:/etc"] },
+);
+```
+
+## Consumption surface per kind
+
+- **task** — `constructor!(...)` in a `#[workflow]` (Rust) or
+  `cloaca.constructor(...)` (Python).
+- **reactor** — `#[reactor(from = "...", constructor = "...", config(...))]`
+  replaces the reactor's firing criteria with the WASM member's `evaluate`.
+- **trigger / accumulator** — loaded through the embedded runtime registration
+  API (`load_constructor` lands the member in the matching `Runtime` registry);
+  declarative macro surfaces for these kinds are a follow-on.
+
+## A note on state
+
+The authoring model rebuilds the member instance from its bound config **per
+call**, so seed accumulators are stateless transforms. Cross-event state
+(count/time windows) needs runtime-held state and is a planned follow-on — if
+you need windowing today, author a native `#[accumulator]`.

--- a/examples/constructor-contract/cloacina-provider-extract/Cargo.toml
+++ b/examples/constructor-contract/cloacina-provider-extract/Cargo.toml
@@ -1,0 +1,43 @@
+# CLOACI-T-0825 — seed ACCUMULATOR (field projection) constructor provider.
+#
+# Same author-crate shape as `cloacina-provider-fs`: the clean constructor form
+# built to a wasm32-wasip2 component; the host build only serves `emit_manifest`.
+# Standalone crate, EXCLUDED from the cloacina workspace (under examples/* plus the
+# empty [workspace] table) so the wasm build stays self-contained.
+[workspace]
+
+[package]
+name = "cloacina-provider-extract"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+# cdylib → the wasm component; rlib → so `emit_manifest` (host) can link it.
+crate-type = ["cdylib", "rlib"]
+
+[[bin]]
+name = "emit_manifest"
+path = "src/bin/emit_manifest.rs"
+
+[dependencies]
+# The `#[constructor]` authoring macro under test (path dep; proc-macro runs on host).
+cloacina-macros = { path = "../../../crates/cloacina-macros" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+# Shared, language-neutral contract types (wire structs + manifest + ConstructorError).
+# serde-only → wasm-safe AND host-safe.
+constructor-contract = { path = "../constructor-contract" }
+
+# fidius guest SDK is needed ONLY for the wasm32 component build (the macro's
+# guest glue is `#[cfg(target_arch = "wasm32")]`). Target-gating it keeps the
+# host build (the `emit_manifest` bin) free of wasm-only deps.
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+fidius-guest = "0.5.5"
+fidius-macro = "0.5.5"
+wit-bindgen = "0.44"
+
+[profile.release]
+opt-level = "s"
+lto = true
+strip = true

--- a/examples/constructor-contract/cloacina-provider-extract/src/bin/emit_manifest.rs
+++ b/examples/constructor-contract/cloacina-provider-extract/src/bin/emit_manifest.rs
@@ -1,0 +1,30 @@
+/*
+ *  Copyright 2026 Colliery Software
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+//! CLOACI-T-0834 — print the macro-generated constructor manifest as JSON.
+//!
+//! Stands in for the packaging step that writes the sidecar `constructor.json`: it
+//! calls the `#[constructor]`-generated `__constructor_manifest()` and prints
+//! `ConstructorManifest::to_json()` to stdout. A host-only target — the manifest fn is
+//! emitted on every target, while the wasm guest glue is not.
+
+fn main() {
+    let manifest = cloacina_provider_extract::__provider_manifest();
+    print!(
+        "{}",
+        manifest.to_json().expect("serialize provider manifest")
+    );
+}

--- a/examples/constructor-contract/cloacina-provider-extract/src/lib.rs
+++ b/examples/constructor-contract/cloacina-provider-extract/src/lib.rs
@@ -1,0 +1,70 @@
+/*
+ *  Copyright 2026 Colliery Software
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+//! CLOACI-T-0825 — seed ACCUMULATOR provider: field projection.
+//!
+//! Projects a configured field out of each incoming event: an event carrying the
+//! field emits a boundary `{ "<field>": <value> }`; an event without it buffers
+//! (no boundary). The everyday "map/filter the event stream into boundaries"
+//! building block — configure `field = "order_id"` and only order events pass
+//! through, already narrowed to the value the graph cares about.
+//!
+//! NOTE the authoring model is per-call: the instance is rebuilt from its bound
+//! config for every `ingest`, so seed accumulators are STATELESS transforms.
+//! Windowing/counting across events needs runtime-held state — a follow-on.
+
+#![allow(dead_code)]
+// The fidius `#[plugin_interface]` macro emits a `#[cfg(host)]`-style gate the
+// workspace check-cfg lint flags as unknown — benign (mirrors the loader's own allow).
+#![allow(unexpected_cfgs)]
+
+use cloacina_macros::{constructor, constructor_provider};
+use constructor_contract::ConstructorError;
+
+/// Emits a boundary containing the configured `#[config] field` when the event
+/// carries it; buffers events that don't.
+#[constructor(
+    kind = accumulator,
+    name = "extract",
+    version = "0.1.0",
+    contract = constructor_contract,
+    description = "Projects a configured field from each event into the boundary; buffers events without it.",
+    author = "CLOACI-T-0825"
+)]
+pub struct Extract {
+    /// The event field to project into the boundary, bound once at load.
+    #[config]
+    field: String,
+}
+
+impl Extract {
+    /// The ONLY thing the author writes: decode the event, and emit the
+    /// projected field as the boundary when present.
+    fn ingest(&self, event_json: &str) -> Result<Option<String>, ConstructorError> {
+        let event: serde_json::Value = serde_json::from_str(event_json)
+            .map_err(|e| ConstructorError::msg(format!("decode event: {e}")))?;
+        match event.get(&self.field) {
+            Some(value) => {
+                let boundary = serde_json::json!({ self.field.clone(): value });
+                Ok(Some(boundary.to_string()))
+            }
+            None => Ok(None),
+        }
+    }
+}
+
+// The provider suite shell (CLOACI-A-0011): one member behind one component.
+constructor_provider!(contract = constructor_contract, accumulator = [Extract],);

--- a/examples/constructor-contract/cloacina-provider-quorum/Cargo.toml
+++ b/examples/constructor-contract/cloacina-provider-quorum/Cargo.toml
@@ -1,0 +1,43 @@
+# CLOACI-T-0825 — seed REACTOR (quorum firing criteria) constructor provider.
+#
+# Same author-crate shape as `cloacina-provider-fs`: the clean constructor form
+# built to a wasm32-wasip2 component; the host build only serves `emit_manifest`.
+# Standalone crate, EXCLUDED from the cloacina workspace (under examples/* plus the
+# empty [workspace] table) so the wasm build stays self-contained.
+[workspace]
+
+[package]
+name = "cloacina-provider-quorum"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+# cdylib → the wasm component; rlib → so `emit_manifest` (host) can link it.
+crate-type = ["cdylib", "rlib"]
+
+[[bin]]
+name = "emit_manifest"
+path = "src/bin/emit_manifest.rs"
+
+[dependencies]
+# The `#[constructor]` authoring macro under test (path dep; proc-macro runs on host).
+cloacina-macros = { path = "../../../crates/cloacina-macros" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+# Shared, language-neutral contract types (wire structs + manifest + ConstructorError).
+# serde-only → wasm-safe AND host-safe.
+constructor-contract = { path = "../constructor-contract" }
+
+# fidius guest SDK is needed ONLY for the wasm32 component build (the macro's
+# guest glue is `#[cfg(target_arch = "wasm32")]`). Target-gating it keeps the
+# host build (the `emit_manifest` bin) free of wasm-only deps.
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+fidius-guest = "0.5.5"
+fidius-macro = "0.5.5"
+wit-bindgen = "0.44"
+
+[profile.release]
+opt-level = "s"
+lto = true
+strip = true

--- a/examples/constructor-contract/cloacina-provider-quorum/src/bin/emit_manifest.rs
+++ b/examples/constructor-contract/cloacina-provider-quorum/src/bin/emit_manifest.rs
@@ -1,0 +1,30 @@
+/*
+ *  Copyright 2026 Colliery Software
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+//! CLOACI-T-0834 — print the macro-generated constructor manifest as JSON.
+//!
+//! Stands in for the packaging step that writes the sidecar `constructor.json`: it
+//! calls the `#[constructor]`-generated `__constructor_manifest()` and prints
+//! `ConstructorManifest::to_json()` to stdout. A host-only target — the manifest fn is
+//! emitted on every target, while the wasm guest glue is not.
+
+fn main() {
+    let manifest = cloacina_provider_quorum::__provider_manifest();
+    print!(
+        "{}",
+        manifest.to_json().expect("serialize provider manifest")
+    );
+}

--- a/examples/constructor-contract/cloacina-provider-quorum/src/lib.rs
+++ b/examples/constructor-contract/cloacina-provider-quorum/src/lib.rs
@@ -1,0 +1,67 @@
+/*
+ *  Copyright 2026 Colliery Software
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+//! CLOACI-T-0825 — seed REACTOR provider: quorum firing criteria.
+//!
+//! Fires the graph when at least `required` accumulator boundaries are held —
+//! the "wait for N of my inputs before running" criteria, configurable per
+//! instance. `required = 1` is "fire on anything"; `required = <boundary
+//! count>` is "wait for all".
+
+#![allow(dead_code)]
+// The fidius `#[plugin_interface]` macro emits a `#[cfg(host)]`-style gate the
+// workspace check-cfg lint flags as unknown — benign (mirrors the loader's own allow).
+#![allow(unexpected_cfgs)]
+
+use cloacina_macros::{constructor, constructor_provider};
+use constructor_contract::ConstructorError;
+
+/// Fires when at least `#[config] required` boundaries are held.
+#[constructor(
+    kind = reactor,
+    name = "quorum",
+    version = "0.1.0",
+    contract = constructor_contract,
+    description = "Fires when at least `required` accumulator boundaries are held.",
+    author = "CLOACI-T-0825"
+)]
+pub struct Quorum {
+    /// How many held boundaries constitute a quorum, bound once at load.
+    #[config]
+    required: i64,
+}
+
+impl Quorum {
+    /// The ONLY thing the author writes: count the held boundaries and fire
+    /// (with the count in the fire payload) once the quorum is met.
+    fn evaluate(&self, boundaries_json: &str) -> Result<Option<String>, ConstructorError> {
+        let boundaries: std::collections::HashMap<String, serde_json::Value> =
+            serde_json::from_str(boundaries_json)
+                .map_err(|e| ConstructorError::msg(format!("decode boundaries: {e}")))?;
+
+        let held = boundaries.len() as i64;
+        if held >= self.required {
+            Ok(Some(
+                serde_json::json!({ "quorum": held, "required": self.required }).to_string(),
+            ))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+// The provider suite shell (CLOACI-A-0011): one member behind one component.
+constructor_provider!(contract = constructor_contract, reactor = [Quorum],);

--- a/examples/constructor-contract/cloacina-provider-sensor/Cargo.toml
+++ b/examples/constructor-contract/cloacina-provider-sensor/Cargo.toml
@@ -1,0 +1,43 @@
+# CLOACI-T-0825 — seed TRIGGER (file-presence sensor) constructor provider.
+#
+# Same author-crate shape as `cloacina-provider-fs`: the clean constructor form
+# built to a wasm32-wasip2 component; the host build only serves `emit_manifest`.
+# Standalone crate, EXCLUDED from the cloacina workspace (under examples/* plus the
+# empty [workspace] table) so the wasm build stays self-contained.
+[workspace]
+
+[package]
+name = "cloacina-provider-sensor"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+# cdylib → the wasm component; rlib → so `emit_manifest` (host) can link it.
+crate-type = ["cdylib", "rlib"]
+
+[[bin]]
+name = "emit_manifest"
+path = "src/bin/emit_manifest.rs"
+
+[dependencies]
+# The `#[constructor]` authoring macro under test (path dep; proc-macro runs on host).
+cloacina-macros = { path = "../../../crates/cloacina-macros" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+# Shared, language-neutral contract types (wire structs + manifest + ConstructorError).
+# serde-only → wasm-safe AND host-safe.
+constructor-contract = { path = "../constructor-contract" }
+
+# fidius guest SDK is needed ONLY for the wasm32 component build (the macro's
+# guest glue is `#[cfg(target_arch = "wasm32")]`). Target-gating it keeps the
+# host build (the `emit_manifest` bin) free of wasm-only deps.
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+fidius-guest = "0.5.5"
+fidius-macro = "0.5.5"
+wit-bindgen = "0.44"
+
+[profile.release]
+opt-level = "s"
+lto = true
+strip = true

--- a/examples/constructor-contract/cloacina-provider-sensor/src/bin/emit_manifest.rs
+++ b/examples/constructor-contract/cloacina-provider-sensor/src/bin/emit_manifest.rs
@@ -1,0 +1,30 @@
+/*
+ *  Copyright 2026 Colliery Software
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+//! CLOACI-T-0834 — print the macro-generated constructor manifest as JSON.
+//!
+//! Stands in for the packaging step that writes the sidecar `constructor.json`: it
+//! calls the `#[constructor]`-generated `__constructor_manifest()` and prints
+//! `ConstructorManifest::to_json()` to stdout. A host-only target — the manifest fn is
+//! emitted on every target, while the wasm guest glue is not.
+
+fn main() {
+    let manifest = cloacina_provider_sensor::__provider_manifest();
+    print!(
+        "{}",
+        manifest.to_json().expect("serialize provider manifest")
+    );
+}

--- a/examples/constructor-contract/cloacina-provider-sensor/src/lib.rs
+++ b/examples/constructor-contract/cloacina-provider-sensor/src/lib.rs
@@ -1,0 +1,69 @@
+/*
+ *  Copyright 2026 Colliery Software
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+//! CLOACI-T-0825 — seed TRIGGER provider: a file-presence sensor.
+//!
+//! The classic "sensor" (Airflow's FileSensor): fires when the configured path
+//! exists, skips when it doesn't. The check runs INSIDE the WASM sandbox, so it
+//! only sees the filesystem the consuming workflow granted — with no
+//! `fs = ["ro:<dir>"]` grant the path is invisible (default-closed) and the
+//! trigger simply never fires.
+//!
+//! Same author-crate shape as `cloacina-provider-fs`: the clean constructor form
+//! (struct + one `poll` body) with the guest glue generated under
+//! `#[cfg(target_arch = "wasm32")]`, so the crate also builds on the host for
+//! `emit_manifest`.
+
+#![allow(dead_code)]
+// The fidius `#[plugin_interface]` macro emits a `#[cfg(host)]`-style gate the
+// workspace check-cfg lint flags as unknown — benign (mirrors the loader's own allow).
+#![allow(unexpected_cfgs)]
+
+use cloacina_macros::{constructor, constructor_provider};
+use constructor_contract::ConstructorError;
+
+/// Fires when the bound `#[config] path` exists inside the sandbox; skips
+/// otherwise. Visibility of the path is grant-gated (`fs = ["ro:<dir>"]`).
+#[constructor(
+    kind = trigger,
+    name = "file_present",
+    version = "0.1.0",
+    contract = constructor_contract,
+    description = "Fires when a configured path exists inside the sandbox (grant-gated file sensor).",
+    author = "CLOACI-T-0825"
+)]
+pub struct FilePresent {
+    /// The path whose presence fires the trigger, bound once per instance at load.
+    #[config]
+    path: String,
+}
+
+impl FilePresent {
+    /// Fire when the path exists. `Path::exists()` swallows sandbox denials as
+    /// `false`, so an ungranted path reads as "not present" — the trigger fails
+    /// closed by never firing rather than erroring every poll.
+    fn poll(&self) -> Result<bool, ConstructorError> {
+        if std::path::Path::new(&self.path).exists() {
+            self.set("path", self.path.clone());
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+}
+
+// The provider suite shell (CLOACI-A-0011): one member behind one component.
+constructor_provider!(contract = constructor_contract, trigger = [FilePresent],);

--- a/examples/fixtures/demo-constructor-py/package.toml
+++ b/examples/fixtures/demo-constructor-py/package.toml
@@ -1,0 +1,27 @@
+# Demo (CLOACI-T-0831): a packaged PYTHON workflow whose first DAG node is a WASM
+# constructor-provider member — the Python twin of demo-constructor-rust.
+#
+# Python packages have no Cargo.toml, so `[metadata.providers]` is the
+# AUTHORITATIVE provider declaration (A-0010 for Python): the compiler
+# synthesizes a scratch Cargo project from these specs, builds each provider to
+# a WASM component, and bundles it into `package_providers` — the server then
+# resolves `cloaca.constructor(...)` refs hermetically at load.
+#
+# TEMPLATE — `__WORKSPACE__` is rewritten to an absolute path by
+# docker/pack-demo-fixtures.sh before packing.
+[package]
+name = "demo-constructor-py"
+version = "0.1.0"
+interface = "cloacina-workflow-plugin"
+interface_version = 1
+extension = "cloacina"
+
+[metadata]
+workflow_name = "constructor_demo_py"
+language = "python"
+description = "python constructor provider demo — sandboxed read via a capability grant"
+author = "CLOACI-T-0831"
+entry_module = "constructor_demo_py.tasks"
+
+[metadata.providers]
+cloacina-provider-fs = { path = "__WORKSPACE__/examples/constructor-contract/cloacina-provider-fs" }

--- a/examples/fixtures/demo-constructor-py/workflow/constructor_demo_py/tasks.py
+++ b/examples/fixtures/demo-constructor-py/workflow/constructor_demo_py/tasks.py
@@ -1,0 +1,32 @@
+"""Demo Python constructor workflow (CLOACI-T-0831).
+
+The Python twin of demo-constructor-rust: the first DAG node is
+cloacina-provider-fs's `read_file` member, resolved from the provider BUNDLED
+by the compiler (declared in this package's `[metadata.providers]`) and
+executed in a WASM sandbox that can reach ONLY the granted `/etc`
+(default-closed otherwise). It reads `/etc/hostname` — a REGULAR file docker
+bind-mounts into every container (NOT `/etc/os-release`, a symlink the sandbox
+correctly refuses to follow out of the grant) — and the downstream Python task
+summarizes what came through the sandbox.
+
+    py_reader (wasm constructor) ─▶ py_summarize (python task)
+"""
+from __future__ import annotations
+
+import cloaca
+
+cloaca.constructor(
+    id="py_reader",
+    from_="cloacina-provider-fs@0.1.0",
+    constructor="read_file",
+    config={"path": "/etc/hostname"},
+    grants={"fs": ["ro:/etc"]},
+)
+
+
+@cloaca.task(dependencies=["py_reader"])
+def py_summarize(context):
+    contents = context.get("contents") or ""
+    context.set("py_sandbox_read_bytes", len(contents))
+    context.set("py_sandbox_read_hostname", contents.strip())
+    return context


### PR DESCRIPTION
## CLOACI-I-0132 — the final five tasks; initiative → completed

Closes out the constructors initiative (core framework merged in #168). All five live-verified on a **virgin demo stack with the stock fleet executor** — no overrides, no workarounds.

- **T-0833 — load-time version pins**: `from = "name@version"` is now ENFORCED against the resolved `provider.json` version (exact or segment-prefix: `0.1` matches 0.1.x, not 0.10.x — same semantics as the build-side bundle filter). Mismatch fails closed naming both versions.
- **T-0825 — seed provider library**, one per primitive, each a single-member A-0011 suite: `cloacina-provider-fs` (task, pre-existing) · `cloacina-provider-sensor/file_present` (grant-gated FileSensor) · `cloacina-provider-extract/extract` (field projection) · `cloacina-provider-quorum/quorum` (N-of-M firing). New wasm-lane test drives all three through wasmtime.
- **T-0835 — automatic stale-artifact recompile**: a load failing with fidius "incompatible ABI version" / "interface hash mismatch" flips the row back to `pending`; the compiler rebuilds from retained source and the next reconcile tick loads it. Once-per-package-per-process guard prevents ping-pong. Turns the post-upgrade mystery-failure pile (seen live: 10 packages at ABI 200 vs 500) into a self-healing cycle.
- **T-0831 — packaged-Python live**: `demo-constructor-py` fixture (`[metadata.providers]` + module-level `cloaca.constructor`); built, bundled, loaded, **Completed on the fleet**.
- **T-0838 — fleet/agent constructor execution**: `GET /v1/agent/providers/{digest}` (content-addressed, mirrors the artifact fetch) + the agent-side Step-5b twin in both the Rust and Python load paths, fail-closed both directions with hermetic search-path handling.

**Live proof**: all 17 demo packages built clean; `constructor_demo` (Rust) and `constructor_demo_py` both Completed **executing on agents** — final contexts carry the agent container's own hostname read from its `/etc/hostname` inside the WASM sandbox through the `ro:/etc` grant.

**Tests**: full constructor wasm lane 9 files / 33 tests green (incl. the new seed-library and pin-enforcement tests); fixed a pre-existing reactor-scheduler flake (parallel tests racing the process-global search path — now serialized).

Metis: T-0825/0831/0833/0835/0838 completed with evidence; **I-0132 → completed**.

https://claude.ai/code/session_01VWpWbgCzNdQkFT74S3wPRM