### PR TITLE
fix(T-0842): state-accumulator windows were write-only on the boundary wire

### DIFF
--- a/.metis/backlog/bugs/CLOACI-T-0842.md
+++ b/.metis/backlog/bugs/CLOACI-T-0842.md
@@ -1,0 +1,129 @@
+---
+id: fires-log-renders-state
+level: task
+title: "Fires log renders state-accumulator windows as null — capture_fire_inputs only decodes passthrough frames"
+short_code: "CLOACI-T-0842"
+created_at: 2026-07-05T22:47:18.558543+00:00
+updated_at: 2026-07-05T22:54:28.088539+00:00
+parent:
+blocked_by: []
+archived: false
+
+tags:
+  - "#task"
+  - "#bug"
+  - "#phase/active"
+
+
+exit_criteria_met: false
+initiative_id: NULL
+---
+
+# Fires log renders state-accumulator windows as null — capture_fire_inputs only decodes passthrough frames
+
+*This template includes sections for various types of tasks. Delete sections that don't apply to your specific use case.*
+
+## Parent Initiative **[CONDITIONAL: Assigned Task]**
+
+[[Parent Initiative]]
+
+## Objective **[REQUIRED]**
+
+Filed as the "fires log shows `inputs: null` for state accumulators" cosmetic (known residual from T-0839's live verification). Investigation revealed the real shape of the bug — the state accumulator's boundary wire format, `bincode(Vec<serde_json::Value>)`, is **WRITE-ONLY**: `serde_json::Value` cannot deserialize from bincode (non-self-describing format; `Value::deserialize` needs `deserialize_any`). Nothing anywhere could ever read a state window:
+
+- `capture_fire_inputs` (fires log) → `null` — the reported symptom
+- `input_cache_to_ffi_cache` (packaged-CG FFI + fleet dispatch) → hard error
+- `PythonGraphExecutor::execute`'s input loop (`cache.get::<Value>`) → silently skipped — **and this decode failure also hit passthrough frames, meaning Python CG nodes have NEVER received accumulator inputs at all** (empty `cache_values` on every fire; nodes tolerate missing args so nobody noticed)
+
+## Fix — one wire shape for every boundary
+
+Emit state windows in the SAME shape passthrough events use: `bincode(Vec<u8>)` wrapping JSON bytes (a JSON array of the bounded history). `state_window_frame()` helper at both emit sites (restore-time + per-append). Every existing decoder then just works — the fires log's first decode branch, the FFI cache conversion, and (fixed alongside, same bug class) the Python executor's input loop now decodes the real wire shape (`get::<Vec<u8>>` + JSON parse) instead of the impossible `get::<Value>`.
+
+### Type
+- [x] Bug - Production issue that needs fixing
+
+### Priority
+- [x] P2 - Medium (fires-log observability + Python CG node inputs)
+
+### Impact Assessment
+- **Affected Users**: anyone using state accumulators (window invisible everywhere) or Python CGs with accumulator-fed nodes (inputs silently empty).
+- **Reproduction Steps**:
+  1. Inject events into a state accumulator (e.g. `py_window`, capacity 5) until its reactor fires.
+  2. `GET /v1/health/reactors/<reactor>/fires` → the state source renders `inputs: null`.
+- **Expected vs Actual**: expected the bounded window as a JSON array; actual `null` (and empty node inputs on the py side).
+
+## Acceptance Criteria
+
+## Acceptance Criteria
+
+## Acceptance Criteria **[REQUIRED]**
+
+- [ ] Fires log renders a state accumulator's window as a JSON array (live-verified).
+- [ ] Passthrough capture unchanged (regression test covers both shapes).
+- [ ] State runtime tests updated to the new wire shape; CG suite green.
+- [ ] Python CG node inputs actually populated (decode the real frame shape).
+
+## Test Cases **[CONDITIONAL: Testing Task]**
+
+{Delete unless this is a testing task}
+
+### Test Case 1: {Test Case Name}
+- **Test ID**: TC-001
+- **Preconditions**: {What must be true before testing}
+- **Steps**:
+  1. {Step 1}
+  2. {Step 2}
+  3. {Step 3}
+- **Expected Results**: {What should happen}
+- **Actual Results**: {To be filled during execution}
+- **Status**: {Pass/Fail/Blocked}
+
+### Test Case 2: {Test Case Name}
+- **Test ID**: TC-002
+- **Preconditions**: {What must be true before testing}
+- **Steps**:
+  1. {Step 1}
+  2. {Step 2}
+- **Expected Results**: {What should happen}
+- **Actual Results**: {To be filled during execution}
+- **Status**: {Pass/Fail/Blocked}
+
+## Documentation Sections **[CONDITIONAL: Documentation Task]**
+
+{Delete unless this is a documentation task}
+
+### User Guide Content
+- **Feature Description**: {What this feature does and why it's useful}
+- **Prerequisites**: {What users need before using this feature}
+- **Step-by-Step Instructions**:
+  1. {Step 1 with screenshots/examples}
+  2. {Step 2 with screenshots/examples}
+  3. {Step 3 with screenshots/examples}
+
+### Troubleshooting Guide
+- **Common Issue 1**: {Problem description and solution}
+- **Common Issue 2**: {Problem description and solution}
+- **Error Messages**: {List of error messages and what they mean}
+
+### API Documentation **[CONDITIONAL: API Documentation]**
+- **Endpoint**: {API endpoint description}
+- **Parameters**: {Required and optional parameters}
+- **Example Request**: {Code example}
+- **Example Response**: {Expected response format}
+
+## Implementation Notes **[CONDITIONAL: Technical Task]**
+
+{Keep for technical tasks, delete for non-technical. Technical details, approach, or important considerations}
+
+### Technical Approach
+{How this will be implemented}
+
+### Dependencies
+{Other tasks or systems this depends on}
+
+### Risk Considerations
+{Technical risks and mitigation strategies}
+
+## Status Updates **[REQUIRED]**
+
+*To be added during implementation*

--- a/.metis/backlog/bugs/CLOACI-T-0842.md
+++ b/.metis/backlog/bugs/CLOACI-T-0842.md
@@ -4,7 +4,7 @@ level: task
 title: "Fires log renders state-accumulator windows as null — capture_fire_inputs only decodes passthrough frames"
 short_code: "CLOACI-T-0842"
 created_at: 2026-07-05T22:47:18.558543+00:00
-updated_at: 2026-07-05T22:54:28.088539+00:00
+updated_at: 2026-07-05T22:59:18.794443+00:00
 parent:
 blocked_by: []
 archived: false
@@ -12,7 +12,7 @@ archived: false
 tags:
   - "#task"
   - "#bug"
-  - "#phase/active"
+  - "#phase/completed"
 
 
 exit_criteria_met: false
@@ -51,6 +51,8 @@ Emit state windows in the SAME shape passthrough events use: `bincode(Vec<u8>)` 
   1. Inject events into a state accumulator (e.g. `py_window`, capacity 5) until its reactor fires.
   2. `GET /v1/health/reactors/<reactor>/fires` → the state source renders `inputs: null`.
 - **Expected vs Actual**: expected the bounded window as a JSON array; actual `null` (and empty node inputs on the py side).
+
+## Acceptance Criteria
 
 ## Acceptance Criteria
 
@@ -126,4 +128,9 @@ Emit state windows in the SAME shape passthrough events use: `bincode(Vec<u8>)` 
 
 ## Status Updates **[REQUIRED]**
 
-*To be added during implementation*
+### 2026-07-05 — FIXED + LIVE-PROVEN (branch fix/t0842-fires-log-state-windows, commit 96774394)
+First attempt (decode `bincode(Vec<Value>)` in `capture_fire_inputs`) was DISPROVEN by its own regression test — bincode cannot deserialize `Value` at all (the runtime tests that seemed to contradict this decode `Vec<i64>`, not `Value`). That proved the wire format itself was write-only and forced the correct fix at the EMIT side: `state_window_frame()` ships the window as `bincode(Vec<u8>)` of the JSON array (the passthrough shape) at both emit sites; every existing decoder then just works. The Python executor's input loop — which could never decode ANY frame shape via `get::<Value>` — now decodes the real wire (`get::<Vec<u8>>` + JSON parse), so py CG nodes receive accumulator inputs for the first time.
+
+**Tests**: `capture_fire_inputs_decodes_state_windows_and_passthrough` (both shapes), state runtime tests updated to the new wire, CG suite 46/46.
+
+**LIVE PROOF (demo stack)**: five injects into `py_window` (capacity 5) → `demo_py_state_rx` fires show the window GROWING in the fires log — `"inputs":{"py_window":[{"value":1.0},…,{"value":4.0}]}` then `[…,{"value":5.0}]` — previously an unbroken column of `null`. All ACs met. COMPLETE.

--- a/crates/cloacina-python/src/computation_graph.rs
+++ b/crates/cloacina-python/src/computation_graph.rs
@@ -713,11 +713,18 @@ impl PythonGraphExecutor {
     ) -> GraphResult {
         let executor = self.clone();
 
-        // Deserialize cache inputs
+        // Deserialize cache inputs. Boundary frames are bincode(Vec<u8>) of
+        // raw JSON (passthrough events AND — since CLOACI-T-0842 — state
+        // windows). The old `cache.get::<serde_json::Value>` could NEVER
+        // decode either shape (`Value` can't deserialize from bincode —
+        // deserialize_any), so node inputs were silently empty; decode the
+        // real wire shape.
         let mut cache_values: HashMap<String, serde_json::Value> = HashMap::new();
         for acc_name in &executor.accumulators {
-            if let Some(Ok(val)) = cache.get::<serde_json::Value>(acc_name) {
-                cache_values.insert(acc_name.clone(), val);
+            if let Some(Ok(json_bytes)) = cache.get::<Vec<u8>>(acc_name) {
+                if let Ok(val) = serde_json::from_slice::<serde_json::Value>(&json_bytes) {
+                    cache_values.insert(acc_name.clone(), val);
+                }
             }
         }
 

--- a/crates/cloacina/src/computation_graph/accumulator.rs
+++ b/crates/cloacina/src/computation_graph/accumulator.rs
@@ -1054,6 +1054,20 @@ impl<T: Serialize + DeserializeOwned + Send + Clone + 'static> StateAccumulator<
 /// evicts if over capacity, persists to DAL, and emits the full list as boundary.
 ///
 /// On startup: loads from DAL and emits current list to reactor.
+/// Encode a state window for the boundary wire (CLOACI-T-0842).
+///
+/// The window ships in the SAME shape passthrough events use —
+/// `bincode(Vec<u8>)` of JSON bytes (here, a JSON array) — because the
+/// previous `bincode(Vec<T>)` encoding was WRITE-ONLY for the
+/// `serde_json::Value` instantiation the factory uses: `Value` can't
+/// deserialize from bincode (non-self-describing, `deserialize_any`), so the
+/// fires log rendered `null`, the FFI cache conversion errored, and no
+/// consumer could read the window. One wire shape for every boundary means
+/// every existing decoder just works.
+fn state_window_frame<T: Serialize>(list: &[T]) -> Result<Vec<u8>, String> {
+    serde_json::to_vec(list).map_err(|e| e.to_string())
+}
+
 pub async fn state_accumulator_runtime<T: Serialize + DeserializeOwned + Send + Clone + 'static>(
     mut acc: StateAccumulator<T>,
     ctx: AccumulatorContext,
@@ -1086,8 +1100,15 @@ pub async fn state_accumulator_runtime<T: Serialize + DeserializeOwned + Send + 
         // Emit current list to reactor immediately (so reactor has state on startup)
         if !acc.buffer.is_empty() && acc.capacity != 0 {
             let list: Vec<T> = acc.buffer.iter().cloned().collect();
-            if let Err(e) = ctx.output.send(&list).await {
-                tracing::error!(name = %ctx.name, "state accumulator initial emit failed: {}", e);
+            match state_window_frame(&list) {
+                Ok(frame) => {
+                    if let Err(e) = ctx.output.send(&frame).await {
+                        tracing::error!(name = %ctx.name, "state accumulator initial emit failed: {}", e);
+                    }
+                }
+                Err(e) => {
+                    tracing::error!(name = %ctx.name, "state window encode failed: {}", e)
+                }
             }
         }
     }
@@ -1149,10 +1170,17 @@ pub async fn state_accumulator_runtime<T: Serialize + DeserializeOwned + Send + 
                         // Emit full list as boundary (unless write-only mode)
                         if acc.capacity != 0 {
                             let list: Vec<T> = acc.buffer.iter().cloned().collect();
-                            if let Err(e) = ctx.output.send(&list).await {
-                                tracing::error!(name = %ctx.name, "state accumulator emit failed: {}", e);
-                            } else {
-                                persist_boundary(&ctx, &list).await;
+                            match state_window_frame(&list) {
+                                Ok(frame) => {
+                                    if let Err(e) = ctx.output.send(&frame).await {
+                                        tracing::error!(name = %ctx.name, "state accumulator emit failed: {}", e);
+                                    } else {
+                                        persist_boundary(&ctx, &list).await;
+                                    }
+                                }
+                                Err(e) => {
+                                    tracing::error!(name = %ctx.name, "state window encode failed: {}", e)
+                                }
                             }
                         }
                     }
@@ -1886,7 +1914,11 @@ mod tests {
                     .expect("boundary should arrive within 2s")
                     .expect("boundary channel open");
             assert_eq!(name, SourceName::new("state_bounded"));
-            let list: Vec<i64> = types::deserialize(&bytes).unwrap();
+            // CLOACI-T-0842: the window ships as JSON-array bytes in the
+            // passthrough bincode(Vec<u8>) wrapper (one wire shape for every
+            // boundary) — decode accordingly.
+            let json_bytes: Vec<u8> = types::deserialize(&bytes).unwrap();
+            let list: Vec<i64> = serde_json::from_slice(&json_bytes).unwrap();
             assert_eq!(
                 list, exp,
                 "bounded history mismatch (capacity={})",

--- a/crates/cloacina/src/computation_graph/reactor.rs
+++ b/crates/cloacina/src/computation_graph/reactor.rs
@@ -1225,6 +1225,48 @@ fn record_reactor_persist_failure(
 
 #[cfg(test)]
 mod tests {
+    /// CLOACI-T-0842: the fires log must render BOTH boundary wire shapes —
+    /// passthrough frames (bincode(Vec<u8>) of raw event JSON) and state
+    /// windows (bincode(Vec<Value>) of the bounded history). State windows
+    /// previously fell through every decode branch and rendered `null`.
+    #[test]
+    fn capture_fire_inputs_decodes_state_windows_and_passthrough() {
+        let mut cache = cloacina_computation_graph::InputCache::new();
+
+        // Passthrough shape: raw JSON bytes wrapped as bincode(Vec<u8>).
+        let event = br#"{"value": 42.0}"#.to_vec();
+        cache.update(
+            cloacina_computation_graph::SourceName::new("passthrough_src"),
+            bincode::serialize(&event).unwrap(),
+        );
+
+        // State-window shape (CLOACI-T-0842): the window ships as JSON-array
+        // bytes in the SAME bincode(Vec<u8>) wrapper passthrough uses — the
+        // old bincode(Vec<Value>) encoding was write-only (Value can't
+        // deserialize from bincode) and rendered null everywhere.
+        let window = vec![
+            serde_json::json!({"value": 1.0}),
+            serde_json::json!({"value": 2.0}),
+        ];
+        cache.update(
+            cloacina_computation_graph::SourceName::new("state_src"),
+            bincode::serialize(&serde_json::to_vec(&window).unwrap()).unwrap(),
+        );
+
+        let inputs = super::capture_fire_inputs(&cache);
+
+        assert_eq!(
+            inputs["passthrough_src"],
+            serde_json::json!({"value": 42.0}),
+            "passthrough frame must decode to the raw event"
+        );
+        assert_eq!(
+            inputs["state_src"],
+            serde_json::json!([{"value": 1.0}, {"value": 2.0}]),
+            "state window must decode to the JSON array, not null"
+        );
+    }
+
     use super::*;
 
     #[test]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "cloacina",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
## T-0842 — the fires-log "inputs: null" cosmetic was a write-only wire format

State accumulators emitted their bounded window as `bincode(Vec<serde_json::Value>)` — which **nothing can decode**: `Value` cannot deserialize from bincode (non-self-describing; `deserialize_any`). Every consumer was blind:

- the fires log rendered `null` for state sources (the reported symptom, known since T-0839)
- `input_cache_to_ffi_cache` (packaged-CG FFI + fleet dispatch) errored on state frames
- the Python executor's input loop (`cache.get::<Value>`) silently skipped — and that same impossible decode also hit passthrough frames, meaning **Python CG nodes have never received accumulator inputs at all** (nodes tolerate missing args, so it never surfaced)

**Fix — one wire shape for every boundary**: state windows now ship as `bincode(Vec<u8>)` wrapping the JSON array (the passthrough shape) via `state_window_frame()` at both emit sites. Every existing decoder just works. The Python input loop now decodes the real frame shape (`get::<Vec<u8>>` + JSON parse), so py CG nodes get their inputs for the first time.

**Tests**: new `capture_fire_inputs_decodes_state_windows_and_passthrough` regression (it disproved the first-attempt decode-side fix and forced the correct emit-side one); state runtime tests updated to the new wire; CG suite 46/46.

**Live proof (demo stack)**: five injects into `py_window` (capacity 5) → the fires log shows the window growing — `[{"value":1.0},…,{"value":4.0}]` then `[…,{"value":5.0}]` — where it was previously an unbroken column of `null`.

Metis: T-0842 completed with evidence.

https://claude.ai/code/session_01VWpWbgCzNdQkFT74S3wPRM