### PR TITLE
feat(T-0664): demo covers the poll-trigger kind + fires the manual trigger in seed

### DIFF
--- a/.metis/backlog/features/CLOACI-T-0664.md
+++ b/.metis/backlog/features/CLOACI-T-0664.md
@@ -3,16 +3,16 @@ id: seed-demo-harness-exercise-every
 level: task
 title: "Seed/demo harness: exercise every UI surface — triggers, computation graphs/reactors, and Python packages"
 short_code: "CLOACI-T-0664"
-created_at: 2026-06-12T02:18:00.000000+00:00
-updated_at: 2026-06-12T02:18:00.000000+00:00
-parent: 
+created_at: 2026-06-12T02:18:00+00:00
+updated_at: 2026-07-05T18:00:18.465618+00:00
+parent:
 blocked_by: []
 archived: false
 
 tags:
   - "#task"
-  - "#phase/backlog"
   - "#feature"
+  - "#phase/completed"
 
 
 exit_criteria_met: false
@@ -42,6 +42,12 @@ demo compose), not host processes.
 - **User Value**: A demo where you can actually *see* triggers firing on a
   schedule, a computation graph + its accumulators, and both Rust and Python
   packages — the full control plane, not just task workflows.
+
+## Acceptance Criteria
+
+## Acceptance Criteria
+
+## Acceptance Criteria
 
 ## Acceptance Criteria **[REQUIRED]**
 
@@ -117,3 +123,9 @@ register *and* fire through the server, not only the daemon.
 4. `docker compose -f docker/docker-compose.demo.yml up --build` → verify
    Workflows + Executions + Triggers + Graphs + Accumulators populate (Rust +
    Python); file any view that doesn't.
+
+### 2026-07-05 — CLOSING: the plan was delivered incrementally across weeks; the two residual gaps closed today (branch feat/t0664-demo-surface-gaps, commit 396c0208)
+The fixture set grew far past the original ask — the demo now packs and seeds: cron trigger (demo-cron-rust), branch/skip (demo-branch-rust), mixed reactor+accumulator+CG+trigger (mixed-rust), manual-trigger fan-out across two packages (demo-fanout-rust/-sub), acme multi-tenant, kafka stream CG, routing CG, complex DAG, Python task/CG/state/cron packages, and both constructor demos (Rust + Python) — all in Docker via pack-demo-fixtures.sh + the compose stack. A verification sweep (2026-07-05) found exactly two residual gaps, both closed today:
+1. **Poll-trigger kind absent from the demo** — `demo-poll-rust` existed but was never packed. Added to pack-demo-fixtures.sh; verified live: `demo_poll_trigger` registered with `poll_interval_ms=30000` in `/v1/tenants/public/triggers`.
+2. **The harness never FIRED the manual trigger** — seed mode now fires `settlement_close` once with a typed event (best-effort on cold stacks); verified live: `settle_ledger` execution Completed with `trigger_origin: "manual"` (the gold manual pill).
+All five ACs met: trigger fixture(s) across all three kinds ✓ · CG fixtures (Rust + Python + kafka + routing) ✓ · Python packages (task/CG/state/cron) ✓ · Docker-native packing/upload ✓ · live-verified per view, with gaps filed separately as they surfaced (T-0744 gauges, T-0839 state-accumulator degradation — both since fixed). COMPLETE.

--- a/docker/pack-demo-fixtures.sh
+++ b/docker/pack-demo-fixtures.sh
@@ -92,6 +92,10 @@ pack_rust_rel mixed-rust
 #     one operator "fire" fans out to both. Publisher (declares the trigger) must
 #     pack/register before the subscriber; "demo-fanout-rust" sorts before
 #     "demo-fanout-sub-rust" and the harness uploads in sorted order. ---
+# --- Poll trigger (Rust) — a 30s poll_interval trigger so the Triggers view
+#     shows the poll-driven kind alongside cron + manual (CLOACI-T-0664). ---
+pack_rust_ws demo-poll-rust
+
 pack_rust_ws demo-fanout-rust
 pack_rust_ws demo-fanout-sub-rust
 

--- a/ui/harness/src/main.mjs
+++ b/ui/harness/src/main.mjs
@@ -246,6 +246,20 @@ async function seed(client) {
   const liveId = await executeReady(client, cfg.slowWorkflow, {});
   log(`in-flight-run: ${liveId} (left running at natural pace)`);
 
+  // 4) MANUAL TRIGGER FIRE (CLOACI-T-0664) — fire the manual-only
+  //    `settlement_close` trigger once so the demo shows an operator fire
+  //    fanning out to its subscribed workflows (gold "manual" pill on the
+  //    started runs). Best-effort: the fan-out packages may still be
+  //    compiling on a cold stack; a miss is logged, not fatal.
+  try {
+    await client.fireTrigger("settlement_close", {
+      event: { region: "eu-west", as_of_date: new Date().toISOString().slice(0, 10) },
+    });
+    log("manual-fire: settlement_close → fanned out to subscribed workflows");
+  } catch (err) {
+    log(`manual-fire: settlement_close skipped (${err?.message ?? err})`);
+  }
+
   log("seed complete:");
   log(`  completed = ${doneId} (${doneStatus})`);
   log(`  failed    = ${failId} (${failStatus})`);


### PR DESCRIPTION
Closes the last two gaps in the demo's UI-surface coverage (T-0664 — the rest of its scope was delivered incrementally across the fixture work of the past weeks):

- **pack-demo-fixtures**: pack `demo-poll-rust` (30s `poll_interval`) so the Triggers view shows the poll-driven kind alongside cron + manual. Verified live: `demo_poll_trigger` registered with `poll_interval_ms=30000`.
- **harness seed**: fire the manual-only `settlement_close` trigger once with a typed event, so the demo shows an operator fire fanning out to its subscribers. Verified live: `settle_ledger` Completed with `trigger_origin: "manual"`. Best-effort on cold stacks (fan-out packages may still be compiling).

Metis: T-0664 → completed with the full coverage inventory.

https://claude.ai/code/session_01VWpWbgCzNdQkFT74S3wPRM