### PR TITLE
fix(ci): fidius interface is v4 with 11 methods — un-red main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,4 @@ clients/python/dist/
 
 # Soak run artifacts (durable logs; not source)
 .angreal/test/soak/runs/
+stress-env

--- a/crates/cloacina/tests/integration/fidius_validation.rs
+++ b/crates/cloacina/tests/integration/fidius_validation.rs
@@ -251,12 +251,12 @@ fn test_plugin_info_populated() {
         "Interface hash should be non-zero"
     );
     assert_eq!(
-        plugin.info.interface_version, 3,
-        "Interface version should be 3 (CLOACI-I-0128 get_input_interface)"
+        plugin.info.interface_version, 4,
+        "Interface version should be 4 (CLOACI-I-0132 get_constructor_metadata)"
     );
     assert_eq!(
-        plugin.method_count, 10,
-        "Should have 10 methods (get_task_metadata, execute_task, get_graph_metadata, execute_graph, get_reactor_metadata, get_trigger_metadata, invoke_trigger_poll, get_triggerless_graph_metadata, invoke_triggerless_graph, get_input_interface)"
+        plugin.method_count, 11,
+        "Should have 11 methods (get_task_metadata, execute_task, get_graph_metadata, execute_graph, get_reactor_metadata, get_trigger_metadata, invoke_trigger_poll, get_triggerless_graph_metadata, invoke_triggerless_graph, get_input_interface, get_constructor_metadata)"
     );
 }
 


### PR DESCRIPTION
Main's postgres integration lanes have been red since **2026-06-29** on exactly one assertion: `test_plugin_info_populated` expects `interface_version == 3` / `method_count == 10` (the I-0128 shape), but the I-0132 constructor work added `get_constructor_metadata` and bumped `#[plugin_interface(version = 4)]` without updating it.

- CI evidence: every main run since the constructors-threading merge fails only this test (`left: 4, right: 3`); the also-logged "intentional graph node panic" is a passing test's expected output, not a failure.
- Fix: assert v4 / 11 methods with the constructor method named in the message.
- Verified statically against `crates/cloacina-workflow-plugin/src/lib.rs:841` (version = 4; 11 trait methods); the PR's own postgres lane is the executable proof (the fixture dylib build is CI-side).

No other stale interface assertions in the tree (grepped).

https://claude.ai/code/session_01VWpWbgCzNdQkFT74S3wPRM