### PR TITLE
fix(T-0754): Python task what/why docstrings survive to the API

### DIFF
--- a/.metis/backlog/bugs/CLOACI-T-0840.md
+++ b/.metis/backlog/bugs/CLOACI-T-0840.md
@@ -1,0 +1,139 @@
+---
+id: in-place-python-package-version
+level: task
+title: "In-place Python package version upgrade silently loses tasks (module re-import is a no-op in the live interpreter)"
+short_code: "CLOACI-T-0840"
+created_at: 2026-07-05T20:00:01.551787+00:00
+updated_at: 2026-07-05T20:00:01.551787+00:00
+parent:
+blocked_by: []
+archived: false
+
+tags:
+  - "#task"
+  - "#phase/backlog"
+  - "#bug"
+
+
+exit_criteria_met: false
+initiative_id: NULL
+---
+
+# In-place Python package version upgrade silently loses tasks (module re-import is a no-op in the live interpreter)
+
+*This template includes sections for various types of tasks. Delete sections that don't apply to your specific use case.*
+
+## Parent Initiative **[CONDITIONAL: Assigned Task]**
+
+[[Parent Initiative]]
+
+## Objective **[REQUIRED]**
+
+Upgrading a Python package IN PLACE on a running server (upload v-next of an already-loaded package name) silently produces an **empty workflow**: the reconciler unloads the old version, imports the new one — but the Python module import is a **no-op** (already in `sys.modules` from the previous version's load), so the `@cloaca.task` decorators never re-run, the fresh scoped Runtime registers 0 tasks, and the loader misclassifies the package as a "reactor library" ("no workflow tasks"). No error anywhere; a server restart fixes it (fresh interpreter → real import).
+
+## Live evidence (2026-07-05, found while verifying T-0754)
+
+Uploading `demo-py-workflow` 0.1.1 to a server that had loaded 0.1.0 at boot:
+```
+Unloaded package: demo-py-workflow v0.1.0
+Reconciler: loading demo-py-workflow v0.1.1
+cloacina_python::loader: Python reactor-library package imported: 2 reactors, no workflow tasks (public::demo-py-workflow::demo_py_workflow)
+Python package loaded: demo-py-workflow v0.1.1 — 0 tasks, workflow 'demo_py_workflow'
+```
+The API then serves `tasks: []` for the workflow. After `docker compose restart server`, the same 0.1.1 row loads with all 4 tasks.
+
+## Why
+
+The agent already knows this trap — `cloacina-agent/src/main.rs` (process_work_packet) caches per-digest runtimes precisely because "re-importing a Python module in a live interpreter is a no-op (so the @task decorators wouldn't re-run and the new Runtime would be empty)". The SERVER's reconciler path (`python_runtime::load_workflow_package` → module import) has no such guard: the second load of the same module name reuses the cached module, whose decorators ran against the PREVIOUS load's scoped runtime.
+
+## Fix directions (pick at implementation)
+
+1. **Evict before re-import**: on package unload (or before the new version's import), drop the package's modules from `sys.modules` (the staging dir gives the module names) so the new import re-executes. Watch for stale references held by running tasks — coordinate with the unload lifecycle.
+2. **Version-namespaced staging/import**: import the new version under a version-suffixed module path (unique `sys.path` root per (package, version), e.g. via `importlib.util` with an explicit name), so imports never collide across versions.
+3. **Detect + refuse loudly** (stopgap): if a Python package load registers 0 tasks for a package whose metadata says it HAS tasks, fail the load with a clear "restart required / module cached" error instead of silently loading an empty workflow.
+
+### Type
+- [x] Bug - Production issue that needs fixing
+
+### Priority
+- [x] P1 - High (a routine version upgrade silently breaks the workflow until someone restarts the server)
+
+### Impact Assessment
+- **Affected Users**: anyone upgrading a Python package version on a live cloacina-server without a restart.
+- **Reproduction Steps**:
+  1. Seed the demo stack; let a Python package (e.g. demo-py-workflow 0.1.0) load.
+  2. Upload the same package as 0.1.1 (any change).
+  3. After build+reconcile: `GET /v1/tenants/public/workflows/demo-py-workflow` → `tasks: []`; executes fail/no-op.
+- **Expected vs Actual**: expected the new version to load with its tasks; actual silent empty workflow until a server restart.
+
+## Acceptance Criteria **[REQUIRED]**
+
+- [ ] Uploading v-next of a loaded Python package results in the new version's tasks registered and executable WITHOUT a server restart.
+- [ ] The task graph + docs persist for the new version (same as a fresh load).
+- [ ] Regression test covering the same-name re-import upgrade path.
+- [ ] If a hard fix is deferred, the stopgap loud-failure (option 3) replaces the silent empty load.
+
+## Test Cases **[CONDITIONAL: Testing Task]**
+
+{Delete unless this is a testing task}
+
+### Test Case 1: {Test Case Name}
+- **Test ID**: TC-001
+- **Preconditions**: {What must be true before testing}
+- **Steps**:
+  1. {Step 1}
+  2. {Step 2}
+  3. {Step 3}
+- **Expected Results**: {What should happen}
+- **Actual Results**: {To be filled during execution}
+- **Status**: {Pass/Fail/Blocked}
+
+### Test Case 2: {Test Case Name}
+- **Test ID**: TC-002
+- **Preconditions**: {What must be true before testing}
+- **Steps**:
+  1. {Step 1}
+  2. {Step 2}
+- **Expected Results**: {What should happen}
+- **Actual Results**: {To be filled during execution}
+- **Status**: {Pass/Fail/Blocked}
+
+## Documentation Sections **[CONDITIONAL: Documentation Task]**
+
+{Delete unless this is a documentation task}
+
+### User Guide Content
+- **Feature Description**: {What this feature does and why it's useful}
+- **Prerequisites**: {What users need before using this feature}
+- **Step-by-Step Instructions**:
+  1. {Step 1 with screenshots/examples}
+  2. {Step 2 with screenshots/examples}
+  3. {Step 3 with screenshots/examples}
+
+### Troubleshooting Guide
+- **Common Issue 1**: {Problem description and solution}
+- **Common Issue 2**: {Problem description and solution}
+- **Error Messages**: {List of error messages and what they mean}
+
+### API Documentation **[CONDITIONAL: API Documentation]**
+- **Endpoint**: {API endpoint description}
+- **Parameters**: {Required and optional parameters}
+- **Example Request**: {Code example}
+- **Example Response**: {Expected response format}
+
+## Implementation Notes **[CONDITIONAL: Technical Task]**
+
+{Keep for technical tasks, delete for non-technical. Technical details, approach, or important considerations}
+
+### Technical Approach
+{How this will be implemented}
+
+### Dependencies
+{Other tasks or systems this depends on}
+
+### Risk Considerations
+{Technical risks and mitigation strategies}
+
+## Status Updates **[REQUIRED]**
+
+*To be added during implementation*

--- a/.metis/backlog/features/CLOACI-T-0664.md
+++ b/.metis/backlog/features/CLOACI-T-0664.md
@@ -3,16 +3,16 @@ id: seed-demo-harness-exercise-every
 level: task
 title: "Seed/demo harness: exercise every UI surface — triggers, computation graphs/reactors, and Python packages"
 short_code: "CLOACI-T-0664"
-created_at: 2026-06-12T02:18:00.000000+00:00
-updated_at: 2026-06-12T02:18:00.000000+00:00
-parent: 
+created_at: 2026-06-12T02:18:00+00:00
+updated_at: 2026-07-05T18:00:18.465618+00:00
+parent:
 blocked_by: []
 archived: false
 
 tags:
   - "#task"
-  - "#phase/backlog"
   - "#feature"
+  - "#phase/completed"
 
 
 exit_criteria_met: false
@@ -42,6 +42,12 @@ demo compose), not host processes.
 - **User Value**: A demo where you can actually *see* triggers firing on a
   schedule, a computation graph + its accumulators, and both Rust and Python
   packages — the full control plane, not just task workflows.
+
+## Acceptance Criteria
+
+## Acceptance Criteria
+
+## Acceptance Criteria
 
 ## Acceptance Criteria **[REQUIRED]**
 
@@ -117,3 +123,9 @@ register *and* fire through the server, not only the daemon.
 4. `docker compose -f docker/docker-compose.demo.yml up --build` → verify
    Workflows + Executions + Triggers + Graphs + Accumulators populate (Rust +
    Python); file any view that doesn't.
+
+### 2026-07-05 — CLOSING: the plan was delivered incrementally across weeks; the two residual gaps closed today (branch feat/t0664-demo-surface-gaps, commit 396c0208)
+The fixture set grew far past the original ask — the demo now packs and seeds: cron trigger (demo-cron-rust), branch/skip (demo-branch-rust), mixed reactor+accumulator+CG+trigger (mixed-rust), manual-trigger fan-out across two packages (demo-fanout-rust/-sub), acme multi-tenant, kafka stream CG, routing CG, complex DAG, Python task/CG/state/cron packages, and both constructor demos (Rust + Python) — all in Docker via pack-demo-fixtures.sh + the compose stack. A verification sweep (2026-07-05) found exactly two residual gaps, both closed today:
+1. **Poll-trigger kind absent from the demo** — `demo-poll-rust` existed but was never packed. Added to pack-demo-fixtures.sh; verified live: `demo_poll_trigger` registered with `poll_interval_ms=30000` in `/v1/tenants/public/triggers`.
+2. **The harness never FIRED the manual trigger** — seed mode now fires `settlement_close` once with a typed event (best-effort on cold stacks); verified live: `settle_ledger` execution Completed with `trigger_origin: "manual"` (the gold manual pill).
+All five ACs met: trigger fixture(s) across all three kinds ✓ · CG fixtures (Rust + Python + kafka + routing) ✓ · Python packages (task/CG/state/cron) ✓ · Docker-native packing/upload ✓ · live-verified per view, with gaps filed separately as they surfaced (T-0744 gauges, T-0839 state-accumulator degradation — both since fixed). COMPLETE.

--- a/.metis/backlog/features/CLOACI-T-0754.md
+++ b/.metis/backlog/features/CLOACI-T-0754.md
@@ -4,15 +4,15 @@ level: task
 title: "Pure-Python what/why doc persistence — carry parsed docs through the reconciler path"
 short_code: "CLOACI-T-0754"
 created_at: 2026-06-20T15:20:28.309039+00:00
-updated_at: 2026-06-20T15:20:28.309039+00:00
+updated_at: 2026-07-05T20:01:28.640977+00:00
 parent:
 blocked_by: []
 archived: false
 
 tags:
   - "#task"
-  - "#phase/backlog"
   - "#feature"
+  - "#phase/completed"
 
 
 exit_criteria_met: false
@@ -64,6 +64,12 @@ available at reconcile time.
 
 ## Acceptance Criteria
 
+## Acceptance Criteria
+
+## Acceptance Criteria
+
+## Acceptance Criteria
+
 - [ ] A pure-Python package's `@task` docstrings (what:/why:) surface on
       `WorkflowTaskNode.doc_what` / `doc_why` via the API, matching Rust behavior.
 - [ ] Undocumented Python tasks remain typed `None` (no regression).
@@ -78,4 +84,11 @@ available at reconcile time.
 
 ## Status Updates
 
-*To be added during implementation*
+### 2026-07-05 — DONE via option (1), LIVE-VERIFIED (branch fix/t0754-py-task-docs, commit d032165a)
+Option (1) won over the sketched option (2): no re-parse, no crate lift — the build already has the docs; they just needed a durable home. `PackageMetadata` gains a raw `task_docs: HashMap<String, TaskDocs>` (serde-default), persisted by `mark_build_success_with_docs` on BOTH merge branches (the Python `compiled.is_empty()` branch previously early-returned unless params/surfaces existed — the regression test caught that on its first run); `persist_task_graph_db` re-merges docs per task id when it writes the Python task list at load (previously hardcoded `doc_what/doc_why: None`). Rust behavior unchanged.
+
+**Tests**: `test_python_task_docs_survive_load_time_task_rewrite` (sqlite in-memory, mirrors the real py flow: empty tasks at build → docs stored → load-time rewrite → docs surface per task; undocumented stays None). All crates + test tree compile clean.
+
+**LIVE PROOF (demo stack)**: `demo-py-workflow` gained what:/why: docstrings on `prepare`/`transform`; uploaded as 0.1.1 → built → loaded → `GET /v1/tenants/public/workflows/demo-py-workflow` task_graph node: `"id":"prepare","doc_what":"Stage the demo batch — seed the context the downstream fan-out reads.","doc_why":"Every branch keys off the prepared flags; ..."` — Python parity with Rust achieved.
+
+**Bonus find**: the live verification exposed [[CLOACI-T-0840]] (P1): in-place Python package version upgrades silently lose their tasks (module re-import is a no-op in the live interpreter — the trap the AGENT guards against but the server reconciler doesn't); worked around via server restart for the proof, filed with full evidence + fix directions. COMPLETE.

--- a/crates/cloacina-agent/src/main.rs
+++ b/crates/cloacina-agent/src/main.rs
@@ -1181,6 +1181,7 @@ fn synthetic_package_metadata(
         // interface here (CLOACI-I-0128).
         declared_params: vec![],
         declared_surfaces: vec![],
+        task_docs: Default::default(),
     }
 }
 

--- a/crates/cloacina/src/dal/unified/workflow_packages.rs
+++ b/crates/cloacina/src/dal/unified/workflow_packages.rs
@@ -1562,6 +1562,7 @@ mod tests {
             workflow_triggers: vec![],
             declared_params: vec![],
             declared_surfaces: vec![],
+            task_docs: Default::default(),
         }
     }
 

--- a/crates/cloacina/src/registry/loader/package_loader.rs
+++ b/crates/cloacina/src/registry/loader/package_loader.rs
@@ -83,6 +83,15 @@ pub struct PackageMetadata {
     /// or the package predates the entrypoint.
     #[serde(default)]
     pub declared_surfaces: Vec<cloacina_api_types::DeclaredSurface>,
+    /// CLOACI-T-0754: the compiler's raw build-time doc parse (`what`/`why` per
+    /// local task id), preserved verbatim so load paths that rebuild the task
+    /// list AFTER build — the Python path has no cdylib, so its `tasks` are
+    /// written by the reconciler at load — can re-merge docs instead of losing
+    /// them. Rust packages get their docs overlaid onto `tasks` at build; this
+    /// map is the durable source either way. Empty for undocumented packages
+    /// and metadata predating the field.
+    #[serde(default)]
+    pub task_docs: std::collections::HashMap<String, TaskDocs>,
 }
 
 /// Individual task metadata.
@@ -403,6 +412,8 @@ impl PackageLoader {
             // (extract_metadata_from_so); empty here.
             declared_params: Vec::new(),
             declared_surfaces: Vec::new(),
+            // Docs come from the compiler parse at build success (T-0754).
+            task_docs: Default::default(),
         })
     }
 

--- a/crates/cloacina/src/registry/loader/task_registrar/mod.rs
+++ b/crates/cloacina/src/registry/loader/task_registrar/mod.rs
@@ -315,6 +315,7 @@ mod tests {
             workflow_triggers: Vec::new(),
             declared_params: Vec::new(),
             declared_surfaces: Vec::new(),
+            task_docs: Default::default(),
         }
     }
 

--- a/crates/cloacina/src/registry/workflow_registry/database.rs
+++ b/crates/cloacina/src/registry/workflow_registry/database.rs
@@ -1465,8 +1465,13 @@ impl<S: RegistryStorage> WorkflowRegistryImpl<S> {
             // Pure-Python packages have no cdylib to extract from. CLOACI-T-0760:
             // if the compiler parsed declared params from the Python source,
             // persist them onto the stored (manifest-derived) metadata — this is
-            // the Python parity carry path. Nothing else to merge.
-            if source_declared_params.is_empty() && source_declared_surfaces.is_empty() {
+            // the Python parity carry path. CLOACI-T-0754: the docstring
+            // what/why parse rides the same carry (persist_task_graph_db
+            // re-merges it when it writes the task list at load).
+            if source_declared_params.is_empty()
+                && source_declared_surfaces.is_empty()
+                && task_docs.is_empty()
+            {
                 return Ok(None);
             }
             let pid = UniversalUuid(package_id);
@@ -1516,6 +1521,10 @@ impl<S: RegistryStorage> WorkflowRegistryImpl<S> {
             merged.declared_params = source_declared_params.to_vec();
             // CLOACI-T-0770: carry source-parsed CG boundary surfaces too.
             merged.declared_surfaces = source_declared_surfaces.to_vec();
+            // CLOACI-T-0754: preserve the raw docstring parse — the Python
+            // task list doesn't exist yet (written at load by
+            // persist_task_graph_db, which merges docs from this map).
+            merged.task_docs = task_docs.clone();
             let json = serde_json::to_string(&merged).map_err(RegistryError::Serialization)?;
             return Ok(Some(json));
         }
@@ -1602,6 +1611,10 @@ impl<S: RegistryStorage> WorkflowRegistryImpl<S> {
                 }
             }
         }
+        // CLOACI-T-0754: also persist the RAW doc map. Python packages have no
+        // tasks at build time (no cdylib) — their task list is written later by
+        // persist_task_graph_db, which re-merges docs from this map.
+        merged.task_docs = task_docs.clone();
 
         let json = serde_json::to_string(&merged).map_err(RegistryError::Serialization)?;
         Ok(Some(json))
@@ -1688,9 +1701,11 @@ impl<S: RegistryStorage> WorkflowRegistryImpl<S> {
                 dependencies: deps.clone(),
                 description: String::new(),
                 source_location: String::new(),
-                // Python doc carry is a deferred follow-up (CLOACI-T-0752).
-                doc_what: None,
-                doc_why: None,
+                // CLOACI-T-0754: re-merge the compiler's build-time doc parse
+                // (stored on the metadata by mark_build_success_with_docs) so
+                // Python docstring what/why survive the load-time task rewrite.
+                doc_what: merged.task_docs.get(id).and_then(|d| d.what.clone()),
+                doc_why: merged.task_docs.get(id).and_then(|d| d.why.clone()),
             })
             .collect();
 
@@ -2349,6 +2364,7 @@ mod tests {
             workflow_triggers: vec![],
             declared_params: vec![],
             declared_surfaces: vec![],
+            task_docs: Default::default(),
         }
     }
 
@@ -2381,6 +2397,74 @@ mod tests {
         assert_eq!(reg_id, registry_id);
         assert_eq!(retrieved.package_name, "reg-pkg");
         assert_eq!(retrieved.version, "1.0.0");
+    }
+
+    /// CLOACI-T-0754: Python packages have NO tasks at build time (no cdylib) —
+    /// their task list is written later by persist_task_graph_db. The compiler's
+    /// docstring parse must survive that rewrite: mark_build_success_with_docs
+    /// stores the raw docs map on the metadata, and the load-time task rewrite
+    /// re-merges it. Mirrors the real py flow: upload (tasks empty) → build with
+    /// docs → reconciler persists the task graph → docs surface per task.
+    #[cfg(feature = "sqlite")]
+    #[tokio::test]
+    async fn test_python_task_docs_survive_load_time_task_rewrite() {
+        use crate::registry::loader::package_loader::TaskDocs;
+
+        let registry = create_test_registry().await;
+        let registry_id = Uuid::new_v4().to_string();
+        // Python-style row: no tasks at upload/build time.
+        let mut meta = sample_metadata("py-docs-pkg", "1.0.0");
+        meta.tasks = vec![];
+        let pkg_id = registry
+            .store_package_metadata(&registry_id, &meta)
+            .await
+            .unwrap();
+        registry.claim_next_build().await.unwrap();
+
+        let mut docs = std::collections::HashMap::new();
+        docs.insert(
+            "prepare".to_string(),
+            TaskDocs {
+                what: Some("Stage the batch".to_string()),
+                why: Some("Bad seeds fail the run".to_string()),
+            },
+        );
+        registry
+            .mark_build_success_with_docs(pkg_id, Vec::new(), docs, Vec::new(), Vec::new())
+            .await
+            .unwrap();
+
+        // The reconciler writes the task graph at load (the step that previously
+        // clobbered docs with None).
+        registry
+            .persist_task_graph_db(
+                pkg_id.into(),
+                vec![
+                    ("prepare".to_string(), vec![]),
+                    ("undocumented".to_string(), vec!["prepare".to_string()]),
+                ],
+            )
+            .await
+            .unwrap();
+
+        let (_, retrieved, _) = registry
+            .get_package_metadata("py-docs-pkg", "1.0.0")
+            .await
+            .unwrap()
+            .unwrap();
+        let prepare = retrieved
+            .tasks
+            .iter()
+            .find(|t| t.local_id == "prepare")
+            .expect("prepare task persisted");
+        assert_eq!(prepare.doc_what.as_deref(), Some("Stage the batch"));
+        assert_eq!(prepare.doc_why.as_deref(), Some("Bad seeds fail the run"));
+        let undoc = retrieved
+            .tasks
+            .iter()
+            .find(|t| t.local_id == "undocumented")
+            .unwrap();
+        assert!(undoc.doc_what.is_none() && undoc.doc_why.is_none());
     }
 
     #[cfg(feature = "sqlite")]

--- a/crates/cloacina/src/registry/workflow_registry/mod.rs
+++ b/crates/cloacina/src/registry/workflow_registry/mod.rs
@@ -529,6 +529,8 @@ impl<S: RegistryStorage + Send + Sync> WorkflowRegistry for WorkflowRegistryImpl
             // entrypoint (CLOACI-I-0128); empty at upload.
             declared_params: vec![],
             declared_surfaces: vec![],
+            // Filled at build success from the compiler doc parse (CLOACI-T-0754).
+            task_docs: Default::default(),
         };
 
         let registry_id = self.storage.store_binary(package_data).await?;

--- a/crates/cloacina/tests/integration/dal/workflow_packages.rs
+++ b/crates/cloacina/tests/integration/dal/workflow_packages.rs
@@ -46,6 +46,7 @@ async fn test_store_and_get_package_metadata() {
         workflow_triggers: vec![],
         declared_params: vec![],
         declared_surfaces: vec![],
+        task_docs: Default::default(),
     };
 
     // Create a corresponding workflow_registry entry first
@@ -107,6 +108,7 @@ async fn test_store_duplicate_package_metadata() {
         workflow_triggers: vec![],
         declared_params: vec![],
         declared_surfaces: vec![],
+        task_docs: Default::default(),
     };
 
     // Create a corresponding workflow_registry entry first
@@ -187,6 +189,7 @@ async fn test_list_all_packages() {
             workflow_triggers: vec![],
             declared_params: vec![],
             declared_surfaces: vec![],
+            task_docs: Default::default(),
         };
 
         package_names.push(test_metadata.package_name.clone());
@@ -239,6 +242,7 @@ async fn test_delete_package_metadata() {
         workflow_triggers: vec![],
         declared_params: vec![],
         declared_surfaces: vec![],
+        task_docs: Default::default(),
     };
 
     // Create a corresponding workflow_registry entry first
@@ -375,6 +379,7 @@ async fn test_store_package_with_complex_metadata() {
         workflow_triggers: vec![],
         declared_params: vec![],
         declared_surfaces: vec![],
+        task_docs: Default::default(),
     };
 
     // Create a corresponding workflow_registry entry first
@@ -451,6 +456,7 @@ async fn test_store_package_with_invalid_uuid() {
         workflow_triggers: vec![],
         declared_params: vec![],
         declared_surfaces: vec![],
+        task_docs: Default::default(),
     };
 
     // Try to store with invalid UUID
@@ -514,6 +520,7 @@ async fn test_package_versioning() {
         workflow_triggers: vec![],
         declared_params: vec![],
         declared_surfaces: vec![],
+        task_docs: Default::default(),
     };
     workflow_packages_dal
         .store_package_metadata(&registry_id, &meta_v1, storage_type, None)

--- a/docker/pack-demo-fixtures.sh
+++ b/docker/pack-demo-fixtures.sh
@@ -92,6 +92,10 @@ pack_rust_rel mixed-rust
 #     one operator "fire" fans out to both. Publisher (declares the trigger) must
 #     pack/register before the subscriber; "demo-fanout-rust" sorts before
 #     "demo-fanout-sub-rust" and the harness uploads in sorted order. ---
+# --- Poll trigger (Rust) — a 30s poll_interval trigger so the Triggers view
+#     shows the poll-driven kind alongside cron + manual (CLOACI-T-0664). ---
+pack_rust_ws demo-poll-rust
+
 pack_rust_ws demo-fanout-rust
 pack_rust_ws demo-fanout-sub-rust
 

--- a/examples/fixtures/demo-py-workflow/workflow/demo_py_workflow/tasks.py
+++ b/examples/fixtures/demo-py-workflow/workflow/demo_py_workflow/tasks.py
@@ -22,12 +22,22 @@ import cloaca
 )
 @cloaca.task(dependencies=[])
 def prepare(context):
+    """what: Stage the demo batch — seed the context the downstream fan-out reads.
+
+    why: Every branch keys off the prepared flags; a bad seed fails the whole run,
+    so preparation is its own observable step. (CLOACI-T-0754: demonstrates Python
+    what/why docstrings surfacing in the UI like Rust doc comments.)
+    """
     context.set("demo_py_prepare", True)
     return context
 
 
 @cloaca.task(dependencies=["prepare"])
 def transform(context):
+    """what: Apply the demo transformation to the prepared batch.
+
+    why: Runs in parallel with validate to demonstrate the fan-out shape.
+    """
     context.set("demo_py_transform", True)
     return context
 

--- a/ui/harness/src/main.mjs
+++ b/ui/harness/src/main.mjs
@@ -246,6 +246,20 @@ async function seed(client) {
   const liveId = await executeReady(client, cfg.slowWorkflow, {});
   log(`in-flight-run: ${liveId} (left running at natural pace)`);
 
+  // 4) MANUAL TRIGGER FIRE (CLOACI-T-0664) — fire the manual-only
+  //    `settlement_close` trigger once so the demo shows an operator fire
+  //    fanning out to its subscribed workflows (gold "manual" pill on the
+  //    started runs). Best-effort: the fan-out packages may still be
+  //    compiling on a cold stack; a miss is logged, not fatal.
+  try {
+    await client.fireTrigger("settlement_close", {
+      event: { region: "eu-west", as_of_date: new Date().toISOString().slice(0, 10) },
+    });
+    log("manual-fire: settlement_close → fanned out to subscribed workflows");
+  } catch (err) {
+    log(`manual-fire: settlement_close skipped (${err?.message ?? err})`);
+  }
+
   log("seed complete:");
   log(`  completed = ${doneId} (${doneStatus})`);
   log(`  failed    = ${failId} (${failStatus})`);


### PR DESCRIPTION
## T-0754 — Python doc parity with Rust, live-verified

The compiler has parsed Python `what:`/`why:` docstrings since T-0752, but they vanished before reaching the API in two places:

1. `mark_build_success_with_docs` only overlaid docs onto the metadata's task list — **empty for Python at build time** (no cdylib) — and its Python carry-branch early-returned unless params/surfaces existed.
2. `persist_task_graph_db` (the load-time task-list write for Python packages) rebuilt every `TaskMetadata` with hardcoded `doc_what/doc_why: None`.

**Fix**: `PackageMetadata` gains a raw `task_docs` map (serde-default) persisted at build success on both merge branches; `persist_task_graph_db` re-merges it per task id. Rust behavior unchanged (docs still overlay directly; the map is the durable source either way).

**Tests**: `test_python_task_docs_survive_load_time_task_rewrite` mirrors the real Python flow (empty tasks at build → docs stored → load-time rewrite → docs surface; undocumented stays `None`) — and caught the early-return gap on its first run.

**Live proof (demo stack)**: `demo-py-workflow` 0.1.1 with docstrings on `prepare`/`transform` → built → loaded → the API task_graph node carries `"doc_what": "Stage the demo batch — …"` / `"doc_why": "Every branch keys off the prepared flags; …"`.

**Bonus find (filed as CLOACI-T-0840, P1)**: the live verification exposed that in-place Python package version upgrades silently lose their tasks — module re-import is a no-op in the live interpreter (the exact trap the agent guards against; the server reconciler doesn't). Full evidence + three fix directions in the task.

https://claude.ai/code/session_01VWpWbgCzNdQkFT74S3wPRM