### PR TITLE
fix(ci): harden all compose lanes against the postgres init-restart race (T-0806)

### DIFF
--- a/.angreal/test/_utils.py
+++ b/.angreal/test/_utils.py
@@ -21,3 +21,86 @@ def print_final_success(message):
     print(f"\n{'='*50}")
     print(message)
     print(f"{'='*50}")
+
+
+def wait_for_postgres_stable(
+    compose_file=".angreal/docker-compose.yaml",
+    cwd=None,
+    user="cloacina",
+    consecutive=3,
+    attempts=60,
+    interval=1.0,
+):
+    """Wait until the compose Postgres is *stably* accepting connections.
+
+    `pg_isready` can pass during Postgres's init-restart window and then the
+    server bounces — a caller that fires psql right after a single success
+    races the restart and dies with a transient connection error (exit 56;
+    this flaked the 0.9.0 release nightly). Require `consecutive` successes,
+    `interval` apart, so the bounce window can't slip through. (CLOACI-T-0806;
+    the readiness half of PR #145's `_fresh_database` retry.)
+    """
+    import subprocess
+    import time
+
+    streak = 0
+    for _ in range(attempts):
+        r = subprocess.run(
+            [
+                "docker", "compose", "-f", str(compose_file),
+                "exec", "-T", "postgres", "pg_isready", "-U", user,
+            ],
+            capture_output=True,
+            cwd=cwd,
+        )
+        if r.returncode == 0:
+            streak += 1
+            if streak >= consecutive:
+                return
+        else:
+            streak = 0
+        time.sleep(interval)
+    raise RuntimeError(
+        f"Postgres not stably ready after {attempts} checks "
+        f"(needed {consecutive} consecutive pg_isready successes)"
+    )
+
+
+def psql_retry(
+    sql_args,
+    compose_file=".angreal/docker-compose.yaml",
+    cwd=None,
+    user="cloacina",
+    dbname="postgres",
+    attempts=10,
+    interval=2.0,
+):
+    """Run IDEMPOTENT psql statements against the compose Postgres, retrying
+    transient connection failures (the exit-56 class). Mirrors the hardening
+    PR #145 gave the UI e2e `_fresh_database`; shared so every lane gets it
+    (CLOACI-T-0806). `sql_args` is the list of trailing psql args (e.g.
+    ["-c", "DROP ...", "-c", "CREATE ..."]).
+    """
+    import subprocess
+    import time
+
+    last = None
+    for _ in range(attempts):
+        last = subprocess.run(
+            [
+                "docker", "compose", "-f", str(compose_file),
+                "exec", "-T", "postgres",
+                "psql", "-U", user, "-d", dbname,
+            ]
+            + list(sql_args),
+            capture_output=True,
+            cwd=cwd,
+        )
+        if last.returncode == 0:
+            return last
+        time.sleep(interval)
+    import subprocess as _sp
+
+    raise _sp.CalledProcessError(
+        last.returncode, last.args, output=last.stdout, stderr=last.stderr
+    )

--- a/.angreal/test/auth.py
+++ b/.angreal/test/auth.py
@@ -39,17 +39,12 @@ def start_postgres():
         ["docker", "compose", "-f", ".angreal/docker-compose.yaml", "up", "-d"],
         check=True,
     )
-    for _ in range(30):
-        result = subprocess.run(
-            ["docker", "compose", "-f", ".angreal/docker-compose.yaml", "exec", "-T",
-             "postgres", "pg_isready", "-U", "cloacina"],
-            capture_output=True,
-        )
-        if result.returncode == 0:
-            print("  Postgres is ready.")
-            return
-        time.sleep(1)
-    raise RuntimeError("Postgres failed to start")
+    # CLOACI-T-0806: consecutive-success readiness — a single pg_isready pass
+    # can land inside the init-restart bounce (exit 56).
+    from ._utils import wait_for_postgres_stable
+
+    wait_for_postgres_stable()
+    print("  Postgres is ready.")
 
 
 def stop_postgres():

--- a/.angreal/test/e2e/cli.py
+++ b/.angreal/test/e2e/cli.py
@@ -40,18 +40,13 @@ def _start_postgres():
         ["docker", "compose", "-f", ".angreal/docker-compose.yaml", "up", "-d"],
         check=True,
     )
-    for _ in range(30):
-        r = subprocess.run(
-            [
-                "docker", "compose", "-f", ".angreal/docker-compose.yaml",
-                "exec", "-T", "postgres", "pg_isready", "-U", "cloacina",
-            ],
-            capture_output=True,
-        )
-        if r.returncode == 0:
-            return
-        time.sleep(1)
-    raise RuntimeError("Postgres not ready")
+    # CLOACI-T-0806: require CONSECUTIVE pg_isready successes — a single pass
+    # can land inside Postgres's init-restart window, and the next psql then
+    # races the bounce (exit 56). This is the shared entrypoint for the e2e
+    # lanes, so hardening here covers every caller.
+    from .._utils import wait_for_postgres_stable
+
+    wait_for_postgres_stable()
 
 
 def _wait_for_health(base_url: str, timeout_s: float = 30.0, server_proc=None):

--- a/.angreal/test/e2e/compiler.py
+++ b/.angreal/test/e2e/compiler.py
@@ -67,19 +67,11 @@ def _start_postgres():
         cwd=REPO_ROOT,
         check=True,
     )
-    for _ in range(30):
-        r = subprocess.run(
-            [
-                "docker", "compose", "-f", ".angreal/docker-compose.yaml",
-                "exec", "-T", "postgres", "pg_isready", "-U", "cloacina",
-            ],
-            cwd=REPO_ROOT,
-            capture_output=True,
-        )
-        if r.returncode == 0:
-            return
-        time.sleep(1)
-    raise RuntimeError("Postgres not ready after 30s")
+    # CLOACI-T-0806: consecutive-success readiness so the follow-on psql
+    # can't race the init-restart bounce (exit 56).
+    from .._utils import wait_for_postgres_stable
+
+    wait_for_postgres_stable(cwd=REPO_ROOT)
 
 
 def _wait_http(

--- a/.angreal/test/e2e/sdk_contract.py
+++ b/.angreal/test/e2e/sdk_contract.py
@@ -45,18 +45,15 @@ PROJECT_ROOT = Path(angreal.get_root()).parent
 def _fresh_database():
     """Drop + recreate the `cloacina` database so prior state can't leak
     into contract assertions (the server currently hardcodes the dbname —
-    CLOACI-T-0649 — so isolation has to happen at this level)."""
-    subprocess.run(
-        [
-            "docker", "compose", "-f", ".angreal/docker-compose.yaml",
-            "exec", "-T", "postgres",
-            "psql", "-U", "cloacina", "-d", "postgres",
-            "-c", "DROP DATABASE IF EXISTS cloacina WITH (FORCE);",
-            "-c", "CREATE DATABASE cloacina OWNER cloacina;",
-        ],
-        check=True,
-        capture_output=True,
-    )
+    CLOACI-T-0649 — so isolation has to happen at this level). Retried via
+    the shared helper — the raw check=True call raced Postgres's
+    init-restart bounce (exit 56, CLOACI-T-0806)."""
+    from .._utils import psql_retry
+
+    psql_retry([
+        "-c", "DROP DATABASE IF EXISTS cloacina WITH (FORCE);",
+        "-c", "CREATE DATABASE cloacina OWNER cloacina;",
+    ])
 
 
 @contextlib.contextmanager

--- a/.angreal/test/e2e/ui_e2e.py
+++ b/.angreal/test/e2e/ui_e2e.py
@@ -70,25 +70,18 @@ def _run(cmd, cwd=PROJECT_ROOT, env=None):
 
 
 def _fresh_database():
-    # `_start_postgres` waits on `pg_isready`, but Postgres can still bounce
-    # during its init-restart window right after that passes — so a single
-    # DROP/CREATE can race a not-yet-stable server and fail with a transient
-    # connection error (exit 56). Retry a few times rather than killing the
-    # whole UI e2e run on a flake; the SQL is idempotent so re-running is safe.
-    last = None
-    for _ in range(10):
-        last = subprocess.run(
-            ["docker", "compose", "-f", str(COMPOSE_FILE), "exec", "-T", "postgres",
-             "psql", "-U", "cloacina", "-d", "postgres",
-             "-c", "DROP DATABASE IF EXISTS cloacina WITH (FORCE);",
-             "-c", "CREATE DATABASE cloacina OWNER cloacina;"],
-            capture_output=True,
-        )
-        if last.returncode == 0:
-            return
-        time.sleep(2)
-    raise subprocess.CalledProcessError(
-        last.returncode, last.args, output=last.stdout, stderr=last.stderr
+    # Postgres can bounce during its init-restart window even after
+    # `pg_isready` passes, so the DROP/CREATE retries transient failures
+    # (exit 56). PR #145 hardened this copy first; CLOACI-T-0806 lifted the
+    # pattern into the shared helper every lane now uses.
+    from .._utils import psql_retry
+
+    psql_retry(
+        [
+            "-c", "DROP DATABASE IF EXISTS cloacina WITH (FORCE);",
+            "-c", "CREATE DATABASE cloacina OWNER cloacina;",
+        ],
+        compose_file=str(COMPOSE_FILE),
     )
 
 

--- a/.angreal/test/e2e/ws.py
+++ b/.angreal/test/e2e/ws.py
@@ -38,17 +38,12 @@ def start_postgres():
         ["docker", "compose", "-f", ".angreal/docker-compose.yaml", "up", "-d"],
         check=True,
     )
-    for _ in range(30):
-        result = subprocess.run(
-            ["docker", "compose", "-f", ".angreal/docker-compose.yaml", "exec", "-T",
-             "postgres", "pg_isready", "-U", "cloacina"],
-            capture_output=True,
-        )
-        if result.returncode == 0:
-            print("  Postgres is ready.")
-            return
-        time.sleep(1)
-    raise RuntimeError("Postgres failed to start")
+    # CLOACI-T-0806: consecutive-success readiness — a single pg_isready pass
+    # can land inside the init-restart bounce (exit 56).
+    from .._utils import wait_for_postgres_stable
+
+    wait_for_postgres_stable()
+    print("  Postgres is ready.")
 
 
 def stop_postgres():

--- a/.angreal/test/integration.py
+++ b/.angreal/test/integration.py
@@ -193,9 +193,14 @@ def integration(
         exit_code = docker_up()
         if exit_code != 0:
             raise RuntimeError("Docker setup failed")
-        # Wait for services to be ready
-        print("Waiting for PostgreSQL to be ready...")
-        time.sleep(30)
+        # Wait for services to be ready. CLOACI-T-0806: a blind sleep(30)
+        # let one lane fire psql inside Postgres's init-restart bounce (exit
+        # 56, run 28125071912) — require consecutive pg_isready successes
+        # instead (also usually much faster than 30s).
+        print("Waiting for PostgreSQL to be stably ready...")
+        from ._utils import wait_for_postgres_stable
+
+        wait_for_postgres_stable()
 
     try:
         # Build feature flags - use --no-default-features for non-default feature sets

--- a/.angreal/test/metrics_format.py
+++ b/.angreal/test/metrics_format.py
@@ -68,16 +68,13 @@ def metrics_format():
         print("Failed to start Postgres.")
         return up.returncode
 
-    for _ in range(30):
-        ready = subprocess.run(
-            ["docker", "compose", "-f", str(compose_file), "exec", "-T",
-             "postgres", "pg_isready", "-U", "cloacina"],
-            capture_output=True,
-        )
-        if ready.returncode == 0:
-            break
-        time.sleep(1)
-    else:
+    # CLOACI-T-0806: consecutive-success readiness — a single pg_isready pass
+    # can land inside the init-restart bounce (exit 56).
+    from ._utils import wait_for_postgres_stable
+
+    try:
+        wait_for_postgres_stable(compose_file=str(compose_file))
+    except RuntimeError:
         subprocess.run(["docker", "compose", "-f", str(compose_file), "down", "-v"])
         print("Postgres never became ready.")
         return 1

--- a/.metis/backlog/tech-debt/CLOACI-T-0806.md
+++ b/.metis/backlog/tech-debt/CLOACI-T-0806.md
@@ -4,15 +4,15 @@ level: task
 title: "CI robustness — harden the remaining docker-compose test lanes against the postgres readiness race (exit 56)"
 short_code: "CLOACI-T-0806"
 created_at: 2026-06-25T12:03:18.070555+00:00
-updated_at: 2026-06-25T12:03:18.070555+00:00
+updated_at: 2026-07-06T00:04:37.972075+00:00
 parent: 
 blocked_by: []
 archived: false
 
 tags:
   - "#task"
-  - "#phase/backlog"
   - "#tech-debt"
+  - "#phase/completed"
 
 
 exit_criteria_met: false
@@ -75,6 +75,12 @@ Multiple docker-compose-based test lanes intermittently fail with **exit code 56
 - **Current Problems**: {What's difficult/slow/buggy now}
 - **Benefits of Fixing**: {What improves after refactoring}
 - **Risk Assessment**: {Risks of not addressing this}
+
+## Acceptance Criteria
+
+## Acceptance Criteria
+
+## Acceptance Criteria
 
 ## Acceptance Criteria **[REQUIRED]**
 
@@ -150,3 +156,8 @@ Multiple docker-compose-based test lanes intermittently fail with **exit code 56
 ## Status Updates **[REQUIRED]**
 
 **2026-06-25 — filed** during the v0.9.0 release recovery. Reference fix already landed: **PR #145** added a 10×/2s retry to `_fresh_database` in `.angreal/test/e2e/ui_e2e.py`. Exit-56 occurrences this session: UI Acceptance E2E `_fresh_database` psql (fixed), Integration Tests (sqlite, ubuntu) in run 28125071912 (RuntimeError/exit 56; the tests themselves passed). Strengthening `cli.py:_start_postgres` is the highest-leverage single change since it's the shared entrypoint. (Note: a *separate* nightly-harness gap — the UI e2e server not seeding the `acme` tenant-admin key — was fixed in PR #146; that's not this task.)
+
+### 2026-07-05 — DONE + LIVE-PROVEN (branch fix/t0806-pg-readiness-race)
+Two shared helpers in `.angreal/test/_utils.py`: `wait_for_postgres_stable` (requires N **consecutive** `pg_isready` successes, 1s apart — a single pass can land inside the init-restart bounce) and `psql_retry` (idempotent-DDL retry, the PR #145 pattern lifted out of its one copy). Rewired **eight** call sites — the AC's five (`e2e/cli.py _start_postgres` [shared entrypoint], `integration.py` [blind `sleep(30)` → stable wait, also faster], `e2e/compiler.py`, `e2e/sdk_contract.py _fresh_database` [was raw `check=True`], `e2e/ui_e2e.py` [deduped onto the helper]) **plus three more single-success loops the audit list missed**: `auth.py`, `metrics_format.py`, `e2e/ws.py`. No remaining "compose up → immediate psql check=True" sites (swept).
+
+**LIVE PROOF**: 3 complete fresh-volume init cycles (`down -v` → `up` → stable-wait → IMMEDIATE DROP/CREATE — the exact window where the bounce lives): stable at ~3.8s each (vs the 30s blind sleep), DROP/CREATE ok every time, zero exit-56. All 9 touched files parse; imports match each file's conventions. COMPLETE.


### PR DESCRIPTION
## T-0806 — exit-56 hardening, every lane

`pg_isready` can pass inside Postgres's **init-restart window**; a lane that fires psql right after a single success races the bounce and dies with a transient connection failure (exit 56 — this flaked the 0.9.0 release nightly). PR #145 hardened one call site; this finishes the job.

**Two shared helpers** (`.angreal/test/_utils.py`):
- `wait_for_postgres_stable` — requires N **consecutive** `pg_isready` successes so the bounce window can't slip through
- `psql_retry` — idempotent-DDL retry (the #145 pattern, lifted out of its single copy)

**Eight call sites rewired** — the task's audit list of five (`e2e/cli.py _start_postgres` [the shared entrypoint], `integration.py` [blind `sleep(30)` → stable wait, now also ~26s faster], `e2e/compiler.py`, `e2e/sdk_contract.py` [was raw `check=True`], `e2e/ui_e2e.py` [deduped]) plus three more single-success loops the audit missed (`auth.py`, `metrics_format.py`, `e2e/ws.py`). Swept: no remaining "compose up → immediate psql `check=True`" sites.

**Live proof**: 3 complete fresh-volume init cycles (down -v → up → stable-wait → immediate DROP/CREATE — the exact window where the bounce lives): stable at ~3.8s each, DDL ok every time, zero exit-56.

Metis: T-0806 completed with evidence.

https://claude.ai/code/session_01VWpWbgCzNdQkFT74S3wPRM