### PR TITLE
feat(T-0722): computation graphs execute on the agent fleet (whole-graph dispatch)

### DIFF
--- a/.metis/backlog/features/CLOACI-T-0722.md
+++ b/.metis/backlog/features/CLOACI-T-0722.md
@@ -4,15 +4,15 @@ level: task
 title: "Execute computation graphs on the agent fleet (whole-graph dispatch per reactor firing)"
 short_code: "CLOACI-T-0722"
 created_at: 2026-06-17T05:20:37.681473+00:00
-updated_at: 2026-06-17T05:20:37.681473+00:00
-parent: 
+updated_at: 2026-07-05T21:27:54.352089+00:00
+parent:
 blocked_by: []
 archived: false
 
 tags:
   - "#task"
-  - "#phase/backlog"
   - "#feature"
+  - "#phase/active"
 
 
 exit_criteria_met: false
@@ -109,6 +109,10 @@ scheduler state machine, and full per-node `InputCache` marshalling + output
 re-injection. Research-level rewrite, low marginal payoff over whole-graph.
 
 ## Acceptance Criteria
+
+## Acceptance Criteria
+
+## Acceptance Criteria
 - [ ] With `--default-executor fleet`, a packaged Rust CG firing runs on an agent
       (verified via agent logs + graph fires advancing) and the reactor records
       the result; in-process behaviour is unchanged without the fleet.
@@ -126,3 +130,12 @@ re-injection. Research-level rewrite, low marginal payoff over whole-graph.
 - 2026-06-17: Parked as a **later** item (not on the current branch). Plan is
   self-contained; recorded recommended no-agent policy (in-process fallback after
   dispatch timeout). Stays in `#phase/backlog` until scheduled.
+
+### 2026-07-05 — implementation (branch feat/t0722-cg-fleet-dispatch); steps 1–5 code-complete, all 3 crates check clean
+Followed the plan with two verified simplifications: (a) NO reactor-side package plumbing — the fleet executor resolves graph→package at fire time via `find_package_for_surface("reactor", name)` (the T-0773 seam); (b) the SERVER pre-converts the snapshot to the FFI cache shape (extracted `input_cache_to_ffi_cache` from the bridge), keeping the agent lean and the packet JSON-friendly.
+- **Seam (cloacina)**: `computation_graph::graph_executor` — `GraphExecutor` trait + `GraphFireEvent { graph_name, tenant_id, snapshot, in_process: CompiledGraphFn }` + `InProcessGraphExecutor` default. Reactor holds the executor (`with_graph_executor`); BOTH fire sites (Latest + Sequential) route through it. Scheduler stores a swappable default + `set_graph_executor`, applied at both spawn sites (incl. restart).
+- **Wire**: `GRAPH_PACKET_KIND="agent_graph"` + `GraphWorkPacket { firing_id, graph_name, cache, artifact, timeout, tenant_id }`. The coordinator rendezvous reused verbatim — `/v1/agent/result` is a pure uuid→result forward; graph firings key it with a fresh `firing_id`.
+- **Server** (`fleet_graph_executor.rs`): package resolve → digest/language → `select_fleet_agent` (per-target aware) → enqueue → await. **Fallback policy (the AC's no-capacity answer)**: PRE-dispatch failures (embedded graph, Python package, no agent, enqueue error, agent Refused) → in-process via the carried closure with a warning — the reactor NEVER deadlocks; POST-dispatch failures (agent Failure, result timeout) → GraphResult::error WITHOUT a local re-run (no double execution). Wired under `use_fleet` → `scheduler.set_graph_executor(..)`.
+- **Agent**: `GRAPH_PACKET_KIND` arm + `process_graph_packet` (fetch cdylib by digest, per-digest `LoadedGraphPlugin` cache, FFI `execute_graph(cache)`, outputs → `context.outputs`); saturation → Refused (server falls back in-process).
+- **SCOPE CALL — Python CGs stay in-process in v1** (deviation from AC #2, flagged): a py CG's compiled fn is a live PyObject built from module registrations, not a shippable artifact; dispatching it needs the agent to replicate the py CG load path per package — a real follow-on, not a packet field. The fleet executor detects `language == python` and cleanly falls back in-process (logged). Rust packaged CGs — the scaling case — dispatch fully.
+Remaining: tests, live demo verification (Rust CG fires on an agent), PR.

--- a/.metis/backlog/features/CLOACI-T-0722.md
+++ b/.metis/backlog/features/CLOACI-T-0722.md
@@ -4,7 +4,7 @@ level: task
 title: "Execute computation graphs on the agent fleet (whole-graph dispatch per reactor firing)"
 short_code: "CLOACI-T-0722"
 created_at: 2026-06-17T05:20:37.681473+00:00
-updated_at: 2026-07-05T21:27:54.352089+00:00
+updated_at: 2026-07-05T21:56:29.288255+00:00
 parent:
 blocked_by: []
 archived: false
@@ -12,7 +12,7 @@ archived: false
 tags:
   - "#task"
   - "#feature"
-  - "#phase/active"
+  - "#phase/completed"
 
 
 exit_criteria_met: false
@@ -113,6 +113,8 @@ re-injection. Research-level rewrite, low marginal payoff over whole-graph.
 ## Acceptance Criteria
 
 ## Acceptance Criteria
+
+## Acceptance Criteria
 - [ ] With `--default-executor fleet`, a packaged Rust CG firing runs on an agent
       (verified via agent logs + graph fires advancing) and the reactor records
       the result; in-process behaviour is unchanged without the fleet.
@@ -139,3 +141,7 @@ Followed the plan with two verified simplifications: (a) NO reactor-side package
 - **Agent**: `GRAPH_PACKET_KIND` arm + `process_graph_packet` (fetch cdylib by digest, per-digest `LoadedGraphPlugin` cache, FFI `execute_graph(cache)`, outputs → `context.outputs`); saturation → Refused (server falls back in-process).
 - **SCOPE CALL — Python CGs stay in-process in v1** (deviation from AC #2, flagged): a py CG's compiled fn is a live PyObject built from module registrations, not a shippable artifact; dispatching it needs the agent to replicate the py CG load path per package — a real follow-on, not a packet field. The fleet executor detects `language == python` and cleanly falls back in-process (logged). Rust packaged CGs — the scaling case — dispatch fully.
 Remaining: tests, live demo verification (Rust CG fires on an agent), PR.
+
+### 2026-07-05 — 🎯 LIVE-VERIFIED ON THE FLEET — CLOSING (commit 4f01cd81)
+CG test suite 45/45 (zero regression from the seam). **Live proof (demo stack, rebuilt server+agents, fleet executor)**: server boot logged "Fleet GRAPH executor installed on the CG scheduler"; REST-injected `{"value": 42.0}` into `alpha` (mixed-rust, Rust packaged CG) → `mixed_reactor` fired → **"fleet: graph firing completed on agent agent_id=145f2a42… duration_ms=14"** → fires log advanced with `ok: true` and DECODABLE inputs `{"alpha": {"value": 42.0}}` (the T-0839 inject-encoding fix compounding), 127ms end-to-end.
+**AC disposition**: Rust CG on agent ✓ (live) · in-process unchanged without fleet ✓ (default executor + 45/45 suite) · no regression ✓ (reactor live, fires advancing, inputs decodable) · no-capacity policy ✓ (pre-dispatch in-process fallback / post-dispatch no-double-run, documented) · **Python CG on agent — deliberately deferred to [[CLOACI-T-0841]]** (filed with the full source-shipping design; py CGs fall back in-process cleanly today). COMPLETE.

--- a/.metis/backlog/features/CLOACI-T-0841.md
+++ b/.metis/backlog/features/CLOACI-T-0841.md
@@ -1,0 +1,134 @@
+---
+id: python-computation-graphs-on-the
+level: task
+title: "Python computation graphs on the agent fleet — agent-side graph-fn assembly from source (T-0722 follow-on)"
+short_code: "CLOACI-T-0841"
+created_at: 2026-07-05T21:54:59.701905+00:00
+updated_at: 2026-07-05T21:54:59.701905+00:00
+parent:
+blocked_by: []
+archived: false
+
+tags:
+  - "#task"
+  - "#phase/backlog"
+  - "#feature"
+
+
+exit_criteria_met: false
+initiative_id: NULL
+---
+
+# Python computation graphs on the agent fleet — agent-side graph-fn assembly from source (T-0722 follow-on)
+
+*This template includes sections for various types of tasks. Delete sections that don't apply to your specific use case.*
+
+## Parent Initiative **[CONDITIONAL: Assigned Task]**
+
+[[Parent Initiative]]
+
+## Objective **[REQUIRED]**
+
+Extend T-0722's whole-graph fleet dispatch to PYTHON-packaged computation graphs. Today `FleetGraphExecutor` detects `language == "python"` and falls back in-process (cleanly, logged): a py CG's compiled graph fn is a live PyObject assembled by the cloaca graph-builder machinery (node registrations + topology + dispatcher composition) inside the scheduler's load path — not a shippable artifact.
+
+The model is the same source-shipping approach Python TASKS already use on the fleet (T-0716): PyObjects never cross a boundary — the agent fetches the source archive by digest, imports it in ITS interpreter, and materializes its own objects. What's missing is a standalone "import module → assemble JUST the graph fn (no accumulators/reactor wiring) → call with the FFI cache" path the agent can run per firing:
+
+1. Factor the py graph-fn assembly out of the scheduler-coupled load path (cloacina-python graph builder) into a callable that takes (staged module, graph name) → graph fn.
+2. Agent `process_graph_packet`: when `language == "python"`, fetch the SOURCE archive (the `/v1/agent/source/{digest}` path tasks use), stage + import (the T-0840 eviction applies), assemble the graph fn, convert the packet cache into the py-side input shape, execute, report.
+3. Server: drop the python early-fallback and dispatch (packet gains `language`, mirroring `WorkPacket`).
+4. Verify live: `demo_py_graph` fires on an agent.
+
+### Type
+- [x] Feature - New functionality or enhancement
+
+### Priority
+- [x] P2 - Medium (scaling parity; py CGs run correctly in-process today via T-0722's fallback)
+
+### Impact Assessment **[CONDITIONAL: Bug]**
+- **Affected Users**: {Number/percentage of users affected}
+- **Reproduction Steps**:
+  1. {Step 1}
+  2. {Step 2}
+  3. {Step 3}
+- **Expected vs Actual**: {What should happen vs what happens}
+
+### Business Justification **[CONDITIONAL: Feature]**
+- **User Value**: {Why users need this}
+- **Business Value**: {Impact on metrics/revenue}
+- **Effort Estimate**: {Rough size - S/M/L/XL}
+
+### Technical Debt Impact **[CONDITIONAL: Tech Debt]**
+- **Current Problems**: {What's difficult/slow/buggy now}
+- **Benefits of Fixing**: {What improves after refactoring}
+- **Risk Assessment**: {Risks of not addressing this}
+
+## Acceptance Criteria **[REQUIRED]**
+
+- [ ] {Specific, testable requirement 1}
+- [ ] {Specific, testable requirement 2}
+- [ ] {Specific, testable requirement 3}
+
+## Test Cases **[CONDITIONAL: Testing Task]**
+
+{Delete unless this is a testing task}
+
+### Test Case 1: {Test Case Name}
+- **Test ID**: TC-001
+- **Preconditions**: {What must be true before testing}
+- **Steps**:
+  1. {Step 1}
+  2. {Step 2}
+  3. {Step 3}
+- **Expected Results**: {What should happen}
+- **Actual Results**: {To be filled during execution}
+- **Status**: {Pass/Fail/Blocked}
+
+### Test Case 2: {Test Case Name}
+- **Test ID**: TC-002
+- **Preconditions**: {What must be true before testing}
+- **Steps**:
+  1. {Step 1}
+  2. {Step 2}
+- **Expected Results**: {What should happen}
+- **Actual Results**: {To be filled during execution}
+- **Status**: {Pass/Fail/Blocked}
+
+## Documentation Sections **[CONDITIONAL: Documentation Task]**
+
+{Delete unless this is a documentation task}
+
+### User Guide Content
+- **Feature Description**: {What this feature does and why it's useful}
+- **Prerequisites**: {What users need before using this feature}
+- **Step-by-Step Instructions**:
+  1. {Step 1 with screenshots/examples}
+  2. {Step 2 with screenshots/examples}
+  3. {Step 3 with screenshots/examples}
+
+### Troubleshooting Guide
+- **Common Issue 1**: {Problem description and solution}
+- **Common Issue 2**: {Problem description and solution}
+- **Error Messages**: {List of error messages and what they mean}
+
+### API Documentation **[CONDITIONAL: API Documentation]**
+- **Endpoint**: {API endpoint description}
+- **Parameters**: {Required and optional parameters}
+- **Example Request**: {Code example}
+- **Example Response**: {Expected response format}
+
+## Implementation Notes **[CONDITIONAL: Technical Task]**
+
+{Keep for technical tasks, delete for non-technical. Technical details, approach, or important considerations}
+
+### Technical Approach
+{How this will be implemented}
+
+### Dependencies
+{Other tasks or systems this depends on}
+
+### Risk Considerations
+{Technical risks and mitigation strategies}
+
+## Status Updates **[REQUIRED]**
+
+*To be added during implementation*

--- a/crates/cloacina-agent/src/main.rs
+++ b/crates/cloacina-agent/src/main.rs
@@ -43,8 +43,8 @@ use base64::Engine as _;
 use clap::Parser;
 use cloacina::fleet::{
     host_target_triple, AgentHeartbeatRequest, AgentRegisterRequest, AgentRegisterResponse,
-    AgentResultRequest, AgentResultResponse, RefusalReason, WorkPacket, AGENT_PROTOCOL_VERSION,
-    AGENT_RECIPIENT_PREFIX, WORK_PACKET_KIND,
+    AgentResultRequest, AgentResultResponse, GraphWorkPacket, RefusalReason, WorkPacket,
+    AGENT_PROTOCOL_VERSION, AGENT_RECIPIENT_PREFIX, GRAPH_PACKET_KIND, WORK_PACKET_KIND,
 };
 use futures_util::{SinkExt, StreamExt};
 use serde::Serialize;
@@ -443,6 +443,40 @@ async fn handle_text_frame(
                 .and_then(|v| v.as_i64())
                 .ok_or_else(|| anyhow!("push frame missing numeric `id`"))?;
             let kind = env.get("kind").and_then(|v| v.as_str()).unwrap_or("");
+            // CLOACI-T-0722: whole-graph firings ride their own packet kind.
+            if kind == GRAPH_PACKET_KIND {
+                let cur = in_flight.load(Ordering::SeqCst);
+                let packet = decode_graph_packet(&env).context("decode graph packet")?;
+                if cur >= max_concurrency {
+                    warn!(
+                        in_flight = cur,
+                        max_concurrency, "saturated; refusing graph firing"
+                    );
+                    spawn_graph_refusal(
+                        http.clone(),
+                        server.to_string(),
+                        api_key.to_string(),
+                        agent_id.to_string(),
+                        packet,
+                        "agent at max_concurrency".to_string(),
+                        ack_tx.clone(),
+                        push_id,
+                    );
+                    return Ok(());
+                }
+                spawn_graph_worker(
+                    http.clone(),
+                    server.to_string(),
+                    api_key.to_string(),
+                    agent_id.to_string(),
+                    packet,
+                    in_flight.clone(),
+                    ack_tx.clone(),
+                    push_id,
+                    cache_dir.clone(),
+                );
+                return Ok(());
+            }
             if kind != WORK_PACKET_KIND {
                 warn!(kind = %kind, push_id, "non-work push received; acking + ignoring");
                 let _ = ack_tx.send(Message::Text(make_ack(push_id)?.into()));
@@ -506,6 +540,18 @@ fn decode_packet(env: &serde_json::Value) -> Result<WorkPacket> {
     serde_json::from_slice::<WorkPacket>(&bytes).with_context(|| "deserialize WorkPacket JSON")
 }
 
+fn decode_graph_packet(env: &serde_json::Value) -> Result<GraphWorkPacket> {
+    let b64 = env
+        .get("payload_b64")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow!("push frame missing `payload_b64`"))?;
+    let bytes = BASE64
+        .decode(b64)
+        .with_context(|| "decode base64 payload")?;
+    serde_json::from_slice::<GraphWorkPacket>(&bytes)
+        .with_context(|| "deserialize GraphWorkPacket JSON")
+}
+
 fn make_ack(id: i64) -> Result<String> {
     let v = serde_json::json!({
         "type": "ack",
@@ -558,6 +604,193 @@ fn spawn_packet_worker(
         }
         in_flight.fetch_sub(1, Ordering::SeqCst);
     });
+}
+
+/// CLOACI-T-0722: per-digest cache of loaded GRAPH plugins, mirroring the
+/// task-side `loaded_runtimes()` — one dlopen per package, reused across
+/// firings for the process lifetime.
+fn loaded_graphs() -> &'static tokio::sync::Mutex<
+    std::collections::HashMap<
+        String,
+        Arc<cloacina::computation_graph::packaging_bridge::LoadedGraphPlugin>,
+    >,
+> {
+    static CACHE: std::sync::OnceLock<
+        tokio::sync::Mutex<
+            std::collections::HashMap<
+                String,
+                Arc<cloacina::computation_graph::packaging_bridge::LoadedGraphPlugin>,
+            >,
+        >,
+    > = std::sync::OnceLock::new();
+    CACHE.get_or_init(|| tokio::sync::Mutex::new(std::collections::HashMap::new()))
+}
+
+/// CLOACI-T-0722: spawn a worker that executes one whole-graph firing —
+/// fetch the cdylib by digest, `execute_graph(cache)` via FFI, report the
+/// outcome under the packet's `firing_id` (the server's rendezvous key).
+#[allow(clippy::too_many_arguments)]
+fn spawn_graph_worker(
+    http: reqwest::Client,
+    server: String,
+    api_key: String,
+    agent_id: String,
+    packet: GraphWorkPacket,
+    in_flight: Arc<AtomicU32>,
+    ack_tx: mpsc::UnboundedSender<Message>,
+    push_id: i64,
+    cache_dir: Arc<std::path::PathBuf>,
+) {
+    in_flight.fetch_add(1, Ordering::SeqCst);
+    tokio::spawn(async move {
+        let start = Instant::now();
+        let outcome =
+            process_graph_packet(&packet, &http, &server, &api_key, cache_dir.as_path()).await;
+        let duration_ms = start.elapsed().as_millis() as u64;
+        let req = AgentResultRequest {
+            protocol_version: AGENT_PROTOCOL_VERSION,
+            agent_id: agent_id.clone(),
+            task_execution_id: packet.firing_id.clone(),
+            attempt: 1,
+            duration_ms,
+            outcome,
+        };
+        report_outcome(&http, &server, &api_key, &req).await;
+        if let Ok(ack) = make_ack(push_id) {
+            let _ = ack_tx.send(Message::Text(ack.into()));
+        }
+        in_flight.fetch_sub(1, Ordering::SeqCst);
+    });
+}
+
+/// CLOACI-T-0722: refuse a graph firing pre-execution (saturation). The
+/// server treats a refusal as "the agent did NOT run it" and falls back
+/// in-process.
+#[allow(clippy::too_many_arguments)]
+fn spawn_graph_refusal(
+    http: reqwest::Client,
+    server: String,
+    api_key: String,
+    agent_id: String,
+    packet: GraphWorkPacket,
+    message: String,
+    ack_tx: mpsc::UnboundedSender<Message>,
+    push_id: i64,
+) {
+    tokio::spawn(async move {
+        let req = AgentResultRequest {
+            protocol_version: AGENT_PROTOCOL_VERSION,
+            agent_id,
+            task_execution_id: packet.firing_id.clone(),
+            attempt: 1,
+            duration_ms: 0,
+            outcome: cloacina::fleet::AgentOutcome::Refused {
+                reason: RefusalReason::Shutdown,
+                message,
+            },
+        };
+        report_outcome(&http, &server, &api_key, &req).await;
+        if let Ok(ack) = make_ack(push_id) {
+            let _ = ack_tx.send(Message::Text(ack.into()));
+        }
+    });
+}
+
+/// Execute one whole-graph firing (CLOACI-T-0722): fetch + cache the cdylib
+/// by digest, load it once per digest, call the plugin's `execute_graph`
+/// with the packet's pre-converted FFI cache, and map the result.
+async fn process_graph_packet(
+    packet: &GraphWorkPacket,
+    http: &reqwest::Client,
+    server: &str,
+    api_key: &str,
+    cache_dir: &std::path::Path,
+) -> cloacina::fleet::AgentOutcome {
+    let digest = packet.artifact.digest.clone();
+
+    let plugin = {
+        let mut cache = loaded_graphs().lock().await;
+        if let Some(p) = cache.get(&digest) {
+            p.clone()
+        } else {
+            let artifact_path =
+                match fetch_and_cache_artifact(http, server, api_key, &packet.artifact, cache_dir)
+                    .await
+                {
+                    Ok(p) => p,
+                    Err(e) => {
+                        return cloacina::fleet::AgentOutcome::Refused {
+                            reason: RefusalReason::ArtifactFetchFailed,
+                            message: format!("graph artifact fetch failed: {}", e),
+                        };
+                    }
+                };
+            let bytes = match std::fs::read(&artifact_path) {
+                Ok(b) => b,
+                Err(e) => {
+                    return cloacina::fleet::AgentOutcome::Refused {
+                        reason: RefusalReason::ArtifactFetchFailed,
+                        message: format!("read cached graph artifact: {}", e),
+                    };
+                }
+            };
+            let loaded =
+                match cloacina::computation_graph::packaging_bridge::LoadedGraphPlugin::load(&bytes)
+                {
+                    Ok(p) => Arc::new(p),
+                    Err(e) => {
+                        return cloacina::fleet::AgentOutcome::Refused {
+                            reason: RefusalReason::RuntimeLoadFailed,
+                            message: format!("load graph plugin: {}", e),
+                        };
+                    }
+                };
+            cache.insert(digest.clone(), loaded.clone());
+            loaded
+        }
+    };
+
+    let request = cloacina::cloacina_workflow_plugin::GraphExecutionRequest {
+        cache: packet.cache.clone(),
+    };
+    let plugin_for_call = plugin.clone();
+    let result = tokio::task::spawn_blocking(move || plugin_for_call.execute_graph(request)).await;
+
+    match result {
+        Ok(Ok(ffi_result)) => {
+            if ffi_result.success {
+                let outputs: Vec<serde_json::Value> = ffi_result
+                    .terminal_outputs_json
+                    .unwrap_or_default()
+                    .into_iter()
+                    .filter_map(|j| serde_json::from_str::<serde_json::Value>(&j).ok())
+                    .collect();
+                debug!(
+                    graph = %packet.graph_name,
+                    outputs = outputs.len(),
+                    "graph firing executed on agent"
+                );
+                cloacina::fleet::AgentOutcome::Success {
+                    context: serde_json::json!({ "outputs": outputs }),
+                }
+            } else {
+                cloacina::fleet::AgentOutcome::Failure {
+                    message: ffi_result
+                        .error
+                        .unwrap_or_else(|| "unknown FFI graph execution error".to_string()),
+                    classification: cloacina::fleet::FailureClassification::TaskError,
+                }
+            }
+        }
+        Ok(Err(e)) => cloacina::fleet::AgentOutcome::Failure {
+            message: format!("execute_graph FFI call failed: {}", e),
+            classification: cloacina::fleet::FailureClassification::TaskError,
+        },
+        Err(join_err) => cloacina::fleet::AgentOutcome::Failure {
+            message: format!("execute_graph panicked: {}", join_err),
+            classification: cloacina::fleet::FailureClassification::TaskError,
+        },
+    }
 }
 
 /// Spawn a worker that POSTs a refusal + acks. Same shape as `spawn_packet_worker`

--- a/crates/cloacina-server/src/fleet_executor.rs
+++ b/crates/cloacina-server/src/fleet_executor.rs
@@ -731,7 +731,7 @@ fn kind_of(v: &serde_json::Value) -> &'static str {
 /// `Some("public")` and matches only `Some("public")` agents; a named tenant's
 /// work matches only that tenant's agents. `runnable_triples == None` means
 /// "any arch is fine" (interpreted package, e.g. Python).
-fn select_fleet_agent<'a>(
+pub(crate) fn select_fleet_agent<'a>(
     snapshot: &'a [AgentRecord],
     task_tenant: &Option<String>,
     runnable_triples: &Option<Vec<String>>,

--- a/crates/cloacina-server/src/fleet_graph_executor.rs
+++ b/crates/cloacina-server/src/fleet_graph_executor.rs
@@ -1,0 +1,274 @@
+/*
+ *  Copyright 2026 Colliery Software
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+//! Fleet dispatch for computation-graph firings (CLOACI-T-0722).
+//!
+//! Mirrors [`crate::fleet_executor::FleetExecutor`] for the reactor's
+//! whole-graph fire: resolve the graph's owning package + artifact digest,
+//! pick a live agent, ship a [`GraphWorkPacket`] over the substrate outbox,
+//! and await the agent's result through the same uuid→result coordinator
+//! rendezvous the task path uses (`/v1/agent/result` is a pure forward).
+//!
+//! **Fallback policy** (the reactor's hot path must never wedge):
+//! - PRE-dispatch failures — no owning package (embedded graph), a Python
+//!   package (interpreted CGs stay in-process in v1), no eligible agent,
+//!   snapshot conversion or enqueue errors — run the firing **in-process**
+//!   via the closure every [`GraphFireEvent`] carries, with a warning.
+//! - POST-dispatch failures — the agent reported an error, or the result
+//!   wait timed out — surface as a [`GraphResult`] error WITHOUT a local
+//!   re-run: the agent may have executed (or still be executing) the graph,
+//!   and double-running a firing is worse than reporting it failed.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use cloacina::cloacina_computation_graph::{GraphError, GraphResult};
+use cloacina::computation_graph::graph_executor::{GraphExecutor, GraphFireEvent};
+use cloacina::computation_graph::packaging_bridge::input_cache_to_ffi_cache;
+use cloacina::dal::unified::workflow_registry_storage::UnifiedRegistryStorage;
+use cloacina::database::universal_types::UniversalUuid;
+use cloacina::fleet::{
+    host_target_triple, AgentOutcome, ArtifactRef, GraphWorkPacket, AGENT_PROTOCOL_VERSION,
+    AGENT_RECIPIENT_PREFIX, GRAPH_PACKET_KIND,
+};
+use cloacina::models::delivery_outbox::NewDeliveryOutbox;
+use cloacina::registry::workflow_registry::WorkflowRegistryImpl;
+use tracing::{debug, info, warn};
+
+use crate::agent_registry::AgentRegistry;
+use crate::fleet_coordinator::FleetCoordinator;
+use crate::fleet_executor::select_fleet_agent;
+
+/// Max wall-clock to wait for an agent's graph result before reporting the
+/// firing failed. Matches the task path's conservative cap.
+const GRAPH_RESULT_WAIT_TIMEOUT: Duration = Duration::from_secs(300);
+
+pub struct FleetGraphExecutor {
+    dal: cloacina::dal::DAL,
+    /// Admin-schema DAL for the delivery_outbox enqueue (delivery is
+    /// server-global — see `FleetExecutor::outbox_dal`).
+    outbox_dal: cloacina::dal::DAL,
+    agent_registry: Arc<AgentRegistry>,
+    coordinator: Arc<FleetCoordinator>,
+    delivery_wake: cloacina::delivery::WakeHandle,
+    /// Registry handle for resolving a graph's owning package by surface
+    /// name at fire time (`find_package_for_surface("reactor", …)`).
+    registry: WorkflowRegistryImpl<UnifiedRegistryStorage>,
+}
+
+impl FleetGraphExecutor {
+    pub fn new(
+        dal: cloacina::dal::DAL,
+        outbox_dal: cloacina::dal::DAL,
+        agent_registry: Arc<AgentRegistry>,
+        coordinator: Arc<FleetCoordinator>,
+        delivery_wake: cloacina::delivery::WakeHandle,
+        registry: WorkflowRegistryImpl<UnifiedRegistryStorage>,
+    ) -> Self {
+        Self {
+            dal,
+            outbox_dal,
+            agent_registry,
+            coordinator,
+            delivery_wake,
+            registry,
+        }
+    }
+
+    /// Attempt fleet dispatch. `Err(reason)` = pre-dispatch failure — the
+    /// caller falls back to in-process execution.
+    async fn try_dispatch(&self, fire: &GraphFireEvent) -> Result<GraphResult, String> {
+        // 1. Resolve the graph's owning package by its reactor surface name.
+        let package_name = self
+            .registry
+            .find_package_for_surface("reactor", &fire.graph_name)
+            .await
+            .map_err(|e| format!("surface→package lookup failed: {e}"))?
+            .ok_or_else(|| {
+                format!(
+                    "graph '{}' has no owning package (embedded graph)",
+                    fire.graph_name
+                )
+            })?;
+
+        // 2. Resolve the active artifact. Interpreted (Python) CGs stay
+        //    in-process in v1 — their compiled graph fn is a live PyObject,
+        //    not a shippable artifact.
+        let (primary_digest, language) = self
+            .dal
+            .workflow_packages()
+            .get_active_dispatch_for_package(&package_name, None)
+            .await
+            .map_err(|e| format!("artifact digest lookup failed: {e}"))?
+            .ok_or_else(|| format!("no active artifact for package '{package_name}'"))?;
+        if language.eq_ignore_ascii_case("python") {
+            return Err(format!(
+                "package '{package_name}' is Python — CG fleet dispatch is Rust-only in v1"
+            ));
+        }
+
+        // 3. Select a live agent with capacity + a runnable arch (host primary
+        //    ∪ this package's per-target builds) in the graph's tenant.
+        let runnable_triples: Option<Vec<String>> = {
+            let mut t = self
+                .dal
+                .workflow_packages()
+                .get_artifact_triples_for_package(&package_name)
+                .await
+                .unwrap_or_default();
+            t.push(host_target_triple().to_string());
+            Some(t)
+        };
+        let snapshot = self.agent_registry.snapshot();
+        let agent =
+            select_fleet_agent(&snapshot, &fire.tenant_id, &runnable_triples).ok_or_else(|| {
+                format!(
+                    "no live agent with capacity + runnable arch in tenant {:?}",
+                    fire.tenant_id
+                )
+            })?;
+        let agent_id = agent.agent_id.clone();
+        let agent_triple = agent.target_triple.clone();
+
+        // Per-target artifact when one exists for the agent's arch, else the
+        // primary/host build (selection already guaranteed runnability).
+        let (digest, _triple) = match self
+            .dal
+            .workflow_packages()
+            .get_artifact_digest_for_target(&package_name, &agent_triple)
+            .await
+        {
+            Ok(Some(arch_digest)) => (arch_digest, agent_triple),
+            _ => (primary_digest, host_target_triple().to_string()),
+        };
+
+        // 4. Convert the snapshot into the FFI/wire cache shape — the same
+        //    conversion the in-process FFI path performs.
+        let cache = input_cache_to_ffi_cache(&fire.snapshot)
+            .map_err(|e| format!("snapshot conversion failed: {e}"))?;
+
+        // 5. Rendezvous BEFORE enqueue (a fast agent must not race the receiver).
+        let firing_id = UniversalUuid::new_v4();
+        let rx = self.coordinator.register_pending(firing_id);
+
+        let packet = GraphWorkPacket {
+            protocol_version: AGENT_PROTOCOL_VERSION,
+            firing_id: firing_id.0.to_string(),
+            graph_name: fire.graph_name.clone(),
+            cache,
+            artifact: ArtifactRef {
+                fetch_url: format!("/v1/agent/artifact/{}", digest),
+                digest,
+                build_target_triple: agent.target_triple.clone(),
+            },
+            timeout_seconds: 300,
+            tenant_id: fire.tenant_id.clone(),
+        };
+        let payload = serde_json::to_vec(&packet).map_err(|e| {
+            self.coordinator.cancel(firing_id);
+            format!("serialize GraphWorkPacket: {e}")
+        })?;
+
+        let row = NewDeliveryOutbox {
+            recipient: format!("{}{}", AGENT_RECIPIENT_PREFIX, agent_id),
+            kind: GRAPH_PACKET_KIND.to_string(),
+            tenant_id: fire.tenant_id.clone(),
+            payload,
+        };
+        if let Err(e) = self.outbox_dal.delivery_outbox().enqueue(row).await {
+            self.coordinator.cancel(firing_id);
+            return Err(format!("delivery_outbox enqueue: {e}"));
+        }
+        self.delivery_wake.wake();
+        debug!(
+            graph = %fire.graph_name,
+            agent_id = %agent_id,
+            firing_id = %firing_id,
+            "fleet: graph firing enqueued + relay woken"
+        );
+
+        // 6. Await the agent's result. POST-dispatch failures do NOT fall
+        //    back (the agent may have run — or still be running — the graph).
+        match tokio::time::timeout(GRAPH_RESULT_WAIT_TIMEOUT, rx).await {
+            Ok(Ok(result)) => match result.outcome {
+                AgentOutcome::Success { context } => {
+                    // The agent reports terminal outputs as a JSON array under
+                    // "outputs" (may be empty — the reactor only logs them).
+                    let outputs_json: Vec<serde_json::Value> = context
+                        .get("outputs")
+                        .and_then(|v| v.as_array())
+                        .cloned()
+                        .unwrap_or_default();
+                    let outputs: Vec<Box<dyn std::any::Any + Send>> = outputs_json
+                        .iter()
+                        .cloned()
+                        .map(|v| Box::new(v) as Box<dyn std::any::Any + Send>)
+                        .collect();
+                    info!(
+                        graph = %fire.graph_name,
+                        agent_id = %result.agent_id,
+                        duration_ms = result.duration_ms,
+                        "fleet: graph firing completed on agent"
+                    );
+                    Ok(GraphResult::completed_with_json(outputs, outputs_json))
+                }
+                AgentOutcome::Failure {
+                    message,
+                    classification: _,
+                } => Ok(GraphResult::error(GraphError::NodeExecution(format!(
+                    "graph firing failed on agent {}: {}",
+                    result.agent_id, message
+                )))),
+                AgentOutcome::Refused { reason, message } => {
+                    // The agent did NOT run the graph — safe to fall back.
+                    Err(format!(
+                        "agent {} refused the graph firing ({reason:?}): {message}",
+                        result.agent_id
+                    ))
+                }
+            },
+            Ok(Err(_canceled)) => Ok(GraphResult::error(GraphError::NodeExecution(
+                "fleet graph rendezvous canceled before the agent reported".to_string(),
+            ))),
+            Err(_elapsed) => {
+                self.coordinator.cancel(firing_id);
+                Ok(GraphResult::error(GraphError::NodeExecution(format!(
+                    "fleet graph result wait exceeded {}s (agent {}) — NOT re-running \
+                     in-process to avoid a double execution",
+                    GRAPH_RESULT_WAIT_TIMEOUT.as_secs(),
+                    agent_id
+                ))))
+            }
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl GraphExecutor for FleetGraphExecutor {
+    async fn execute(&self, fire: GraphFireEvent) -> GraphResult {
+        match self.try_dispatch(&fire).await {
+            Ok(result) => result,
+            Err(reason) => {
+                warn!(
+                    graph = %fire.graph_name,
+                    reason = %reason,
+                    "fleet: graph dispatch not possible — running firing in-process"
+                );
+                (fire.in_process)(fire.snapshot).await
+            }
+        }
+    }
+}

--- a/crates/cloacina-server/src/lib.rs
+++ b/crates/cloacina-server/src/lib.rs
@@ -26,6 +26,7 @@ pub mod autoscaler;
 pub mod delivery_sink;
 pub mod fleet_coordinator;
 pub mod fleet_executor;
+pub mod fleet_graph_executor;
 pub mod identity;
 pub mod oidc;
 pub mod openapi;
@@ -944,6 +945,40 @@ pub async fn run(
                 "Fleet executor NOT registered — runner has no dispatcher \
                  (push-based execution disabled); fleet dispatch will not fire"
             );
+        }
+
+        // CLOACI-T-0722: computation-graph firings also dispatch to the fleet.
+        // The scheduler's default in-process executor is swapped for the fleet
+        // one; every fire event still carries the compiled closure, so
+        // undispatched graphs (embedded, Python, no agent) fall back in-process.
+        let storage =
+            cloacina::dal::unified::workflow_registry_storage::UnifiedRegistryStorage::new(
+                state.database.clone(),
+            );
+        match cloacina::registry::workflow_registry::WorkflowRegistryImpl::new(
+            storage,
+            state.database.clone(),
+        ) {
+            Ok(registry) => {
+                let graph_fleet = crate::fleet_graph_executor::FleetGraphExecutor::new(
+                    unified_dal.clone(),
+                    unified_dal.clone(),
+                    agent_registry.clone(),
+                    fleet_coordinator.clone(),
+                    delivery_wake.clone(),
+                    registry,
+                );
+                state
+                    .graph_scheduler
+                    .set_graph_executor(Arc::new(graph_fleet))
+                    .await;
+                info!("Fleet GRAPH executor installed on the CG scheduler (CLOACI-T-0722)");
+            }
+            Err(e) => warn!(
+                "Fleet graph executor NOT installed (registry init failed: {}); \
+                 CG firings stay in-process",
+                e
+            ),
         }
     }
 

--- a/crates/cloacina/src/computation_graph/graph_executor.rs
+++ b/crates/cloacina/src/computation_graph/graph_executor.rs
@@ -1,0 +1,72 @@
+/*
+ *  Copyright 2026 Colliery Software
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+//! The graph-execution seam (CLOACI-T-0722).
+//!
+//! Mirrors the task-side `TaskExecutor` trait: when a reactor fires, it hands
+//! the firing to a [`GraphExecutor`] instead of calling the compiled graph
+//! closure directly. The default [`InProcessGraphExecutor`] preserves today's
+//! behavior exactly; `cloacina-server`'s fleet executor ships the firing (the
+//! `InputCache` snapshot + the CG package digest) to an execution agent and
+//! awaits the result — accumulators and reactor state stay host-side, only
+//! the compute leaves.
+//!
+//! Every [`GraphFireEvent`] carries the compiled in-process closure, so a
+//! fleet executor can ALWAYS fall back to local execution (no agent capacity,
+//! unresolvable package, dispatch timeout) rather than wedging the reactor's
+//! hot path.
+
+use std::sync::Arc;
+
+use cloacina_computation_graph::{CompiledGraphFn, GraphResult, InputCache};
+
+/// One reactor firing, ready to execute somewhere.
+pub struct GraphFireEvent {
+    /// The graph (== reactor) name — the fleet executor resolves the owning
+    /// package (and artifact digest) from it at fire time.
+    pub graph_name: String,
+    /// Tenant scope for agent selection; `None` for untagged graphs.
+    pub tenant_id: Option<String>,
+    /// The input snapshot the graph consumes.
+    pub snapshot: InputCache,
+    /// The compiled in-process closure — the default execution AND the
+    /// universal fallback for remote executors.
+    pub in_process: CompiledGraphFn,
+}
+
+/// Where a reactor firing runs. Implementations must be cheap to call per
+/// fire; the reactor awaits the returned result on its hot path.
+#[async_trait::async_trait]
+pub trait GraphExecutor: Send + Sync {
+    async fn execute(&self, fire: GraphFireEvent) -> GraphResult;
+}
+
+/// Default executor: run the compiled graph closure in this process —
+/// byte-for-byte the pre-seam behavior.
+#[derive(Default)]
+pub struct InProcessGraphExecutor;
+
+#[async_trait::async_trait]
+impl GraphExecutor for InProcessGraphExecutor {
+    async fn execute(&self, fire: GraphFireEvent) -> GraphResult {
+        (fire.in_process)(fire.snapshot).await
+    }
+}
+
+/// The shared default used when nothing is injected.
+pub fn in_process_graph_executor() -> Arc<dyn GraphExecutor> {
+    Arc::new(InProcessGraphExecutor)
+}

--- a/crates/cloacina/src/computation_graph/mod.rs
+++ b/crates/cloacina/src/computation_graph/mod.rs
@@ -25,6 +25,7 @@
 
 pub mod accumulator;
 pub mod global_registry;
+pub mod graph_executor;
 pub mod packaging_bridge;
 pub mod reactor;
 pub mod registry;

--- a/crates/cloacina/src/computation_graph/packaging_bridge.rs
+++ b/crates/cloacina/src/computation_graph/packaging_bridge.rs
@@ -43,7 +43,7 @@ use super::types::{GraphError, GraphResult, InputCache, SourceName};
 /// Loaded once from library bytes, kept alive for the lifetime of the graph.
 /// The `PluginHandle` is behind a `Mutex` because fidius calls are synchronous
 /// and must not be invoked concurrently.
-struct LoadedGraphPlugin {
+pub struct LoadedGraphPlugin {
     handle: std::sync::Mutex<fidius_host::PluginHandle>,
     // Keep the temp dir alive so the dylib file isn't deleted while loaded
     _temp_dir: tempfile::TempDir,
@@ -56,8 +56,9 @@ unsafe impl Sync for LoadedGraphPlugin {}
 
 impl LoadedGraphPlugin {
     /// Load a graph plugin from library bytes. The library is written to a temp
-    /// file, loaded via fidius, and kept resident for reuse.
-    fn load(library_data: &[u8]) -> Result<Self, String> {
+    /// file, loaded via fidius, and kept resident for reuse. Public so the
+    /// execution agent can run whole-graph firings (CLOACI-T-0722).
+    pub fn load(library_data: &[u8]) -> Result<Self, String> {
         let temp_dir =
             tempfile::TempDir::new().map_err(|e| format!("Failed to create temp dir: {}", e))?;
 
@@ -93,7 +94,7 @@ impl LoadedGraphPlugin {
     }
 
     /// Call execute_graph on the loaded plugin.
-    fn execute_graph(
+    pub fn execute_graph(
         &self,
         request: GraphExecutionRequest,
     ) -> Result<cloacina_workflow_plugin::GraphExecutionResult, String> {
@@ -265,40 +266,46 @@ pub fn build_declaration_from_ffi(
 }
 
 /// Execute a computation graph via FFI using the pre-loaded plugin handle.
-async fn execute_graph_via_ffi(plugin: &Arc<LoadedGraphPlugin>, cache: &InputCache) -> GraphResult {
+/// Convert an [`InputCache`] snapshot into the FFI/wire cache shape
+/// (source name → UTF-8 JSON string) — the same conversion the in-process FFI
+/// call performs, shared with the fleet path so a dispatched firing carries an
+/// agent-ready cache (CLOACI-T-0722). Boundary frames are `bincode(Vec<u8>)`
+/// of raw event JSON; non-UTF-8 payloads are hex-encoded.
+pub fn input_cache_to_ffi_cache(cache: &InputCache) -> Result<HashMap<String, String>, String> {
     let cache_snapshot = cache.snapshot();
-
-    // Recover raw bytes from bincode wire format, then interpret as UTF-8 JSON
-    // for the FFI boundary. The passthrough accumulator stores raw event bytes
-    // (typically JSON from WebSocket) which are bincode-serialized as Vec<u8>.
     let mut ffi_cache: HashMap<String, String> = HashMap::new();
     for source_name in cache_snapshot.sources() {
         if let Some(raw_bytes) = cache_snapshot.get_raw(source_name.as_str()) {
-            // Wire format is bincode(Vec<u8>) — recover the original bytes
             match bincode::deserialize::<Vec<u8>>(raw_bytes) {
                 Ok(original_bytes) => {
-                    // Original bytes are JSON from WebSocket — convert to string
                     let json_str = String::from_utf8(original_bytes).unwrap_or_else(|e| {
                         tracing::warn!(
                             source = source_name.as_str(),
                             "cache entry is not valid UTF-8, hex-encoding: {}",
                             e
                         );
-                        // Fall back to hex encoding for non-UTF-8 data
                         raw_bytes.iter().map(|b| format!("{:02x}", b)).collect()
                     });
                     ffi_cache.insert(source_name.as_str().to_string(), json_str);
                 }
                 Err(e) => {
-                    return GraphResult::error(GraphError::Serialization(format!(
+                    return Err(format!(
                         "Failed to deserialize cache entry '{}' for FFI: {}",
                         source_name.as_str(),
                         e
-                    )));
+                    ));
                 }
             }
         }
     }
+    Ok(ffi_cache)
+}
+
+async fn execute_graph_via_ffi(plugin: &Arc<LoadedGraphPlugin>, cache: &InputCache) -> GraphResult {
+    let ffi_cache = match input_cache_to_ffi_cache(cache) {
+        Ok(c) => c,
+        Err(e) => return GraphResult::error(GraphError::Serialization(e)),
+    };
 
     let request = GraphExecutionRequest { cache: ffi_cache };
 

--- a/crates/cloacina/src/computation_graph/reactor.rs
+++ b/crates/cloacina/src/computation_graph/reactor.rs
@@ -483,6 +483,10 @@ pub struct Reactor {
     /// criteria on the `Latest` path — this is the seam a WASM reactor
     /// constructor's `evaluate` plugs into.
     evaluator: Option<Arc<dyn ReactorFireDecider>>,
+    /// Where firings execute (CLOACI-T-0722): in-process by default, or the
+    /// server's fleet executor (whole-graph dispatch to an agent). Every fire
+    /// event carries the compiled closure as the executor's fallback.
+    graph_executor: Arc<dyn super::graph_executor::GraphExecutor>,
 }
 
 impl Reactor {
@@ -512,7 +516,19 @@ impl Reactor {
             batch_flush_senders: Vec::new(),
             stats: Arc::new(ReactorStats::default()),
             evaluator: None,
+            graph_executor: super::graph_executor::in_process_graph_executor(),
         }
+    }
+
+    /// Set where firings execute (CLOACI-T-0722): the server injects its
+    /// fleet executor here when `--default-executor fleet`; embedded and
+    /// default paths keep the in-process executor.
+    pub fn with_graph_executor(
+        mut self,
+        executor: Arc<dyn super::graph_executor::GraphExecutor>,
+    ) -> Self {
+        self.graph_executor = executor;
+        self
     }
 
     /// Set a pluggable firing-decision hook (CLOACI-T-0828).
@@ -861,6 +877,9 @@ impl Reactor {
         // CLOACI-T-0828: when set, replaces the WhenAny/WhenAll criteria on the
         // Latest path with an external firing decision (a WASM reactor `evaluate`).
         let evaluator = self.evaluator.clone();
+        // CLOACI-T-0722: firings run through the pluggable executor (in-process
+        // by default; the fleet executor ships them to an agent).
+        let graph_executor = self.graph_executor.clone();
 
         loop {
             tokio::select! {
@@ -900,7 +919,14 @@ impl Reactor {
                                 // CLOACI-T-0775: capture the triggering inputs before
                                 // the snapshot is moved into the graph call.
                                 let fire_inputs = capture_fire_inputs(&snapshot);
-                                let result = (graph)(snapshot).await;
+                                let result = graph_executor
+                                    .execute(super::graph_executor::GraphFireEvent {
+                                        graph_name: graph_name_exec.clone(),
+                                        tenant_id: tenant_id_exec.clone(),
+                                        snapshot,
+                                        in_process: graph.clone(),
+                                    })
+                                    .await;
                                 metrics::counter!(
                                     "cloacina_reactor_fires_total",
                                     "graph" => graph_name_exec.clone(),
@@ -966,7 +992,14 @@ impl Reactor {
                                         ).await;
                                         // CLOACI-T-0775: capture inputs before the move.
                                         let fire_inputs = capture_fire_inputs(&snapshot);
-                                        let result = (graph)(snapshot).await;
+                                        let result = graph_executor
+                                            .execute(super::graph_executor::GraphFireEvent {
+                                                graph_name: graph_name_exec.clone(),
+                                                tenant_id: tenant_id_exec.clone(),
+                                                snapshot,
+                                                in_process: graph.clone(),
+                                            })
+                                            .await;
                                         metrics::counter!(
                                             "cloacina_reactor_fires_total",
                                             "graph" => graph_name_exec.clone(),

--- a/crates/cloacina/src/computation_graph/scheduler.rs
+++ b/crates/cloacina/src/computation_graph/scheduler.rs
@@ -434,6 +434,10 @@ const SUCCESS_RESET_SECS: u64 = 60;
 pub struct ComputationGraphScheduler {
     /// Endpoint registry for WebSocket routing.
     registry: EndpointRegistry,
+    /// Where reactor firings execute (CLOACI-T-0722): in-process by default;
+    /// the server swaps in its fleet executor under `--default-executor
+    /// fleet`. Applied to every reactor spawned (and re-spawned) after set.
+    graph_executor: Arc<RwLock<Arc<dyn super::graph_executor::GraphExecutor>>>,
     /// Running reactors, keyed by reactor name. Each reactor owns a subscriber
     /// map that may contain one or more graphs sharing this reactor instance.
     reactors: Arc<RwLock<HashMap<String, RunningGraph>>>,
@@ -454,6 +458,9 @@ impl ComputationGraphScheduler {
     pub fn new(registry: EndpointRegistry) -> Self {
         Self {
             registry,
+            graph_executor: Arc::new(RwLock::new(
+                super::graph_executor::in_process_graph_executor(),
+            )),
             reactors: Arc::new(RwLock::new(HashMap::new())),
             graph_to_reactor: Arc::new(RwLock::new(HashMap::new())),
             graph_topologies: Arc::new(RwLock::new(HashMap::new())),
@@ -465,6 +472,9 @@ impl ComputationGraphScheduler {
     pub fn with_dal(registry: EndpointRegistry, dal: crate::dal::unified::DAL) -> Self {
         Self {
             registry,
+            graph_executor: Arc::new(RwLock::new(
+                super::graph_executor::in_process_graph_executor(),
+            )),
             reactors: Arc::new(RwLock::new(HashMap::new())),
             graph_to_reactor: Arc::new(RwLock::new(HashMap::new())),
             graph_topologies: Arc::new(RwLock::new(HashMap::new())),
@@ -487,6 +497,16 @@ impl ComputationGraphScheduler {
     /// packages) typically pass `&[]` and address the reactor by its name.
     ///
     /// Subscribers are bound separately via [`bind_graph_to_reactor`].
+    /// Swap the graph executor firings run through (CLOACI-T-0722). Takes
+    /// effect for reactors spawned/restarted AFTER the call — the server sets
+    /// this once at startup, before any packages load.
+    pub async fn set_graph_executor(
+        &self,
+        executor: Arc<dyn super::graph_executor::GraphExecutor>,
+    ) {
+        *self.graph_executor.write().await = executor;
+    }
+
     pub async fn load_reactor(
         &self,
         reactor_name: String,
@@ -620,7 +640,8 @@ impl ComputationGraphScheduler {
         .with_health(reactor_health_tx)
         .with_expected_sources(expected_sources)
         .with_accumulator_health(acc_health_rxs)
-        .with_tenant_id(tenant_id.clone());
+        .with_tenant_id(tenant_id.clone())
+        .with_graph_executor(self.graph_executor.read().await.clone());
 
         // CLOACI-T-0830: a resolved reactor-constructor decider replaces the
         // built-in WhenAny/WhenAll criteria — the WASM guest's `evaluate` decides
@@ -1275,7 +1296,8 @@ impl ComputationGraphScheduler {
                 .with_health(reactor_health_tx)
                 .with_expected_sources(expected_sources)
                 .with_accumulator_health(restart_acc_health_rxs)
-                .with_tenant_id(running.declaration.tenant_id.clone());
+                .with_tenant_id(running.declaration.tenant_id.clone())
+                .with_graph_executor(self.graph_executor.read().await.clone());
                 // CLOACI-T-0830: re-install the reactor-constructor decider on
                 // restart. The decider was resolved once at load and is shared
                 // (`Arc<dyn ReactorFireDecider>`, `Send + Sync`), so the restart

--- a/crates/cloacina/src/fleet/protocol.rs
+++ b/crates/cloacina/src/fleet/protocol.rs
@@ -56,6 +56,10 @@ pub const AGENT_PROTOCOL_VERSION: u32 = 1;
 /// a [`WorkPacket`]. Constants here keep the magic string out of call sites.
 pub const WORK_PACKET_KIND: &str = "agent_work";
 
+/// Substrate push `kind` for a whole-graph firing dispatched to an agent
+/// (CLOACI-T-0722). Payload = a serialized [`GraphWorkPacket`].
+pub const GRAPH_PACKET_KIND: &str = "agent_graph";
+
 /// Substrate recipient prefix for agent connections. The full recipient
 /// string for an agent is `format!("{}{}", AGENT_RECIPIENT_PREFIX, agent_id)`.
 pub const AGENT_RECIPIENT_PREFIX: &str = "agent:";
@@ -167,6 +171,32 @@ pub struct WorkPacket {
     /// still handled as before. (CLOACI-T-0716)
     #[serde(default)]
     pub language: Option<String>,
+}
+
+/// One reactor firing shipped to an agent for whole-graph execution
+/// (CLOACI-T-0722). The server pre-converts the reactor's `InputCache`
+/// snapshot into the FFI cache shape (source name → JSON string), so the
+/// agent's job is: fetch the cdylib by digest, `execute_graph(cache)`,
+/// report the outcome via the standard `/v1/agent/result` rendezvous keyed
+/// by `firing_id`. Accumulators + reactor state never leave the server —
+/// only the compute does.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GraphWorkPacket {
+    pub protocol_version: u32,
+    /// Rendezvous key: a fresh UUID per firing. The agent reports it back as
+    /// the `task_execution_id` of its `AgentResultRequest` (the coordinator
+    /// is a plain uuid→result rendezvous; graph firings reuse it).
+    pub firing_id: String,
+    /// The graph (== reactor) name inside the package.
+    pub graph_name: String,
+    /// The firing's input snapshot in FFI shape: source name → UTF-8 JSON.
+    pub cache: std::collections::HashMap<String, String>,
+    /// Pointer to the cdylib artifact the agent must `dlopen`.
+    pub artifact: ArtifactRef,
+    /// Per-firing execution timeout.
+    pub timeout_seconds: u32,
+    /// Tenant scope (same semantics as [`WorkPacket::tenant_id`]).
+    pub tenant_id: Option<String>,
 }
 
 /// Reference to a workflow artifact (cdylib) the agent must fetch + load.


### PR DESCRIPTION
## T-0722 — CG compute leaves the server; live-verified on the fleet

When a reactor fires, the firing (InputCache snapshot + CG package digest) ships to an execution agent instead of running in the server's reactor. Accumulators and reactor state stay server-side — only the compute leaves. Per-node dispatch remains explicitly out of scope (see the task's Rejected section).

- **GraphExecutor seam** (`cloacina::computation_graph::graph_executor`): the reactor's two fire sites (Latest + Sequential) route through an injected executor; the default `InProcessGraphExecutor` preserves today's behavior byte-for-byte (CG suite 45/45 unchanged). The scheduler stores a swappable executor applied at spawn + restart.
- **Wire**: `GRAPH_PACKET_KIND` + `GraphWorkPacket` — the server pre-converts the snapshot into the FFI cache shape (extracted `input_cache_to_ffi_cache`), and the fleet coordinator rendezvous is reused verbatim, keyed by a fresh `firing_id` (`/v1/agent/result` is a pure uuid→result forward).
- **Server `FleetGraphExecutor`**: graph→package resolution at fire time (`find_package_for_surface` — no reactor-side plumbing), per-target-aware agent selection, outbox enqueue, result await. **Fallback policy**: PRE-dispatch failures (embedded graph, Python package, no agent, enqueue error, agent refusal) run in-process via the closure every fire event carries — the reactor never deadlocks; POST-dispatch failures surface as errors WITHOUT a local re-run (no double execution).
- **Agent**: `GRAPH_PACKET_KIND` dispatch + `process_graph_packet` — fetch cdylib by digest, per-digest `LoadedGraphPlugin` cache, FFI `execute_graph`; saturation refuses (server falls back).

**Live proof (demo stack)**: `Fleet GRAPH executor installed on the CG scheduler` at boot → injected `{"value": 42.0}` into `alpha` (mixed-rust) → `mixed_reactor` fired → `fleet: graph firing completed on agent agent_id=145f2a42… duration_ms=14` → fires log advanced `ok: true` with decodable inputs, 127ms end-to-end.

**Scope note**: Python CGs stay in-process in v1 (their compiled fn is a live PyObject assembled by the cloaca graph builder — not a shippable artifact); detected and cleanly falls back, filed as CLOACI-T-0841 with the full source-shipping design. Rust packaged CGs — the scaling case — dispatch fully.

Metis: T-0722 completed with evidence; T-0841 filed.

https://claude.ai/code/session_01VWpWbgCzNdQkFT74S3wPRM