### PR TITLE
fix: authz table tripwire count 58 -> 59 (un-red main)

### DIFF
--- a/crates/cloacina-server/src/routes/authz.rs
+++ b/crates/cloacina-server/src/routes/authz.rs
@@ -826,7 +826,7 @@ mod tests {
         let t = build_authz_table();
         assert_eq!(
             t.len(),
-            58,
+            59,
             "authz table size changed — a route was added/removed without updating the table"
         );
 


### PR DESCRIPTION
The `authz_table_classifies_known_routes` no-drift guard asserted **58** routes, but `build_authz_table` has **59** explicitly-classified routes (verified: exactly 59 `add()` calls). The tripwire literal was stale — a route was classified without bumping the count — which failed the `cloacina-server` lib test on **every postgres CI lane**, leaving main red.

- **Not a security gap**: all 59 routes are classified, and the fail-closed middleware 403s anything unclassified regardless. Only the count assertion drifted.
- **Pre-existing**: authz.rs is unchanged since #169 (its 59 routes and the stale 58 literal both date to then); the team squash-merges through unstable CI, so it stayed latent-red. The I-0105 merge's CI run surfaced it.
- `cargo test -p cloacina-server --lib authz` → 8/8 green.

https://claude.ai/code/session_01WSzihhQReYhXGJnNWyTCHt