### PR TITLE
fix(T-0839): packaged Python state accumulators — dispatch type-loss + REST inject encoding

### DIFF
--- a/.metis/backlog/bugs/CLOACI-T-0839.md
+++ b/.metis/backlog/bugs/CLOACI-T-0839.md
@@ -4,15 +4,15 @@ level: task
 title: "Packaged Python state/stream accumulators silently degrade to passthrough server-side (names-only reactor dispatch drops accumulator_type)"
 short_code: "CLOACI-T-0839"
 created_at: 2026-07-05T16:08:11.000964+00:00
-updated_at: 2026-07-05T16:08:11.000964+00:00
+updated_at: 2026-07-05T17:02:57.060280+00:00
 parent:
 blocked_by: []
 archived: false
 
 tags:
   - "#task"
-  - "#phase/backlog"
   - "#bug"
+  - "#phase/active"
 
 
 exit_criteria_met: false
@@ -59,6 +59,10 @@ Thread the Python accumulator registrations through to the dispatch: either (a) 
   2. `POST /v1/health/accumulators/py_window/inject` ×3 with `{"event": {"bid": 1.5, "ask": 1.9}}`.
   3. Observe `cloacina_accumulator_buffer_depth{accumulator="py_window"}` stays 0 and the reactor receives per-event fires, not growing windows.
 - **Expected vs Actual**: expected a capacity-5 window (boundary = list, evicting oldest); actual passthrough (boundary = single event, no state, no persistence).
+
+## Acceptance Criteria
+
+## Acceptance Criteria
 
 ## Acceptance Criteria **[REQUIRED]**
 
@@ -130,4 +134,9 @@ Thread the Python accumulator registrations through to the dispatch: either (a) 
 
 ## Status Updates **[REQUIRED]**
 
-*To be added during implementation*
+### 2026-07-05 — implementation (branch fix/t0839-py-state-accumulator-dispatch), option (b)
+Chose the registration-enrichment shape: new `AccumulatorSpec { name, accumulator_type, config }` in cloacina-computation-graph + `ReactorRegistration.accumulator_specs: Vec<AccumulatorSpec>` (empty on paths where the kind travels out-of-band — Rust packaged reactors use FFI metadata; 17 construction sites updated).
+- **Producer** (cloacina-python `reactor.rs`): the `@cloaca.reactor` registration closure resolves specs LAZILY from `get_registered_accumulators()` (so decorator order doesn't matter), folding state `capacity` into the config map under the same key `state_capacity_from_config` reads.
+- **Consumers**: `build_view_python` (loading.rs) and the names-only `dispatch_runtime_reactors_into_scheduler` (packaging_bridge.rs:664 site) now resolve with precedence **manifest override (deployment wins) → authored spec → passthrough**.
+- **Tests**: `build_view_python_honors_authored_accumulator_specs` (authored state spec survives; override still beats it) — reconciler lib suite green; new producer-side test `test_reactor_registration_carries_authored_accumulator_specs` (py decorators → registration carries state/capacity=5) in python_reactor_library. cloacina-python + macros + computation-graph check clean.
+Remaining: integration-tests compile check, full py test suite, live demo re-verify (py_window N/5 — also closes T-0744's deferred AC), commit/PR.

--- a/.metis/backlog/bugs/CLOACI-T-0839.md
+++ b/.metis/backlog/bugs/CLOACI-T-0839.md
@@ -4,7 +4,7 @@ level: task
 title: "Packaged Python state/stream accumulators silently degrade to passthrough server-side (names-only reactor dispatch drops accumulator_type)"
 short_code: "CLOACI-T-0839"
 created_at: 2026-07-05T16:08:11.000964+00:00
-updated_at: 2026-07-05T17:02:57.060280+00:00
+updated_at: 2026-07-05T17:33:46.210109+00:00
 parent:
 blocked_by: []
 archived: false
@@ -12,7 +12,7 @@ archived: false
 tags:
   - "#task"
   - "#bug"
-  - "#phase/active"
+  - "#phase/completed"
 
 
 exit_criteria_met: false
@@ -59,6 +59,8 @@ Thread the Python accumulator registrations through to the dispatch: either (a) 
   2. `POST /v1/health/accumulators/py_window/inject` ×3 with `{"event": {"bid": 1.5, "ask": 1.9}}`.
   3. Observe `cloacina_accumulator_buffer_depth{accumulator="py_window"}` stays 0 and the reactor receives per-event fires, not growing windows.
 - **Expected vs Actual**: expected a capacity-5 window (boundary = list, evicting oldest); actual passthrough (boundary = single event, no state, no persistence).
+
+## Acceptance Criteria
 
 ## Acceptance Criteria
 
@@ -140,3 +142,10 @@ Chose the registration-enrichment shape: new `AccumulatorSpec { name, accumulato
 - **Consumers**: `build_view_python` (loading.rs) and the names-only `dispatch_runtime_reactors_into_scheduler` (packaging_bridge.rs:664 site) now resolve with precedence **manifest override (deployment wins) → authored spec → passthrough**.
 - **Tests**: `build_view_python_honors_authored_accumulator_specs` (authored state spec survives; override still beats it) — reconciler lib suite green; new producer-side test `test_reactor_registration_carries_authored_accumulator_specs` (py decorators → registration carries state/capacity=5) in python_reactor_library. cloacina-python + macros + computation-graph check clean.
 Remaining: integration-tests compile check, full py test suite, live demo re-verify (py_window N/5 — also closes T-0744's deferred AC), commit/PR.
+
+### 2026-07-05 — 🎯 LIVE-VERIFIED + a SECOND latent bug found and fixed in the same arc
+First live retest proved the spec threads through (`buffer_capacity: 5` at spawn = the REAL state runtime) but injects bounced: "state accumulator deserialize error: expected value". **Onion layer #2**: the REST inject route pre-wrapped events in the bincode boundary frame, violating the accumulator SOCKET contract (raw JSON bytes — what WS sends at ws.rs:277 and what every runtime decodes). The pre-wrap (a) made state/batch accumulators reject REST injects outright and (b) DOUBLE-encoded through passthrough — the long-standing undecodable `inputs: null` in the T-0775 fires log, finally explained. Fixed: inject sends `serde_json::to_vec(&event)`; the frame encoding stays on the reactor `fire_with` path (boundary CACHE, where frames are correct).
+
+**FINAL LIVE PROOF (demo stack):** `py_window` (state, capacity=5) after 3 REST injects → `buffer_depth=3 / buffer_capacity=5` in BOTH `/v1/health/accumulators` and the Prometheus gauge; reactor fired per ingest on real windowed boundaries. All four ACs met (stream rides the same resolution path by construction); T-0744's deferred N/5 AC demonstrated in the same run.
+
+**Known residual (separate, cosmetic):** the T-0775 fires-log input CAPTURE decodes only `bincode(json_bytes)` frames; state accumulators emit `bincode(Vec<Value>)` typed frames, so their captured inputs still render `null` in the fires log (worth checking whether py GRAPH input decode has the same gap). COMPLETE.

--- a/crates/cloacina-computation-graph/src/lib.rs
+++ b/crates/cloacina-computation-graph/src/lib.rs
@@ -394,6 +394,20 @@ pub struct ReactorConstructorRef {
     pub grants: Vec<(String, Vec<String>)>,
 }
 
+/// The authored KIND + config of one accumulator a reactor consumes
+/// (CLOACI-T-0839). Carried on [`ReactorRegistration`] so runtime-walking
+/// load paths (notably packaged Python, where `@cloaca.state_accumulator`
+/// is the only declaration) can spawn the right accumulator runtime instead
+/// of defaulting to passthrough. `config` is the same String-keyed map the
+/// manifest override channel uses (e.g. `capacity` for state accumulators).
+#[derive(Debug, Clone)]
+pub struct AccumulatorSpec {
+    pub name: String,
+    /// "passthrough" | "stream" | "polling" | "batch" | "state".
+    pub accumulator_type: String,
+    pub config: std::collections::HashMap<String, String>,
+}
+
 /// Runtime-side description of a reactor.
 ///
 /// Populated by the `#[reactor]` macro's emitted inventory entry.
@@ -401,6 +415,12 @@ pub struct ReactorConstructorRef {
 pub struct ReactorRegistration {
     pub name: String,
     pub accumulator_names: Vec<String>,
+    /// Authored accumulator kinds/configs for (a subset of) `accumulator_names`
+    /// (CLOACI-T-0839). Empty on paths where the kind travels out-of-band
+    /// (Rust packaged reactors carry it in the FFI metadata); populated by the
+    /// Python `@cloaca.reactor` path from the module's accumulator decorators.
+    /// Consumers fall back to manifest overrides, then passthrough.
+    pub accumulator_specs: Vec<AccumulatorSpec>,
     pub reaction_mode: ReactionMode,
     /// Optional packaged WASM reactor-constructor reference (CLOACI-T-0830).
     /// `Some(..)` makes the WASM guest's `evaluate` the reactor's firing

--- a/crates/cloacina-macros/src/reactor_attr.rs
+++ b/crates/cloacina-macros/src/reactor_attr.rs
@@ -457,6 +457,7 @@ fn reactor_impl(
                 constructor: || #cg_path::ReactorRegistration {
                     name: #reactor_name_lit.to_string(),
                     accumulator_names: vec![#(#accumulator_strs.to_string()),*],
+                    accumulator_specs: ::std::vec::Vec::new(),
                     reaction_mode: #cg_path::ReactionMode::#mode_variant,
                     constructor: #lib_constructor_ref,
                 },
@@ -470,6 +471,7 @@ fn reactor_impl(
                 constructor: || #cg_path::ReactorRegistration {
                     name: #reactor_name_lit.to_string(),
                     accumulator_names: vec![#(#accumulator_strs.to_string()),*],
+                    accumulator_specs: ::std::vec::Vec::new(),
                     reaction_mode: #cg_path::ReactionMode::#mode_variant,
                     constructor: ::std::option::Option::None,
                 },

--- a/crates/cloacina-python/src/reactor.rs
+++ b/crates/cloacina-python/src/reactor.rs
@@ -128,13 +128,42 @@ pub fn reactor(
             let reg_name = name_clone.clone();
             let reg_accs = accumulators_clone.clone();
             let reg_mode = reaction_mode;
-            rt.register_reactor(reg_name.clone(), move || ReactorRegistration {
-                name: reg_name.clone(),
-                accumulator_names: reg_accs.clone(),
-                reaction_mode: reg_mode,
-                // CLOACI-T-0830: the Python reactor path doesn't (yet) author
-                // WASM reactor constructors — native dirty-flag firing only.
-                constructor: None,
+            rt.register_reactor(reg_name.clone(), move || {
+                // CLOACI-T-0839: carry the module's authored accumulator kinds
+                // (`@cloaca.state_accumulator(capacity=N)` etc.) on the
+                // registration, so runtime-walking load paths (packaged Python
+                // via the reconciler) spawn the right accumulator runtime
+                // instead of defaulting to passthrough. Resolved lazily — by
+                // the time anyone calls `get_reactor`, all module decorators
+                // have run regardless of declaration order.
+                let accumulator_specs = crate::computation_graph::get_registered_accumulators()
+                    .into_iter()
+                    .filter(|areg| reg_accs.contains(&areg.name))
+                    .map(|areg| {
+                        let mut config = areg.config.clone();
+                        // state capacity rides the config map (the same key
+                        // `state_capacity_from_config` reads host-side).
+                        if areg.accumulator_type == "state" {
+                            config
+                                .entry("capacity".to_string())
+                                .or_insert_with(|| areg.capacity.to_string());
+                        }
+                        cloacina_computation_graph::AccumulatorSpec {
+                            name: areg.name,
+                            accumulator_type: areg.accumulator_type,
+                            config,
+                        }
+                    })
+                    .collect();
+                ReactorRegistration {
+                    name: reg_name.clone(),
+                    accumulator_names: reg_accs.clone(),
+                    accumulator_specs,
+                    reaction_mode: reg_mode,
+                    // CLOACI-T-0830: the Python reactor path doesn't (yet) author
+                    // WASM reactor constructors — native dirty-flag firing only.
+                    constructor: None,
+                }
             });
 
             tracing::debug!(

--- a/crates/cloacina-python/tests/python_reactor_library.rs
+++ b/crates/cloacina-python/tests/python_reactor_library.rs
@@ -280,3 +280,60 @@ class OnlyRx:
         });
     assert_eq!(dispatched, vec!["m3a_only_rx".to_string()]);
 }
+
+/// CLOACI-T-0839: the `@cloaca.reactor` registration carries the module's
+/// AUTHORED accumulator kinds (`@cloaca.state_accumulator(capacity=N)`), so
+/// runtime-walking load paths (packaged Python via the reconciler) spawn the
+/// right accumulator runtime instead of silently degrading to passthrough.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_reactor_registration_carries_authored_accumulator_specs() {
+    pyo3::prepare_freethreaded_python();
+
+    let rt = Arc::new(cloacina::Runtime::empty());
+    let _scope = ScopedRuntime::new(rt.clone()).unwrap();
+
+    Python::with_gil(|py| {
+        let locals = pyo3::types::PyDict::new(py);
+        locals
+            .set_item(
+                "reactor",
+                pyo3::wrap_pyfunction!(py_reactor::reactor, py).unwrap(),
+            )
+            .unwrap();
+        locals
+            .set_item(
+                "state_accumulator",
+                pyo3::wrap_pyfunction!(
+                    cloacina_python::computation_graph::state_accumulator_decorator,
+                    py
+                )
+                .unwrap(),
+            )
+            .unwrap();
+
+        py.run(
+            c_str!(
+                r#"
+@state_accumulator(capacity=5)
+def spec_window(event):
+    return event
+
+@reactor(name="spec_rx", accumulators=["spec_window"], mode="when_any")
+class SpecRx: pass
+"#
+            ),
+            None,
+            Some(&locals),
+        )
+        .unwrap();
+    });
+
+    let reg = rt.get_reactor("spec_rx").expect("reactor registered");
+    let spec = reg
+        .accumulator_specs
+        .iter()
+        .find(|s| s.name == "spec_window")
+        .expect("authored accumulator spec carried on the registration");
+    assert_eq!(spec.accumulator_type, "state");
+    assert_eq!(spec.config.get("capacity").map(|s| s.as_str()), Some("5"));
+}

--- a/crates/cloacina-server/src/routes/health_graphs.rs
+++ b/crates/cloacina-server/src/routes/health_graphs.rs
@@ -709,15 +709,27 @@ pub async fn inject_accumulator(
         }
     }
 
-    // Serialize the typed JSON event to the boundary wire encoding server-side.
-    let boundary = match encode_boundary_input(&req.event) {
+    // CLOACI-T-0839: deliver RAW JSON bytes — the accumulator SOCKET contract
+    // (what the WS producer path sends and what every accumulator runtime
+    // decodes: state's serde_json::from_slice, batch's buffered events, and
+    // passthrough — whose own emit adds the one boundary-frame wrap).
+    // Pre-wrapping in the boundary frame here (the old behavior) double-encoded
+    // through passthrough (the fires log showed undecodable `inputs: null`)
+    // and made state/batch accumulators reject the event outright
+    // ("deserialize error: expected value"). The frame encoding remains
+    // correct for the reactor `fire_with` path, which feeds the boundary
+    // CACHE, not an accumulator socket.
+    let event = match serde_json::to_vec(&req.event) {
         Ok(b) => b,
-        Err(e) => return ApiError::bad_request("invalid_input", e).into_response(),
+        Err(e) => {
+            return ApiError::bad_request("invalid_input", format!("encode event: {}", e))
+                .into_response()
+        }
     };
 
     match state
         .endpoint_registry
-        .send_to_accumulator(&name, boundary)
+        .send_to_accumulator(&name, event)
         .await
     {
         Ok(delivered) => {

--- a/crates/cloacina/src/computation_graph/packaging_bridge.rs
+++ b/crates/cloacina/src/computation_graph/packaging_bridge.rs
@@ -678,20 +678,31 @@ pub async fn dispatch_runtime_reactors_into_scheduler(
             .accumulator_names
             .iter()
             .map(|acc_name| {
-                let factory: Arc<dyn AccumulatorFactory> = match accumulator_overrides
+                // CLOACI-T-0839 precedence: manifest override (deployment wins)
+                // → authored spec carried on the registration → passthrough.
+                // The authored-spec fallback closes the gap where a
+                // runtime-registered reactor's state/stream accumulators
+                // silently degraded to passthrough (this site only had names).
+                let (acc_type, acc_config) = match accumulator_overrides
                     .iter()
                     .find(|cfg| &cfg.name == acc_name)
                 {
-                    Some(override_cfg) => match override_cfg.accumulator_type.as_str() {
-                        "stream" => Arc::new(StreamBackendAccumulatorFactory::new(
-                            override_cfg.config.clone(),
-                        )),
-                        "state" => Arc::new(StateAccumulatorFactory::new(
-                            state_capacity_from_config(&override_cfg.config),
-                        )),
-                        _ => Arc::new(PassthroughAccumulatorFactory),
+                    Some(cfg) => (cfg.accumulator_type.clone(), cfg.config.clone()),
+                    None => match registration
+                        .accumulator_specs
+                        .iter()
+                        .find(|spec| &spec.name == acc_name)
+                    {
+                        Some(spec) => (spec.accumulator_type.clone(), spec.config.clone()),
+                        None => ("passthrough".to_string(), Default::default()),
                     },
-                    None => Arc::new(PassthroughAccumulatorFactory),
+                };
+                let factory: Arc<dyn AccumulatorFactory> = match acc_type.as_str() {
+                    "stream" => Arc::new(StreamBackendAccumulatorFactory::new(acc_config)),
+                    "state" => Arc::new(StateAccumulatorFactory::new(state_capacity_from_config(
+                        &acc_config,
+                    ))),
+                    _ => Arc::new(PassthroughAccumulatorFactory),
                 };
                 AccumulatorDeclaration {
                     name: acc_name.clone(),

--- a/crates/cloacina/src/registry/reconciler/loading.rs
+++ b/crates/cloacina/src/registry/reconciler/loading.rs
@@ -1374,10 +1374,22 @@ impl RegistryReconciler {
                 .accumulator_names
                 .iter()
                 .map(|acc_name| {
+                    // CLOACI-T-0839 precedence: manifest override (deployment
+                    // wins) → authored spec carried on the registration (e.g.
+                    // Python's `@cloaca.state_accumulator`) → passthrough.
+                    // Before the authored-spec fallback existed, packaged
+                    // Python state/stream accumulators silently degraded to
+                    // passthrough here.
                     let (accumulator_type, config) = accumulator_overrides
                         .iter()
                         .find(|cfg| &cfg.name == acc_name)
                         .map(|cfg| (cfg.accumulator_type.clone(), cfg.config.clone()))
+                        .or_else(|| {
+                            reg.accumulator_specs
+                                .iter()
+                                .find(|spec| &spec.name == acc_name)
+                                .map(|spec| (spec.accumulator_type.clone(), spec.config.clone()))
+                        })
                         .unwrap_or_else(|| ("passthrough".to_string(), Default::default()));
                     AccumulatorDeclarationEntry {
                         name: acc_name.clone(),
@@ -2403,6 +2415,7 @@ mod tests {
             cloacina_computation_graph::ReactorRegistration {
                 name: "py_reactor".to_string(),
                 accumulator_names: vec!["src_a".to_string(), "src_b".to_string()],
+                accumulator_specs: vec![],
                 reaction_mode: cloacina_computation_graph::ReactionMode::WhenAny,
                 constructor: None,
             }
@@ -2432,6 +2445,7 @@ mod tests {
             cloacina_computation_graph::ReactorRegistration {
                 name: "preexisting".to_string(),
                 accumulator_names: vec!["x".to_string()],
+                accumulator_specs: vec![],
                 reaction_mode: cloacina_computation_graph::ReactionMode::WhenAny,
                 constructor: None,
             }
@@ -2456,6 +2470,7 @@ mod tests {
             cloacina_computation_graph::ReactorRegistration {
                 name: "py_reactor".to_string(),
                 accumulator_names: vec!["topic_a".to_string()],
+                accumulator_specs: vec![],
                 reaction_mode: cloacina_computation_graph::ReactionMode::WhenAll,
                 constructor: None,
             }
@@ -2477,6 +2492,62 @@ mod tests {
         assert_eq!(acc.accumulator_type, "stream");
         assert_eq!(acc.config.get("topic").map(|s| s.as_str()), Some("events"));
         assert_eq!(view.reactors[0].reaction_mode, "when_all");
+    }
+
+    /// CLOACI-T-0839: an AUTHORED accumulator spec carried on the runtime
+    /// registration (e.g. Python's `@cloaca.state_accumulator(capacity=5)`)
+    /// must reach the view when no manifest override exists — previously this
+    /// silently degraded to passthrough. A manifest override still wins.
+    #[tokio::test]
+    async fn build_view_python_honors_authored_accumulator_specs() {
+        let reconciler = make_test_reconciler();
+        let runtime = runtime_of(&reconciler);
+        runtime.register_reactor("py_state_rx".to_string(), || {
+            let mut config = std::collections::HashMap::new();
+            config.insert("capacity".to_string(), "5".to_string());
+            cloacina_computation_graph::ReactorRegistration {
+                name: "py_state_rx".to_string(),
+                accumulator_names: vec!["py_window".to_string(), "overridden".to_string()],
+                accumulator_specs: vec![
+                    cloacina_computation_graph::AccumulatorSpec {
+                        name: "py_window".to_string(),
+                        accumulator_type: "state".to_string(),
+                        config,
+                    },
+                    cloacina_computation_graph::AccumulatorSpec {
+                        name: "overridden".to_string(),
+                        accumulator_type: "state".to_string(),
+                        config: Default::default(),
+                    },
+                ],
+                reaction_mode: cloacina_computation_graph::ReactionMode::WhenAny,
+                constructor: None,
+            }
+        });
+
+        // Deployment override on the SECOND accumulator — it must beat the
+        // authored spec; the first accumulator uses its authored spec.
+        let overrides = vec![cloacina_workflow_plugin::types::AccumulatorConfig {
+            name: "overridden".to_string(),
+            accumulator_type: "passthrough".to_string(),
+            config: Default::default(),
+        }];
+
+        let (pre_r, pre_t, pre_g) = empty_pre_snapshots();
+        let view = reconciler.build_view_python("py-pkg", &pre_r, &pre_t, &pre_g, &overrides);
+        assert_eq!(view.reactors.len(), 1);
+        let accs = &view.reactors[0].accumulators;
+        let window = accs.iter().find(|a| a.name == "py_window").unwrap();
+        assert_eq!(
+            window.accumulator_type, "state",
+            "authored spec must not degrade to passthrough"
+        );
+        assert_eq!(window.config.get("capacity").map(|s| s.as_str()), Some("5"));
+        let overridden = accs.iter().find(|a| a.name == "overridden").unwrap();
+        assert_eq!(
+            overridden.accumulator_type, "passthrough",
+            "manifest override must beat the authored spec"
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -3058,6 +3129,7 @@ mod tests {
             cloacina_computation_graph::ReactorRegistration {
                 name: "ephemeral_rx".to_string(),
                 accumulator_names: vec!["alpha".to_string()],
+                accumulator_specs: vec![],
                 reaction_mode: cloacina_computation_graph::ReactionMode::WhenAny,
                 constructor: None,
             }

--- a/crates/cloacina/tests/integration/computation_graph.rs
+++ b/crates/cloacina/tests/integration/computation_graph.rs
@@ -2180,6 +2180,7 @@ async fn test_cloaci_t_0538_split_form_scheduler_end_to_end() {
     let reactor_reg = ReactorRegistration {
         name: "cloaci_t_0538_reactor_split".to_string(),
         accumulator_names: vec!["alpha".to_string()],
+        accumulator_specs: vec![],
         reaction_mode: ComputationReactionMode::WhenAny,
         constructor: None,
     };
@@ -2274,6 +2275,7 @@ async fn test_cloaci_t_0538_split_missing_accumulator_fails() {
     let reactor_reg = ReactorRegistration {
         name: "cloaci_t_0538_broken_reactor".to_string(),
         accumulator_names: vec!["alpha".to_string()],
+        accumulator_specs: vec![],
         reaction_mode: ComputationReactionMode::WhenAny,
         constructor: None,
     };
@@ -2337,6 +2339,7 @@ async fn test_cloaci_t_0544_two_graphs_share_one_reactor_via_split_form() {
     let reactor_reg = ReactorRegistration {
         name: "cloaci_t_0544_shared_reactor".to_string(),
         accumulator_names: vec!["alpha".to_string()],
+        accumulator_specs: vec![],
         reaction_mode: ComputationReactionMode::WhenAny,
         constructor: None,
     };
@@ -2437,6 +2440,7 @@ async fn test_cloaci_t_0544_contract_mismatch_rejected() {
     let reactor_v1 = ReactorRegistration {
         name: "cloaci_t_0544_clash".to_string(),
         accumulator_names: vec!["alpha".to_string()],
+        accumulator_specs: vec![],
         reaction_mode: ComputationReactionMode::WhenAny,
         constructor: None,
     };
@@ -2458,6 +2462,7 @@ async fn test_cloaci_t_0544_contract_mismatch_rejected() {
     let reactor_v2 = ReactorRegistration {
         name: "cloaci_t_0544_clash".to_string(),
         accumulator_names: vec!["alpha".to_string()],
+        accumulator_specs: vec![],
         reaction_mode: ComputationReactionMode::WhenAll,
         constructor: None,
     };
@@ -2549,6 +2554,7 @@ async fn test_cloaci_t_0544_dispatch_is_concurrent() {
     let reactor_reg = ReactorRegistration {
         name: "cloaci_t_0544_concurrent_reactor".to_string(),
         accumulator_names: vec!["alpha".to_string()],
+        accumulator_specs: vec![],
         reaction_mode: ComputationReactionMode::WhenAny,
         constructor: None,
     };
@@ -2774,6 +2780,7 @@ async fn test_cloaci_t_0544_unbind_keeps_reactor_running() {
     let reactor_reg = ReactorRegistration {
         name: "cloaci_t_0544_unbind_reactor".to_string(),
         accumulator_names: vec!["alpha".to_string()],
+        accumulator_specs: vec![],
         reaction_mode: ComputationReactionMode::WhenAny,
         constructor: None,
     };
@@ -2848,6 +2855,7 @@ async fn test_cloaci_t_0544_unload_reactor_rejects_with_subscribers() {
     let reactor_reg = ReactorRegistration {
         name: "cloaci_t_0544_busy_reactor".to_string(),
         accumulator_names: vec!["alpha".to_string()],
+        accumulator_specs: vec![],
         reaction_mode: ComputationReactionMode::WhenAny,
         constructor: None,
     };
@@ -2914,6 +2922,7 @@ async fn test_cloaci_t_0538_runtime_reactor_registry_shape() {
         cloacina::ReactorRegistration {
             name: "cloaci_t_0538_reactor_split".to_string(),
             accumulator_names: vec!["alpha".to_string()],
+            accumulator_specs: vec![],
             reaction_mode: cloacina::ComputationReactionMode::WhenAny,
             constructor: None,
         }


### PR DESCRIPTION
## T-0839 (P1) — two real bugs, one live proof

**Bug 1 — silent passthrough degradation.** The names-only reactor dispatch (`runtime.get_reactor` → `accumulator_names`) had no way to learn an accumulator's authored kind, so packaged Python `@cloaca.state_accumulator(capacity=N)` silently spawned as **passthrough** server-side — windowing/state semantics vanished with no error (found live while verifying T-0744: `py_window` fired per-event with zero buffer).

Fix: new `AccumulatorSpec` carried on `ReactorRegistration.accumulator_specs`; the `@cloaca.reactor` registration closure resolves specs lazily from the module's accumulator decorators (declaration-order-proof), and both consumers (`build_view_python` + the names-only dispatch) resolve with precedence **manifest override → authored spec → passthrough**.

**Bug 2 — REST inject encoding (uncovered by the retest).** The inject route pre-wrapped events in the bincode boundary frame, violating the accumulator **socket contract** (raw JSON bytes — what the WS producer sends and every runtime decodes). This made state/batch accumulators reject REST injects outright, and double-encoded through passthrough — finally explaining the long-standing undecodable `inputs: null` in the fires log. Fix: inject sends raw JSON; the frame encoding stays on the reactor `fire_with` path (boundary cache, where frames are correct).

**Live proof (demo stack):** `py_window` (state, capacity=5) after 3 REST injects → `buffer_depth=3 / buffer_capacity=5` in **both** `/v1/health/accumulators` and the Prometheus gauge, reactor firing per ingest on real windowed boundaries. Closes T-0839's ACs and demonstrates T-0744's deferred N/5 AC.

**Tests:** `build_view_python_honors_authored_accumulator_specs` (spec survives; override still wins) · `test_reactor_registration_carries_authored_accumulator_specs` (py decorators → registration carries state/capacity=5) · reconciler + python-reactor suites green; all crates incl. integration tests compile clean.

**Known residual (noted in Metis):** the fires-log input *capture* decodes only `bincode(json_bytes)` frames; state accumulators emit typed `bincode(Vec<Value>)` frames, so their captured inputs still render `null` — cosmetic capture gap, separate follow-up.

https://claude.ai/code/session_01VWpWbgCzNdQkFT74S3wPRM