### PR TITLE
feat(I-0134): single source of version truth + bump 0.10.0

### DIFF
--- a/.angreal/task_release.py
+++ b/.angreal/task_release.py
@@ -1,0 +1,50 @@
+"""
+Release version management for Cloacina (CLOACI-I-0134).
+
+Thin angreal wrapper over `version_lockstep.py` (which holds the logic and is
+also run directly by the pre-commit hook / CI). ONE source of version truth:
+the `[workspace.package] version` in the root Cargo.toml; `release bump`
+rewrites every core touchpoint from one input, `release check` fails on drift.
+Providers under `examples/` are independently versioned (ADR A-0010) and are
+NOT touched.
+"""
+
+import angreal  # type: ignore
+
+# version_lockstep.py sits beside this file; angreal puts .angreal on sys.path
+# (same as task_services.py's `from utils import ...`). It is not a `task_*`
+# module, so angreal does not load it as a task.
+import version_lockstep  # noqa: E402
+
+release = angreal.command_group(
+    name="release", about="version bump + drift guard (single source of version truth)"
+)
+
+
+@release()
+@angreal.command(
+    name="check",
+    about="fail if any version touchpoint disagrees with the workspace version (drift guard)",
+    when_to_use=["verifying a bump landed everywhere", "reproducing the pre-commit guard"],
+    when_not_to_use=["needing to change the version (use `release bump`)"],
+)
+def check():
+    """Assert every core version touchpoint equals the canonical workspace version.
+
+    (The pre-commit hook runs `python .angreal/version_lockstep.py check` directly
+    for readable output — angreal swallows task stdout. Exit code is authoritative.)
+    """
+    return version_lockstep.run_check()
+
+
+@release()
+@angreal.command(
+    name="bump",
+    about="set the whole core repo (Rust/npm/python/scaffold + CHANGELOG stub) to a new version",
+    when_to_use=["cutting a release", "moving to the next dev version"],
+    when_not_to_use=["touching provider versions (independent, A-0010)"],
+)
+@angreal.argument(name="version", help="target semver, e.g. 0.10.0", required=True, takes_value=True)
+def bump(version: str):
+    """Rewrite every core version touchpoint to `version`. The git tag stays a human step."""
+    return version_lockstep.run_bump(version)

--- a/.angreal/version_lockstep.py
+++ b/.angreal/version_lockstep.py
@@ -1,0 +1,170 @@
+"""
+Single source of version truth for Cloacina CORE (CLOACI-I-0134).
+
+Standalone (no `angreal` import) so the pre-commit hook / CI can run it directly
+with `python .angreal/version_lockstep.py check` and get readable output — the
+angreal task runner swallows task stdout, so the guard lives here and
+`task_release.py` is a thin wrapper.
+
+Canonical version = `[workspace.package] version` in the root Cargo.toml.
+Every other CORE touchpoint inherits it (Rust `{ workspace = true }`) or is
+rewritten from it. Providers under `examples/` are independently versioned by
+design (ADR A-0010 / I-0134 D-6) and are deliberately NOT touched or checked.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+_SEMVER = re.compile(r"^\d+\.\d+\.\d+$")
+
+_JSON_FILES = [
+    ("npm · typescript client", "clients/typescript/package.json"),
+    ("npm · ui", "ui/package.json"),
+    ("npm · ui harness", "ui/harness/package.json"),
+]
+_PY_PYPROJECT = ("python · client pyproject", "clients/python/pyproject.toml")
+_PY_INIT = ("python · client __init__", "clients/python/src/cloacina_client/__init__.py")
+_SCAFFOLD = ("scaffold · CLOACINA_CRATE_VERSION", "crates/cloacinactl/src/nouns/package/new.rs")
+
+
+def _read(rel: str) -> str:
+    return (PROJECT_ROOT / rel).read_text()
+
+
+def _write(rel: str, text: str) -> None:
+    (PROJECT_ROOT / rel).write_text(text)
+
+
+def _minor(v: str) -> str:
+    p = v.split(".")
+    return f"{p[0]}.{p[1]}"
+
+
+def source_version() -> str:
+    """The canonical version: `version` under `[workspace.package]`."""
+    text = _read("Cargo.toml")
+    m = re.search(r"\[workspace\.package\][^\[]*?\bversion\s*=\s*\"([^\"]+)\"", text, re.DOTALL)
+    if not m:
+        raise SystemExit("version-lockstep: no [workspace.package] version in root Cargo.toml")
+    return m.group(1)
+
+
+def found_versions(source: str):
+    """(label, found, expected) for every core touchpoint."""
+    out = []
+    cargo = _read("Cargo.toml")
+    for m in re.finditer(
+        r"^(cloacina[\w-]*)\s*=\s*\{\s*version\s*=\s*\"([^\"]+)\"[^}]*path\s*=\s*\"crates/",
+        cargo,
+        re.MULTILINE,
+    ):
+        out.append((f"Cargo · {m.group(1)} dep pin", m.group(2), source))
+    for label, rel in _JSON_FILES:
+        m = re.search(r'"version"\s*:\s*"([^"]+)"', _read(rel))
+        out.append((label, m.group(1) if m else "<missing>", source))
+    m = re.search(r'^version\s*=\s*"([^"]+)"', _read(_PY_PYPROJECT[1]), re.MULTILINE)
+    out.append((_PY_PYPROJECT[0], m.group(1) if m else "<missing>", source))
+    m = re.search(r'__version__\s*=\s*"([^"]+)"', _read(_PY_INIT[1]))
+    out.append((_PY_INIT[0], m.group(1) if m else "<missing>", source))
+    m = re.search(r'CLOACINA_CRATE_VERSION:\s*&str\s*=\s*"([^"]+)"', _read(_SCAFFOLD[1]))
+    out.append((_SCAFFOLD[0], m.group(1) if m else "<missing>", _minor(source)))
+    return out
+
+
+def mismatches():
+    source = source_version()
+    return source, [(l, g, e) for (l, g, e) in found_versions(source) if g != e]
+
+
+def set_version(new: str) -> None:
+    source_minor = _minor(new)
+    cargo = _read("Cargo.toml")
+    cargo = re.sub(
+        r"(\[workspace\.package\][^\[]*?\bversion\s*=\s*\")[^\"]+(\")",
+        lambda mm: mm.group(1) + new + mm.group(2),
+        cargo,
+        count=1,
+        flags=re.DOTALL,
+    )
+    cargo = re.sub(
+        r"^(cloacina[\w-]*\s*=\s*\{\s*version\s*=\s*\")[^\"]+(\"[^}]*path\s*=\s*\"crates/)",
+        lambda mm: mm.group(1) + new + mm.group(2),
+        cargo,
+        flags=re.MULTILINE,
+    )
+    _write("Cargo.toml", cargo)
+    for _, rel in _JSON_FILES:
+        t = _read(rel)
+        t = re.sub(r'("version"\s*:\s*")[^"]+(")', r"\g<1>" + new + r"\g<2>", t, count=1)
+        _write(rel, t)
+    t = _read(_PY_PYPROJECT[1])
+    t = re.sub(r'^(version\s*=\s*")[^"]+(")', r"\g<1>" + new + r"\g<2>", t, count=1, flags=re.MULTILINE)
+    _write(_PY_PYPROJECT[1], t)
+    t = _read(_PY_INIT[1])
+    t = re.sub(r'(__version__\s*=\s*")[^"]+(")', r"\g<1>" + new + r"\g<2>", t, count=1)
+    _write(_PY_INIT[1], t)
+    t = _read(_SCAFFOLD[1])
+    t = re.sub(r'(CLOACINA_CRATE_VERSION:\s*&str\s*=\s*")[^"]+(")', r"\g<1>" + source_minor + r"\g<2>", t, count=1)
+    _write(_SCAFFOLD[1], t)
+
+
+def changelog_stub(new: str) -> None:
+    cl = PROJECT_ROOT / "CHANGELOG.md"
+    if not cl.exists():
+        return
+    text = cl.read_text()
+    if re.search(rf"^##\s*\[{re.escape(new)}\]", text, re.MULTILINE):
+        return
+    stub = f"## [{new}] - UNRELEASED\n\n### Added\n\n### Changed\n\n### Fixed\n\n"
+    m = re.search(r"^##\s*\[", text, re.MULTILINE)
+    text = (text[: m.start()] + stub + text[m.start():]) if m else (text.rstrip() + "\n\n" + stub)
+    cl.write_text(text)
+
+
+def run_check() -> int:
+    source, bad = mismatches()
+    if not bad:
+        print(f"version-lockstep OK — {len(found_versions(source))} touchpoints all at {source}")
+        return 0
+    print(f"version DRIFT — canonical [workspace.package] version is {source}:", file=sys.stderr)
+    for lbl, got, exp in bad:
+        print(f"  ✗ {lbl}: found {got!r}, expected {exp!r}", file=sys.stderr)
+    print("\nRun `angreal release bump <version>` to set every touchpoint from one input.", file=sys.stderr)
+    return 1
+
+
+def run_bump(new: str) -> int:
+    if not _SEMVER.match(new):
+        print(f"release bump: {new!r} is not MAJOR.MINOR.PATCH semver", file=sys.stderr)
+        return 1
+    old = source_version()
+    set_version(new)
+    changelog_stub(new)
+    _, bad = mismatches()
+    if bad:
+        print("WARNING: touchpoints still drifted after bump:", file=sys.stderr)
+        for lbl, got, exp in bad:
+            print(f"  ✗ {lbl}: {got!r} != {exp!r}", file=sys.stderr)
+        return 1
+    print(f"bumped {old} -> {new} across all core touchpoints + CHANGELOG stub; version-lockstep verified.")
+    print(f"Next: review, commit, then `git tag v{new}` when ready.")
+    return 0
+
+
+def main(argv) -> int:
+    if not argv or argv[0] == "check":
+        return run_check()
+    if argv[0] == "bump":
+        if len(argv) < 2:
+            print("usage: version_lockstep.py bump <version>", file=sys.stderr)
+            return 2
+        return run_bump(argv[1])
+    print(f"unknown command {argv[0]!r} (expected: check | bump <version>)", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/.metis/backlog/tech-debt/CLOACI-T-0871.md
+++ b/.metis/backlog/tech-debt/CLOACI-T-0871.md
@@ -1,0 +1,139 @@
+---
+id: first-party-provider-audit
+level: task
+title: "First-party provider audit + promotion out of examples/ — which are real providers, where do they live"
+short_code: "CLOACI-T-0871"
+created_at: 2026-07-08T11:43:20.369192+00:00
+updated_at: 2026-07-08T11:43:20.369192+00:00
+parent: 
+blocked_by: []
+archived: false
+
+tags:
+  - "#task"
+  - "#phase/backlog"
+  - "#tech-debt"
+
+
+exit_criteria_met: false
+initiative_id: NULL
+---
+
+# First-party provider audit + promotion out of examples/ — which are real providers, where do they live
+
+*This template includes sections for various types of tasks. Delete sections that don't apply to your specific use case.*
+
+## Parent Initiative **[CONDITIONAL: Assigned Task]**
+
+[[Parent Initiative]]
+
+## Objective **[REQUIRED]**
+
+Surfaced during I-0134 (version single-source, 2026-07-08). Providers are already independently versioned standalone crates (per [[CLOACI-A-0010]]) living under `examples/constructor-contract/`: `cloacina-provider-{fs,extract,quorum,sensor}` (each own `[workspace]`, own `version = "0.1.0"`, excluded from core's workspace). **Location smell:** if any are FIRST-PARTY providers meant to actually ship, `examples/` is a poor release home.
+
+Audit which of these are real first-party providers vs. purely illustrative examples (maintainer note: **only `cloacina-provider-fs` has a name expected of a real provider**; sensor/quorum/extract likely just demonstrate the pattern). For the real ones, decide the promotion target — a top-level `providers/` directory (still standalone crates, still excluded from core's workspace, each own version) vs. leaving them as examples. Do NOT re-litigate A-0010 (independent versioning is decided); this is about LOCATION/productization only. Pairs with [[CLOACI-T-0872]] (release path).
+
+## Backlog Item Details **[CONDITIONAL: Backlog Item]**
+
+{Delete this section when task is assigned to an initiative}
+
+### Type
+- [ ] Bug - Production issue that needs fixing
+- [ ] Feature - New functionality or enhancement  
+- [ ] Tech Debt - Code improvement or refactoring
+- [ ] Chore - Maintenance or setup work
+
+### Priority
+- [ ] P0 - Critical (blocks users/revenue)
+- [ ] P1 - High (important for user experience)
+- [ ] P2 - Medium (nice to have)
+- [ ] P3 - Low (when time permits)
+
+### Impact Assessment **[CONDITIONAL: Bug]**
+- **Affected Users**: {Number/percentage of users affected}
+- **Reproduction Steps**: 
+  1. {Step 1}
+  2. {Step 2}
+  3. {Step 3}
+- **Expected vs Actual**: {What should happen vs what happens}
+
+### Business Justification **[CONDITIONAL: Feature]**
+- **User Value**: {Why users need this}
+- **Business Value**: {Impact on metrics/revenue}
+- **Effort Estimate**: {Rough size - S/M/L/XL}
+
+### Technical Debt Impact **[CONDITIONAL: Tech Debt]**
+- **Current Problems**: {What's difficult/slow/buggy now}
+- **Benefits of Fixing**: {What improves after refactoring}
+- **Risk Assessment**: {Risks of not addressing this}
+
+## Acceptance Criteria **[REQUIRED]**
+
+- [ ] {Specific, testable requirement 1}
+- [ ] {Specific, testable requirement 2}
+- [ ] {Specific, testable requirement 3}
+
+## Test Cases **[CONDITIONAL: Testing Task]**
+
+{Delete unless this is a testing task}
+
+### Test Case 1: {Test Case Name}
+- **Test ID**: TC-001
+- **Preconditions**: {What must be true before testing}
+- **Steps**: 
+  1. {Step 1}
+  2. {Step 2}
+  3. {Step 3}
+- **Expected Results**: {What should happen}
+- **Actual Results**: {To be filled during execution}
+- **Status**: {Pass/Fail/Blocked}
+
+### Test Case 2: {Test Case Name}
+- **Test ID**: TC-002
+- **Preconditions**: {What must be true before testing}
+- **Steps**: 
+  1. {Step 1}
+  2. {Step 2}
+- **Expected Results**: {What should happen}
+- **Actual Results**: {To be filled during execution}
+- **Status**: {Pass/Fail/Blocked}
+
+## Documentation Sections **[CONDITIONAL: Documentation Task]**
+
+{Delete unless this is a documentation task}
+
+### User Guide Content
+- **Feature Description**: {What this feature does and why it's useful}
+- **Prerequisites**: {What users need before using this feature}
+- **Step-by-Step Instructions**:
+  1. {Step 1 with screenshots/examples}
+  2. {Step 2 with screenshots/examples}
+  3. {Step 3 with screenshots/examples}
+
+### Troubleshooting Guide
+- **Common Issue 1**: {Problem description and solution}
+- **Common Issue 2**: {Problem description and solution}
+- **Error Messages**: {List of error messages and what they mean}
+
+### API Documentation **[CONDITIONAL: API Documentation]**
+- **Endpoint**: {API endpoint description}
+- **Parameters**: {Required and optional parameters}
+- **Example Request**: {Code example}
+- **Example Response**: {Expected response format}
+
+## Implementation Notes **[CONDITIONAL: Technical Task]**
+
+{Keep for technical tasks, delete for non-technical. Technical details, approach, or important considerations}
+
+### Technical Approach
+{How this will be implemented}
+
+### Dependencies
+{Other tasks or systems this depends on}
+
+### Risk Considerations
+{Technical risks and mitigation strategies}
+
+## Status Updates **[REQUIRED]**
+
+*To be added during implementation*

--- a/.metis/backlog/tech-debt/CLOACI-T-0872.md
+++ b/.metis/backlog/tech-debt/CLOACI-T-0872.md
@@ -1,0 +1,139 @@
+---
+id: independent-provider-release-path
+level: task
+title: "Independent provider release path — publish/tag first-party providers on their own cadence (not core's v* tag)"
+short_code: "CLOACI-T-0872"
+created_at: 2026-07-08T11:43:21.080493+00:00
+updated_at: 2026-07-08T11:43:21.080493+00:00
+parent: 
+blocked_by: []
+archived: false
+
+tags:
+  - "#task"
+  - "#phase/backlog"
+  - "#tech-debt"
+
+
+exit_criteria_met: false
+initiative_id: NULL
+---
+
+# Independent provider release path — publish/tag first-party providers on their own cadence (not core's v* tag)
+
+*This template includes sections for various types of tasks. Delete sections that don't apply to your specific use case.*
+
+## Parent Initiative **[CONDITIONAL: Assigned Task]**
+
+[[Parent Initiative]]
+
+## Objective **[REQUIRED]**
+
+Surfaced during I-0134 (2026-07-08). Providers are STRUCTURALLY independent (standalone crates, own semver, [[CLOACI-A-0010]]) but there is NO operational release path for them: `.github/workflows/unified_release.yml` triggers on CORE `v*` tags only, and the first-party providers aren't published anywhere. So "independent release schedule" is not yet real — only the structure exists.
+
+Design + build a release path for first-party providers that lets them publish/tag on their OWN cadence, decoupled from core's `v*` tag (e.g. per-provider tags like `provider-fs-vX.Y.Z` → publish that crate to crates.io). Keep it separate from the core release pipeline (I-0134 non-goal: don't entangle core's release with providers). Blocked-ish on [[CLOACI-T-0871]] (which providers are real + where they live). Do NOT re-litigate A-0010.
+
+## Backlog Item Details **[CONDITIONAL: Backlog Item]**
+
+{Delete this section when task is assigned to an initiative}
+
+### Type
+- [ ] Bug - Production issue that needs fixing
+- [ ] Feature - New functionality or enhancement  
+- [ ] Tech Debt - Code improvement or refactoring
+- [ ] Chore - Maintenance or setup work
+
+### Priority
+- [ ] P0 - Critical (blocks users/revenue)
+- [ ] P1 - High (important for user experience)
+- [ ] P2 - Medium (nice to have)
+- [ ] P3 - Low (when time permits)
+
+### Impact Assessment **[CONDITIONAL: Bug]**
+- **Affected Users**: {Number/percentage of users affected}
+- **Reproduction Steps**: 
+  1. {Step 1}
+  2. {Step 2}
+  3. {Step 3}
+- **Expected vs Actual**: {What should happen vs what happens}
+
+### Business Justification **[CONDITIONAL: Feature]**
+- **User Value**: {Why users need this}
+- **Business Value**: {Impact on metrics/revenue}
+- **Effort Estimate**: {Rough size - S/M/L/XL}
+
+### Technical Debt Impact **[CONDITIONAL: Tech Debt]**
+- **Current Problems**: {What's difficult/slow/buggy now}
+- **Benefits of Fixing**: {What improves after refactoring}
+- **Risk Assessment**: {Risks of not addressing this}
+
+## Acceptance Criteria **[REQUIRED]**
+
+- [ ] {Specific, testable requirement 1}
+- [ ] {Specific, testable requirement 2}
+- [ ] {Specific, testable requirement 3}
+
+## Test Cases **[CONDITIONAL: Testing Task]**
+
+{Delete unless this is a testing task}
+
+### Test Case 1: {Test Case Name}
+- **Test ID**: TC-001
+- **Preconditions**: {What must be true before testing}
+- **Steps**: 
+  1. {Step 1}
+  2. {Step 2}
+  3. {Step 3}
+- **Expected Results**: {What should happen}
+- **Actual Results**: {To be filled during execution}
+- **Status**: {Pass/Fail/Blocked}
+
+### Test Case 2: {Test Case Name}
+- **Test ID**: TC-002
+- **Preconditions**: {What must be true before testing}
+- **Steps**: 
+  1. {Step 1}
+  2. {Step 2}
+- **Expected Results**: {What should happen}
+- **Actual Results**: {To be filled during execution}
+- **Status**: {Pass/Fail/Blocked}
+
+## Documentation Sections **[CONDITIONAL: Documentation Task]**
+
+{Delete unless this is a documentation task}
+
+### User Guide Content
+- **Feature Description**: {What this feature does and why it's useful}
+- **Prerequisites**: {What users need before using this feature}
+- **Step-by-Step Instructions**:
+  1. {Step 1 with screenshots/examples}
+  2. {Step 2 with screenshots/examples}
+  3. {Step 3 with screenshots/examples}
+
+### Troubleshooting Guide
+- **Common Issue 1**: {Problem description and solution}
+- **Common Issue 2**: {Problem description and solution}
+- **Error Messages**: {List of error messages and what they mean}
+
+### API Documentation **[CONDITIONAL: API Documentation]**
+- **Endpoint**: {API endpoint description}
+- **Parameters**: {Required and optional parameters}
+- **Example Request**: {Code example}
+- **Example Response**: {Expected response format}
+
+## Implementation Notes **[CONDITIONAL: Technical Task]**
+
+{Keep for technical tasks, delete for non-technical. Technical details, approach, or important considerations}
+
+### Technical Approach
+{How this will be implemented}
+
+### Dependencies
+{Other tasks or systems this depends on}
+
+### Risk Considerations
+{Technical risks and mitigation strategies}
+
+## Status Updates **[REQUIRED]**
+
+*To be added during implementation*

--- a/.metis/backlog/tech-debt/CLOACI-T-0873.md
+++ b/.metis/backlog/tech-debt/CLOACI-T-0873.md
@@ -1,0 +1,143 @@
+---
+id: generic-invoke-ffi-marshaling-seam
+level: task
+title: "Generic invoke_ffi marshaling seam — investigate collapsing the 62 per-method-index FFI bridges"
+short_code: "CLOACI-T-0873"
+created_at: 2026-07-08T14:20:14.965414+00:00
+updated_at: 2026-07-08T14:20:14.965414+00:00
+parent: 
+blocked_by: []
+archived: false
+
+tags:
+  - "#task"
+  - "#phase/backlog"
+  - "#tech-debt"
+
+
+exit_criteria_met: false
+initiative_id: NULL
+---
+
+# Generic invoke_ffi marshaling seam — investigate collapsing the 62 per-method-index FFI bridges
+
+*This template includes sections for various types of tasks. Delete sections that don't apply to your specific use case.*
+
+## Parent Initiative **[CONDITIONAL: Assigned Task]**
+
+[[Parent Initiative]]
+
+## Objective **[REQUIRED]**
+
+Tech-debt investigate-and-decide (the ONE "Worth exploring" candidate from the 2026-07-08 architecture deepening review). NOT committed to implement — investigate the seam, decide.
+
+**The shallowness.** ~**62** call sites across `crates/cloacina/src/registry/loader/{package_loader,constructor_loader,ffi_trigger,ffi_triggerless_graph,task_registrar/*}.rs` hand-roll the same shallow FFI bridge per plugin-ABI method index: `serde_json::to_string(&XInvocation) → spawn_blocking { handle.call_method::<_,String>(METHOD_X, &(json,)) } → serde_json::from_str::<XOutcome>`, each with its own `XInvocation`/`XOutcome` struct pair. `ffi_triggerless_graph.rs` literally says *"Same pattern as ffi_trigger.rs but for graphs"*; `constructor_loader.rs` names the pattern outright. The adapter's interface is nearly as simple as its implementation.
+
+**Candidate deepening:** one generic `invoke_ffi::<Req, Res>(handle, METHOD_INDEX, req)` seam owning the JSON round-trip + `spawn_blocking` + FFI-error mapping; the per-index files shrink to their genuinely-unique metadata (poll interval, terminal-output reconstruction, etc.). **Deletion test: PASS** (concentrates the sync/async + serialization boundary where the FFI seam belongs).
+
+**Why tech-debt not initiative:** rated lower than the DAL/GIL/registrar candidates because the per-index metadata differences are slightly more real (each `XInvocation`/`XOutcome` genuinely differs), so the collapse needs a design pass to confirm a generic `<Req,Res>` doesn't fight the per-index specifics. Investigate feasibility + payoff, then decide (fold into an initiative or close). Relates to [[CLOACI-I-0135]]/[[CLOACI-I-0136]]/[[CLOACI-I-0137]] (same "collapse the repeated shallow adapter" theme).
+
+## Backlog Item Details **[CONDITIONAL: Backlog Item]**
+
+{Delete this section when task is assigned to an initiative}
+
+### Type
+- [ ] Bug - Production issue that needs fixing
+- [ ] Feature - New functionality or enhancement  
+- [ ] Tech Debt - Code improvement or refactoring
+- [ ] Chore - Maintenance or setup work
+
+### Priority
+- [ ] P0 - Critical (blocks users/revenue)
+- [ ] P1 - High (important for user experience)
+- [ ] P2 - Medium (nice to have)
+- [ ] P3 - Low (when time permits)
+
+### Impact Assessment **[CONDITIONAL: Bug]**
+- **Affected Users**: {Number/percentage of users affected}
+- **Reproduction Steps**: 
+  1. {Step 1}
+  2. {Step 2}
+  3. {Step 3}
+- **Expected vs Actual**: {What should happen vs what happens}
+
+### Business Justification **[CONDITIONAL: Feature]**
+- **User Value**: {Why users need this}
+- **Business Value**: {Impact on metrics/revenue}
+- **Effort Estimate**: {Rough size - S/M/L/XL}
+
+### Technical Debt Impact **[CONDITIONAL: Tech Debt]**
+- **Current Problems**: {What's difficult/slow/buggy now}
+- **Benefits of Fixing**: {What improves after refactoring}
+- **Risk Assessment**: {Risks of not addressing this}
+
+## Acceptance Criteria **[REQUIRED]**
+
+- [ ] {Specific, testable requirement 1}
+- [ ] {Specific, testable requirement 2}
+- [ ] {Specific, testable requirement 3}
+
+## Test Cases **[CONDITIONAL: Testing Task]**
+
+{Delete unless this is a testing task}
+
+### Test Case 1: {Test Case Name}
+- **Test ID**: TC-001
+- **Preconditions**: {What must be true before testing}
+- **Steps**: 
+  1. {Step 1}
+  2. {Step 2}
+  3. {Step 3}
+- **Expected Results**: {What should happen}
+- **Actual Results**: {To be filled during execution}
+- **Status**: {Pass/Fail/Blocked}
+
+### Test Case 2: {Test Case Name}
+- **Test ID**: TC-002
+- **Preconditions**: {What must be true before testing}
+- **Steps**: 
+  1. {Step 1}
+  2. {Step 2}
+- **Expected Results**: {What should happen}
+- **Actual Results**: {To be filled during execution}
+- **Status**: {Pass/Fail/Blocked}
+
+## Documentation Sections **[CONDITIONAL: Documentation Task]**
+
+{Delete unless this is a documentation task}
+
+### User Guide Content
+- **Feature Description**: {What this feature does and why it's useful}
+- **Prerequisites**: {What users need before using this feature}
+- **Step-by-Step Instructions**:
+  1. {Step 1 with screenshots/examples}
+  2. {Step 2 with screenshots/examples}
+  3. {Step 3 with screenshots/examples}
+
+### Troubleshooting Guide
+- **Common Issue 1**: {Problem description and solution}
+- **Common Issue 2**: {Problem description and solution}
+- **Error Messages**: {List of error messages and what they mean}
+
+### API Documentation **[CONDITIONAL: API Documentation]**
+- **Endpoint**: {API endpoint description}
+- **Parameters**: {Required and optional parameters}
+- **Example Request**: {Code example}
+- **Example Response**: {Expected response format}
+
+## Implementation Notes **[CONDITIONAL: Technical Task]**
+
+{Keep for technical tasks, delete for non-technical. Technical details, approach, or important considerations}
+
+### Technical Approach
+{How this will be implemented}
+
+### Dependencies
+{Other tasks or systems this depends on}
+
+### Risk Considerations
+{Technical risks and mitigation strategies}
+
+## Status Updates **[REQUIRED]**
+
+*To be added during implementation*

--- a/.metis/initiatives/CLOACI-I-0134/initiative.md
+++ b/.metis/initiatives/CLOACI-I-0134/initiative.md
@@ -1,0 +1,174 @@
+---
+id: single-source-of-version-truth
+level: initiative
+title: "Single source of version truth — collapse the ~30-way version drift, one-command bump, CI drift guard"
+short_code: "CLOACI-I-0134"
+created_at: 2026-07-08T11:30:59.278344+00:00
+updated_at: 2026-07-08T11:36:14.476107+00:00
+parent: 
+blocked_by: []
+archived: false
+
+tags:
+  - "#initiative"
+  - "#phase/decompose"
+
+
+exit_criteria_met: false
+estimated_complexity: M
+initiative_id: single-source-of-version-truth
+---
+
+# Single source of version truth — collapse the ~30-way version drift, one-command bump, CI drift guard
+
+> **Phase: discovery.** Design forks below are OPTIONS pending a maintainer check-in. Nothing committed to implementation yet.
+
+## Context **[REQUIRED]**
+
+Prompted by prepping the 0.10.0 bump (2026-07-08) — and by the fact that **this drift keeps recurring**: the UI shell was still displaying `v0.8.0` (`ui/src/components/Shell.tsx:190`) while the Connect page showed `v0.9.0` (`ui/src/routes/Connect.tsx:382`) and `package.json` said `0.9.0` — three different hand-typed versions in one app. There was already a T-0661 "SDK version lockstep" gate, which shows we've fought this before and only patched a subset.
+
+**The version is hardcoded across ~30 places** with NO single source and NO bump script:
+- **Rust:** `Cargo.toml` `[workspace.package] version` + 5 explicit `version = "0.9.0"` pins in `[workspace.dependencies]` (lines 22–26); per-crate path-deps that RE-pin `version = "0.9.0"` in `cloacina`, `-server`, `-compiler`, `-python`, `cloacinactl`, `-workflow-plugin`; and a straggler `cloacina-computation-graph/Cargo.toml` with its OWN `version = "0.9.0"` (not `version.workspace = true`).
+- **npm:** `clients/typescript/package.json`, `ui/package.json`, `ui/harness/package.json`.
+- **Python:** `clients/python/pyproject.toml` + `clients/python/src/cloacina_client/__init__.py` `__version__`; `crates/cloacina-python/pyproject.toml` is `dynamic` (good).
+- **UI display:** two HAND-TYPED literals (`Shell.tsx:190`, `Connect.tsx:382`) that read from nothing.
+- **Scaffold:** `crates/cloacinactl/src/nouns/package/new.rs:39` `CLOACINA_CRATE_VERSION = "0.7"` — pins generated packages' `cloacina-workflow` dep three minors behind.
+- **Docs + CHANGELOG:** tutorial Cargo.toml snippets + `CHANGELOG.md`.
+
+Release is **tag-triggered** (`.github/workflows/unified_release.yml` on `push: tags:`), so the tag is the only irreversible step; every version edit before it is safe.
+
+The recurrence is the point: a mechanical bump fixes 0.10.0 but not the CLASS. This initiative makes version a single source with a one-command bump and a CI guard that FAILS on drift, then dogfoods it by cutting 0.10.0 through the new path.
+
+## Goals & Non-Goals **[REQUIRED]**
+
+**Goals:**
+- **Collapse the sources:** every place that repeats the version either INHERITS it (Rust `version.workspace`/`workspace = true`) or is REGENERATED from one input — no hand-typed version literals survive (esp. the UI display).
+- **One-command bump:** a single `angreal`-fronted command sets the whole repo to a new version (Rust + npm + python + UI + scaffold + docs snippets + CHANGELOG stub).
+- **CI drift guard:** a check that FAILS the build if any touchpoint disagrees with the source — so this can never silently recur (supersedes/extends the T-0661 SDK lockstep gate).
+- **Dogfood:** perform the 0.10.0 bump through the new mechanism, then the release tag is a clean human step.
+
+**Non-Goals:**
+- Automating the release/tag/publish itself (that stays a deliberate human `git tag`); this is about the version SOURCE, not the release pipeline (`unified_release.yml` unchanged).
+- Changing the versioning SCHEME (still semver, single workspace-wide version; not per-crate independent versions).
+- Re-litigating ADR-decided release mechanics.
+
+## Requirements **[CONDITIONAL: Requirements-Heavy Initiative]**
+
+{Delete if not a requirements-focused initiative}
+
+### User Requirements
+- **User Characteristics**: {Technical background, experience level, etc.}
+- **System Functionality**: {What users expect the system to do}
+- **User Interfaces**: {How users will interact with the system}
+
+### System Requirements
+- **Functional Requirements**: {What the system should do - use unique identifiers}
+  - REQ-001: {Functional requirement 1}
+  - REQ-002: {Functional requirement 2}
+- **Non-Functional Requirements**: {How the system should behave}
+  - NFR-001: {Performance requirement}
+  - NFR-002: {Security requirement}
+
+## Use Cases **[CONDITIONAL: User-Facing Initiative]**
+
+{Delete if not user-facing}
+
+### Use Case 1: {Use Case Name}
+- **Actor**: {Who performs this action}
+- **Scenario**: {Step-by-step interaction}
+- **Expected Outcome**: {What should happen}
+
+### Use Case 2: {Use Case Name}
+- **Actor**: {Who performs this action}
+- **Scenario**: {Step-by-step interaction}
+- **Expected Outcome**: {What should happen}
+
+## Architecture **[CONDITIONAL: Technically Complex Initiative]**
+
+{Delete if not technically complex}
+
+### Overview
+{High-level architectural approach}
+
+### Component Diagrams
+{Describe or link to component diagrams}
+
+### Class Diagrams
+{Describe or link to class diagrams - for OOP systems}
+
+### Sequence Diagrams
+{Describe or link to sequence diagrams - for interaction flows}
+
+### Deployment Diagrams
+{Describe or link to deployment diagrams - for infrastructure}
+
+## Detailed Design **[REQUIRED]**
+
+### Design Decisions (2026-07-08 check-in)
+- **D-1 — Rust: maximize native inheritance.** The workspace version is canonical (`[workspace.package] version`). Collapse the 5 `[workspace.dependencies]` explicit `version = "0.9.0"` pins and every per-crate path-dep re-pin to `{ workspace = true }` (version defined ONCE in the dep table). Fix the `cloacina-computation-graph` straggler to `version.workspace = true`. → Rust bumps at 2 points.
+- **D-2 — UI: build-time inject (chosen).** Vite `define` injects `__APP_VERSION__` from `ui/package.json`; `Shell.tsx` + `Connect.tsx` read the constant. The two hand-typed literals are DELETED — no UI version literal can drift again. (harness/ likewise if it displays a version.)
+- **D-3 — One-command bump (`angreal release bump <version>`).** A single task rewrites the non-inheriting touchpoints from one input: workspace version + workspace dep table (Rust), npm `package.json`s, python `pyproject.toml` + `__init__.py`, and a CHANGELOG `[x.y.z]` stub. Idempotent; the release TAG stays a human `git tag` (non-goal to automate).
+- **D-4 — Drift guard: pre-commit hook (chosen).** A `pre-commit` hook asserts every touchpoint == the workspace version and FAILS on mismatch. Rationale (maintainer): the repo's CI/CD runs the pre-commit hooks, so `--no-verify` can't sneak drift past merge — the hook is fired in the pipeline by definition. Supersedes/absorbs the T-0661 SDK-lockstep gate. Runnable locally (`pre-commit run version-lockstep`).
+- **D-5 — Scaffold pin (`CLOACINA_CRATE_VERSION = "0.7"`): SPIKE first (chosen).** Before deciding track-vs-pin, investigate whether a package scaffolded with `cloacina-workflow = "0.7"` actually BUILDS against the current compiler-injected deps (I-0125 injects crate-type/features; does the version pin still matter for resolution?). Then either fold it into the bump (track) or document WHY it's deliberately pinned (so the guard whitelists it and it's not re-flagged as drift).
+- **D-6 — CORE-ONLY; providers are independent by design (2026-07-08 maintainer check).** Providers version + release on their OWN cadence, decoupled from core ([[CLOACI-A-0010]]: "independently published, independently versioned crate"). This is ALREADY the structure — the first-party providers (`examples/constructor-contract/cloacina-provider-*`) are standalone crates (own `[workspace]`, own `version = "0.1.0"`) EXCLUDED from core's workspace. **NO workspace restructure needed.** So I-0134's single-source + bump + guard cover CORE (the main workspace) ONLY; they MUST NOT touch or lockstep `examples/` provider versions, and the drift guard must explicitly IGNORE providers (a provider at 0.1.0 while core is 0.10.0 is CORRECT, not drift). Deferred follow-ups: [[CLOACI-T-0871]] (are the example providers real first-party → promote out of `examples/`? only `fs` looks real) and [[CLOACI-T-0872]] (independent provider release path).
+- **Dogfood:** perform the 0.10.0 bump through the new command + guard, then hand off the tag.
+
+### The version-touchpoint map (the guard's checklist)
+Rust: `Cargo.toml` (`[workspace.package] version` = SOURCE; `[workspace.dependencies]` pins) · `crates/cloacina-computation-graph/Cargo.toml` (straggler). npm: `clients/typescript/package.json` · `ui/package.json` · `ui/harness/package.json`. Python: `clients/python/pyproject.toml` · `clients/python/src/cloacina_client/__init__.py` (`__version__`). UI display: `ui/src/components/Shell.tsx` · `ui/src/routes/Connect.tsx` (→ build-time inject, D-2). Scaffold: `crates/cloacinactl/src/nouns/package/new.rs` (`CLOACINA_CRATE_VERSION`, D-5). Docs: tutorial Cargo.toml snippets (bump-managed or guard-checked). `CHANGELOG.md`.
+
+## Alternatives Considered **[REQUIRED]**
+
+- **Root `VERSION` file as the source.** Rejected — the Cargo `[workspace.package] version` is already the most-inherited source and is language-native for the bulk (Rust); a separate VERSION file adds a redundant source. The bump command takes the version as an arg and the guard pins everyone to the Cargo workspace version.
+- **Per-crate independent versions.** Out of scope (non-goal) — cloacina ships as one lockstepped surface; independent crate versions would multiply the drift problem, not solve it.
+- **Just bump 0.10.0 mechanically.** The status quo — fixes one release, not the recurring class. Rejected as the whole point.
+- **A release-orchestration tool (release-plz / changesets).** Heavier than needed and would fight the angreal-everything convention + the human-tag release model; revisit only if the bump command proves insufficient.
+
+## Implementation Plan **[REQUIRED]**
+
+Decompose (below) into: Rust inheritance collapse, UI build-time inject, the `angreal release bump` command, the pre-commit drift guard, the scaffold-pin spike, and the 0.10.0 dogfood. Order: (Rust ∥ UI) → bump command + guard (need final touchpoint shapes) → spike feeds the command → dogfood last.
+
+## UI/UX Design **[CONDITIONAL: Frontend Initiative]**
+
+{Delete if no UI components}
+
+### User Interface Mockups
+{Describe or link to UI mockups}
+
+### User Flows
+{Describe key user interaction flows}
+
+### Design System Integration
+{How this fits with existing design patterns}
+
+## Testing Strategy **[CONDITIONAL: Separate Testing Initiative]**
+
+{Delete if covered by separate testing initiative}
+
+### Unit Testing
+- **Strategy**: {Approach to unit testing}
+- **Coverage Target**: {Expected coverage percentage}
+- **Tools**: {Testing frameworks and tools}
+
+### Integration Testing
+- **Strategy**: {Approach to integration testing}
+- **Test Environment**: {Where integration tests run}
+- **Data Management**: {Test data strategy}
+
+### System Testing
+- **Strategy**: {End-to-end testing approach}
+- **User Acceptance**: {How UAT will be conducted}
+- **Performance Testing**: {Load and stress testing}
+
+### Test Selection
+{Criteria for determining what to test}
+
+### Bug Tracking
+{How defects will be managed and prioritized}
+
+## Alternatives Considered **[REQUIRED]**
+
+{Alternative approaches and why they were rejected}
+
+## Implementation Plan **[REQUIRED]**
+
+{Phases and timeline for execution}

--- a/.metis/initiatives/CLOACI-I-0134/initiative.md
+++ b/.metis/initiatives/CLOACI-I-0134/initiative.md
@@ -4,14 +4,14 @@ level: initiative
 title: "Single source of version truth — collapse the ~30-way version drift, one-command bump, CI drift guard"
 short_code: "CLOACI-I-0134"
 created_at: 2026-07-08T11:30:59.278344+00:00
-updated_at: 2026-07-08T11:36:14.476107+00:00
+updated_at: 2026-07-08T22:16:25.155333+00:00
 parent: 
 blocked_by: []
 archived: false
 
 tags:
   - "#initiative"
-  - "#phase/decompose"
+  - "#phase/completed"
 
 
 exit_criteria_met: false

--- a/.metis/initiatives/CLOACI-I-0134/tasks/CLOACI-T-0865.md
+++ b/.metis/initiatives/CLOACI-I-0134/tasks/CLOACI-T-0865.md
@@ -1,0 +1,136 @@
+---
+id: rust-version-inheritance-collapse
+level: task
+title: "Rust version inheritance collapse — workspace-inherited path-dep versions, fix the CG straggler"
+short_code: "CLOACI-T-0865"
+created_at: 2026-07-08T11:36:20.337600+00:00
+updated_at: 2026-07-08T11:36:20.337600+00:00
+parent: CLOACI-I-0134
+blocked_by: []
+archived: false
+
+tags:
+  - "#task"
+  - "#phase/todo"
+
+
+exit_criteria_met: false
+initiative_id: CLOACI-I-0134
+---
+
+# Rust version inheritance collapse — workspace-inherited path-dep versions, fix the CG straggler
+
+*This template includes sections for various types of tasks. Delete sections that don't apply to your specific use case.*
+
+## Parent Initiative **[CONDITIONAL: Assigned Task]**
+
+[[CLOACI-I-0134]]
+
+## Objective **[REQUIRED]**
+
+{Clear statement of what this task accomplishes}
+
+## Backlog Item Details **[CONDITIONAL: Backlog Item]**
+
+{Delete this section when task is assigned to an initiative}
+
+### Type
+- [ ] Bug - Production issue that needs fixing
+- [ ] Feature - New functionality or enhancement  
+- [ ] Tech Debt - Code improvement or refactoring
+- [ ] Chore - Maintenance or setup work
+
+### Priority
+- [ ] P0 - Critical (blocks users/revenue)
+- [ ] P1 - High (important for user experience)
+- [ ] P2 - Medium (nice to have)
+- [ ] P3 - Low (when time permits)
+
+### Impact Assessment **[CONDITIONAL: Bug]**
+- **Affected Users**: {Number/percentage of users affected}
+- **Reproduction Steps**: 
+  1. {Step 1}
+  2. {Step 2}
+  3. {Step 3}
+- **Expected vs Actual**: {What should happen vs what happens}
+
+### Business Justification **[CONDITIONAL: Feature]**
+- **User Value**: {Why users need this}
+- **Business Value**: {Impact on metrics/revenue}
+- **Effort Estimate**: {Rough size - S/M/L/XL}
+
+### Technical Debt Impact **[CONDITIONAL: Tech Debt]**
+- **Current Problems**: {What's difficult/slow/buggy now}
+- **Benefits of Fixing**: {What improves after refactoring}
+- **Risk Assessment**: {Risks of not addressing this}
+
+## Acceptance Criteria **[REQUIRED]**
+
+- [ ] {Specific, testable requirement 1}
+- [ ] {Specific, testable requirement 2}
+- [ ] {Specific, testable requirement 3}
+
+## Test Cases **[CONDITIONAL: Testing Task]**
+
+{Delete unless this is a testing task}
+
+### Test Case 1: {Test Case Name}
+- **Test ID**: TC-001
+- **Preconditions**: {What must be true before testing}
+- **Steps**: 
+  1. {Step 1}
+  2. {Step 2}
+  3. {Step 3}
+- **Expected Results**: {What should happen}
+- **Actual Results**: {To be filled during execution}
+- **Status**: {Pass/Fail/Blocked}
+
+### Test Case 2: {Test Case Name}
+- **Test ID**: TC-002
+- **Preconditions**: {What must be true before testing}
+- **Steps**: 
+  1. {Step 1}
+  2. {Step 2}
+- **Expected Results**: {What should happen}
+- **Actual Results**: {To be filled during execution}
+- **Status**: {Pass/Fail/Blocked}
+
+## Documentation Sections **[CONDITIONAL: Documentation Task]**
+
+{Delete unless this is a documentation task}
+
+### User Guide Content
+- **Feature Description**: {What this feature does and why it's useful}
+- **Prerequisites**: {What users need before using this feature}
+- **Step-by-Step Instructions**:
+  1. {Step 1 with screenshots/examples}
+  2. {Step 2 with screenshots/examples}
+  3. {Step 3 with screenshots/examples}
+
+### Troubleshooting Guide
+- **Common Issue 1**: {Problem description and solution}
+- **Common Issue 2**: {Problem description and solution}
+- **Error Messages**: {List of error messages and what they mean}
+
+### API Documentation **[CONDITIONAL: API Documentation]**
+- **Endpoint**: {API endpoint description}
+- **Parameters**: {Required and optional parameters}
+- **Example Request**: {Code example}
+- **Example Response**: {Expected response format}
+
+## Implementation Notes **[CONDITIONAL: Technical Task]**
+
+{Keep for technical tasks, delete for non-technical. Technical details, approach, or important considerations}
+
+### Technical Approach
+{How this will be implemented}
+
+### Dependencies
+{Other tasks or systems this depends on}
+
+### Risk Considerations
+{Technical risks and mitigation strategies}
+
+## Status Updates **[REQUIRED]**
+
+*To be added during implementation*

--- a/.metis/initiatives/CLOACI-I-0134/tasks/CLOACI-T-0865.md
+++ b/.metis/initiatives/CLOACI-I-0134/tasks/CLOACI-T-0865.md
@@ -4,14 +4,14 @@ level: task
 title: "Rust version inheritance collapse — workspace-inherited path-dep versions, fix the CG straggler"
 short_code: "CLOACI-T-0865"
 created_at: 2026-07-08T11:36:20.337600+00:00
-updated_at: 2026-07-08T11:36:20.337600+00:00
+updated_at: 2026-07-08T14:24:35.862728+00:00
 parent: CLOACI-I-0134
 blocked_by: []
 archived: false
 
 tags:
   - "#task"
-  - "#phase/todo"
+  - "#phase/completed"
 
 
 exit_criteria_met: false
@@ -63,6 +63,10 @@ initiative_id: CLOACI-I-0134
 - **Current Problems**: {What's difficult/slow/buggy now}
 - **Benefits of Fixing**: {What improves after refactoring}
 - **Risk Assessment**: {Risks of not addressing this}
+
+## Acceptance Criteria
+
+## Acceptance Criteria
 
 ## Acceptance Criteria **[REQUIRED]**
 
@@ -133,4 +137,6 @@ initiative_id: CLOACI-I-0134
 
 ## Status Updates **[REQUIRED]**
 
-*To be added during implementation*
+### 2026-07-08 — DONE (branch feat/i0134-version-single-source)
+Added 5 more internal crates to root `[workspace.dependencies]` (now 10: +cloacina, cloacina-build, cloacina-computation-graph, cloacina-python, cloacina-workflow-plugin); converted every per-crate internal path-dep across 9 crate Cargo.tomls to `{ workspace = true }` (features/default-features preserved exactly); fixed the `cloacina-computation-graph` straggler `[package] version = "0.9.0"` → `version.workspace = true`. `examples/` untouched (providers keep independent versions, D-6). Version stays 0.9.0.
+**Verified (re-run myself): `cargo metadata` OK; `grep 'version = "0.9.0"' crates/*/Cargo.toml` → nothing (all inherit); cargo check clean for cloacina-server/-compiler/-python/cloacinactl/-agent (proves the `{ workspace = true }` conversion didn't drop features). Only Rust `0.9.0` literals left: root Cargo.toml `[workspace.package]` + the 10 internal `[workspace.dependencies]` entries → Rust now bumps at 2 points in one file.**

--- a/.metis/initiatives/CLOACI-I-0134/tasks/CLOACI-T-0866.md
+++ b/.metis/initiatives/CLOACI-I-0134/tasks/CLOACI-T-0866.md
@@ -4,14 +4,14 @@ level: task
 title: "UI build-time version injection — Vite define from package.json, delete the two literals"
 short_code: "CLOACI-T-0866"
 created_at: 2026-07-08T11:36:21.538151+00:00
-updated_at: 2026-07-08T11:36:21.538151+00:00
+updated_at: 2026-07-08T11:50:23.175461+00:00
 parent: CLOACI-I-0134
 blocked_by: []
 archived: false
 
 tags:
   - "#task"
-  - "#phase/todo"
+  - "#phase/completed"
 
 
 exit_criteria_met: false
@@ -63,6 +63,10 @@ initiative_id: CLOACI-I-0134
 - **Current Problems**: {What's difficult/slow/buggy now}
 - **Benefits of Fixing**: {What improves after refactoring}
 - **Risk Assessment**: {Risks of not addressing this}
+
+## Acceptance Criteria
+
+## Acceptance Criteria
 
 ## Acceptance Criteria **[REQUIRED]**
 
@@ -133,4 +137,6 @@ initiative_id: CLOACI-I-0134
 
 ## Status Updates **[REQUIRED]**
 
-*To be added during implementation*
+### 2026-07-08 — DONE (branch feat/i0134-version-single-source)
+D-2 build-time inject: `ui/vite.config.ts` reads `ui/package.json` via native JSON import + `define: { __APP_VERSION__: JSON.stringify(pkg.version) }`; `resolveJsonModule` enabled in `tsconfig.node.json`; ambient `declare const __APP_VERSION__: string` in `ui/src/vite-env.d.ts`. Both hand-typed literals replaced: `Shell.tsx:190` (`v0.8.0`→`v{__APP_VERSION__}`) and `Connect.tsx:382` (`v0.9.0`→`v{__APP_VERSION__}`). Harness displays no version — left untouched. package.json stays 0.9.0 (bump is T-0870).
+**Verified (re-run myself): grep ui/src for version literals → CLEAN (none); vite define + both edits + ambient decl confirmed in place. Agent ran `npm run build` (tsc -b && vite build) → PASS, dist bundle contains the injected `0.9.0` in both strings.** No literal can drift again.

--- a/.metis/initiatives/CLOACI-I-0134/tasks/CLOACI-T-0866.md
+++ b/.metis/initiatives/CLOACI-I-0134/tasks/CLOACI-T-0866.md
@@ -1,0 +1,136 @@
+---
+id: ui-build-time-version-injection
+level: task
+title: "UI build-time version injection — Vite define from package.json, delete the two literals"
+short_code: "CLOACI-T-0866"
+created_at: 2026-07-08T11:36:21.538151+00:00
+updated_at: 2026-07-08T11:36:21.538151+00:00
+parent: CLOACI-I-0134
+blocked_by: []
+archived: false
+
+tags:
+  - "#task"
+  - "#phase/todo"
+
+
+exit_criteria_met: false
+initiative_id: CLOACI-I-0134
+---
+
+# UI build-time version injection — Vite define from package.json, delete the two literals
+
+*This template includes sections for various types of tasks. Delete sections that don't apply to your specific use case.*
+
+## Parent Initiative **[CONDITIONAL: Assigned Task]**
+
+[[CLOACI-I-0134]]
+
+## Objective **[REQUIRED]**
+
+{Clear statement of what this task accomplishes}
+
+## Backlog Item Details **[CONDITIONAL: Backlog Item]**
+
+{Delete this section when task is assigned to an initiative}
+
+### Type
+- [ ] Bug - Production issue that needs fixing
+- [ ] Feature - New functionality or enhancement  
+- [ ] Tech Debt - Code improvement or refactoring
+- [ ] Chore - Maintenance or setup work
+
+### Priority
+- [ ] P0 - Critical (blocks users/revenue)
+- [ ] P1 - High (important for user experience)
+- [ ] P2 - Medium (nice to have)
+- [ ] P3 - Low (when time permits)
+
+### Impact Assessment **[CONDITIONAL: Bug]**
+- **Affected Users**: {Number/percentage of users affected}
+- **Reproduction Steps**: 
+  1. {Step 1}
+  2. {Step 2}
+  3. {Step 3}
+- **Expected vs Actual**: {What should happen vs what happens}
+
+### Business Justification **[CONDITIONAL: Feature]**
+- **User Value**: {Why users need this}
+- **Business Value**: {Impact on metrics/revenue}
+- **Effort Estimate**: {Rough size - S/M/L/XL}
+
+### Technical Debt Impact **[CONDITIONAL: Tech Debt]**
+- **Current Problems**: {What's difficult/slow/buggy now}
+- **Benefits of Fixing**: {What improves after refactoring}
+- **Risk Assessment**: {Risks of not addressing this}
+
+## Acceptance Criteria **[REQUIRED]**
+
+- [ ] {Specific, testable requirement 1}
+- [ ] {Specific, testable requirement 2}
+- [ ] {Specific, testable requirement 3}
+
+## Test Cases **[CONDITIONAL: Testing Task]**
+
+{Delete unless this is a testing task}
+
+### Test Case 1: {Test Case Name}
+- **Test ID**: TC-001
+- **Preconditions**: {What must be true before testing}
+- **Steps**: 
+  1. {Step 1}
+  2. {Step 2}
+  3. {Step 3}
+- **Expected Results**: {What should happen}
+- **Actual Results**: {To be filled during execution}
+- **Status**: {Pass/Fail/Blocked}
+
+### Test Case 2: {Test Case Name}
+- **Test ID**: TC-002
+- **Preconditions**: {What must be true before testing}
+- **Steps**: 
+  1. {Step 1}
+  2. {Step 2}
+- **Expected Results**: {What should happen}
+- **Actual Results**: {To be filled during execution}
+- **Status**: {Pass/Fail/Blocked}
+
+## Documentation Sections **[CONDITIONAL: Documentation Task]**
+
+{Delete unless this is a documentation task}
+
+### User Guide Content
+- **Feature Description**: {What this feature does and why it's useful}
+- **Prerequisites**: {What users need before using this feature}
+- **Step-by-Step Instructions**:
+  1. {Step 1 with screenshots/examples}
+  2. {Step 2 with screenshots/examples}
+  3. {Step 3 with screenshots/examples}
+
+### Troubleshooting Guide
+- **Common Issue 1**: {Problem description and solution}
+- **Common Issue 2**: {Problem description and solution}
+- **Error Messages**: {List of error messages and what they mean}
+
+### API Documentation **[CONDITIONAL: API Documentation]**
+- **Endpoint**: {API endpoint description}
+- **Parameters**: {Required and optional parameters}
+- **Example Request**: {Code example}
+- **Example Response**: {Expected response format}
+
+## Implementation Notes **[CONDITIONAL: Technical Task]**
+
+{Keep for technical tasks, delete for non-technical. Technical details, approach, or important considerations}
+
+### Technical Approach
+{How this will be implemented}
+
+### Dependencies
+{Other tasks or systems this depends on}
+
+### Risk Considerations
+{Technical risks and mitigation strategies}
+
+## Status Updates **[REQUIRED]**
+
+*To be added during implementation*

--- a/.metis/initiatives/CLOACI-I-0134/tasks/CLOACI-T-0867.md
+++ b/.metis/initiatives/CLOACI-I-0134/tasks/CLOACI-T-0867.md
@@ -1,0 +1,136 @@
+---
+id: angreal-release-bump-command-one
+level: task
+title: "angreal release bump command — one input rewrites every non-inheriting touchpoint"
+short_code: "CLOACI-T-0867"
+created_at: 2026-07-08T11:36:23.077332+00:00
+updated_at: 2026-07-08T11:36:23.077332+00:00
+parent: CLOACI-I-0134
+blocked_by: []
+archived: false
+
+tags:
+  - "#task"
+  - "#phase/todo"
+
+
+exit_criteria_met: false
+initiative_id: CLOACI-I-0134
+---
+
+# angreal release bump command — one input rewrites every non-inheriting touchpoint
+
+*This template includes sections for various types of tasks. Delete sections that don't apply to your specific use case.*
+
+## Parent Initiative **[CONDITIONAL: Assigned Task]**
+
+[[CLOACI-I-0134]]
+
+## Objective **[REQUIRED]**
+
+{Clear statement of what this task accomplishes}
+
+## Backlog Item Details **[CONDITIONAL: Backlog Item]**
+
+{Delete this section when task is assigned to an initiative}
+
+### Type
+- [ ] Bug - Production issue that needs fixing
+- [ ] Feature - New functionality or enhancement  
+- [ ] Tech Debt - Code improvement or refactoring
+- [ ] Chore - Maintenance or setup work
+
+### Priority
+- [ ] P0 - Critical (blocks users/revenue)
+- [ ] P1 - High (important for user experience)
+- [ ] P2 - Medium (nice to have)
+- [ ] P3 - Low (when time permits)
+
+### Impact Assessment **[CONDITIONAL: Bug]**
+- **Affected Users**: {Number/percentage of users affected}
+- **Reproduction Steps**: 
+  1. {Step 1}
+  2. {Step 2}
+  3. {Step 3}
+- **Expected vs Actual**: {What should happen vs what happens}
+
+### Business Justification **[CONDITIONAL: Feature]**
+- **User Value**: {Why users need this}
+- **Business Value**: {Impact on metrics/revenue}
+- **Effort Estimate**: {Rough size - S/M/L/XL}
+
+### Technical Debt Impact **[CONDITIONAL: Tech Debt]**
+- **Current Problems**: {What's difficult/slow/buggy now}
+- **Benefits of Fixing**: {What improves after refactoring}
+- **Risk Assessment**: {Risks of not addressing this}
+
+## Acceptance Criteria **[REQUIRED]**
+
+- [ ] {Specific, testable requirement 1}
+- [ ] {Specific, testable requirement 2}
+- [ ] {Specific, testable requirement 3}
+
+## Test Cases **[CONDITIONAL: Testing Task]**
+
+{Delete unless this is a testing task}
+
+### Test Case 1: {Test Case Name}
+- **Test ID**: TC-001
+- **Preconditions**: {What must be true before testing}
+- **Steps**: 
+  1. {Step 1}
+  2. {Step 2}
+  3. {Step 3}
+- **Expected Results**: {What should happen}
+- **Actual Results**: {To be filled during execution}
+- **Status**: {Pass/Fail/Blocked}
+
+### Test Case 2: {Test Case Name}
+- **Test ID**: TC-002
+- **Preconditions**: {What must be true before testing}
+- **Steps**: 
+  1. {Step 1}
+  2. {Step 2}
+- **Expected Results**: {What should happen}
+- **Actual Results**: {To be filled during execution}
+- **Status**: {Pass/Fail/Blocked}
+
+## Documentation Sections **[CONDITIONAL: Documentation Task]**
+
+{Delete unless this is a documentation task}
+
+### User Guide Content
+- **Feature Description**: {What this feature does and why it's useful}
+- **Prerequisites**: {What users need before using this feature}
+- **Step-by-Step Instructions**:
+  1. {Step 1 with screenshots/examples}
+  2. {Step 2 with screenshots/examples}
+  3. {Step 3 with screenshots/examples}
+
+### Troubleshooting Guide
+- **Common Issue 1**: {Problem description and solution}
+- **Common Issue 2**: {Problem description and solution}
+- **Error Messages**: {List of error messages and what they mean}
+
+### API Documentation **[CONDITIONAL: API Documentation]**
+- **Endpoint**: {API endpoint description}
+- **Parameters**: {Required and optional parameters}
+- **Example Request**: {Code example}
+- **Example Response**: {Expected response format}
+
+## Implementation Notes **[CONDITIONAL: Technical Task]**
+
+{Keep for technical tasks, delete for non-technical. Technical details, approach, or important considerations}
+
+### Technical Approach
+{How this will be implemented}
+
+### Dependencies
+{Other tasks or systems this depends on}
+
+### Risk Considerations
+{Technical risks and mitigation strategies}
+
+## Status Updates **[REQUIRED]**
+
+*To be added during implementation*

--- a/.metis/initiatives/CLOACI-I-0134/tasks/CLOACI-T-0867.md
+++ b/.metis/initiatives/CLOACI-I-0134/tasks/CLOACI-T-0867.md
@@ -4,14 +4,14 @@ level: task
 title: "angreal release bump command — one input rewrites every non-inheriting touchpoint"
 short_code: "CLOACI-T-0867"
 created_at: 2026-07-08T11:36:23.077332+00:00
-updated_at: 2026-07-08T11:36:23.077332+00:00
+updated_at: 2026-07-08T22:15:29.514104+00:00
 parent: CLOACI-I-0134
 blocked_by: []
 archived: false
 
 tags:
   - "#task"
-  - "#phase/todo"
+  - "#phase/completed"
 
 
 exit_criteria_met: false
@@ -63,6 +63,10 @@ initiative_id: CLOACI-I-0134
 - **Current Problems**: {What's difficult/slow/buggy now}
 - **Benefits of Fixing**: {What improves after refactoring}
 - **Risk Assessment**: {Risks of not addressing this}
+
+## Acceptance Criteria
+
+## Acceptance Criteria
 
 ## Acceptance Criteria **[REQUIRED]**
 

--- a/.metis/initiatives/CLOACI-I-0134/tasks/CLOACI-T-0868.md
+++ b/.metis/initiatives/CLOACI-I-0134/tasks/CLOACI-T-0868.md
@@ -4,14 +4,14 @@ level: task
 title: "Version-lockstep drift guard — pre-commit hook that fails on any touchpoint mismatch"
 short_code: "CLOACI-T-0868"
 created_at: 2026-07-08T11:36:24.738947+00:00
-updated_at: 2026-07-08T11:36:24.738947+00:00
+updated_at: 2026-07-08T22:15:30.099952+00:00
 parent: CLOACI-I-0134
 blocked_by: []
 archived: false
 
 tags:
   - "#task"
-  - "#phase/todo"
+  - "#phase/completed"
 
 
 exit_criteria_met: false
@@ -63,6 +63,10 @@ initiative_id: CLOACI-I-0134
 - **Current Problems**: {What's difficult/slow/buggy now}
 - **Benefits of Fixing**: {What improves after refactoring}
 - **Risk Assessment**: {Risks of not addressing this}
+
+## Acceptance Criteria
+
+## Acceptance Criteria
 
 ## Acceptance Criteria **[REQUIRED]**
 

--- a/.metis/initiatives/CLOACI-I-0134/tasks/CLOACI-T-0868.md
+++ b/.metis/initiatives/CLOACI-I-0134/tasks/CLOACI-T-0868.md
@@ -1,0 +1,136 @@
+---
+id: version-lockstep-drift-guard-pre
+level: task
+title: "Version-lockstep drift guard — pre-commit hook that fails on any touchpoint mismatch"
+short_code: "CLOACI-T-0868"
+created_at: 2026-07-08T11:36:24.738947+00:00
+updated_at: 2026-07-08T11:36:24.738947+00:00
+parent: CLOACI-I-0134
+blocked_by: []
+archived: false
+
+tags:
+  - "#task"
+  - "#phase/todo"
+
+
+exit_criteria_met: false
+initiative_id: CLOACI-I-0134
+---
+
+# Version-lockstep drift guard — pre-commit hook that fails on any touchpoint mismatch
+
+*This template includes sections for various types of tasks. Delete sections that don't apply to your specific use case.*
+
+## Parent Initiative **[CONDITIONAL: Assigned Task]**
+
+[[CLOACI-I-0134]]
+
+## Objective **[REQUIRED]**
+
+{Clear statement of what this task accomplishes}
+
+## Backlog Item Details **[CONDITIONAL: Backlog Item]**
+
+{Delete this section when task is assigned to an initiative}
+
+### Type
+- [ ] Bug - Production issue that needs fixing
+- [ ] Feature - New functionality or enhancement  
+- [ ] Tech Debt - Code improvement or refactoring
+- [ ] Chore - Maintenance or setup work
+
+### Priority
+- [ ] P0 - Critical (blocks users/revenue)
+- [ ] P1 - High (important for user experience)
+- [ ] P2 - Medium (nice to have)
+- [ ] P3 - Low (when time permits)
+
+### Impact Assessment **[CONDITIONAL: Bug]**
+- **Affected Users**: {Number/percentage of users affected}
+- **Reproduction Steps**: 
+  1. {Step 1}
+  2. {Step 2}
+  3. {Step 3}
+- **Expected vs Actual**: {What should happen vs what happens}
+
+### Business Justification **[CONDITIONAL: Feature]**
+- **User Value**: {Why users need this}
+- **Business Value**: {Impact on metrics/revenue}
+- **Effort Estimate**: {Rough size - S/M/L/XL}
+
+### Technical Debt Impact **[CONDITIONAL: Tech Debt]**
+- **Current Problems**: {What's difficult/slow/buggy now}
+- **Benefits of Fixing**: {What improves after refactoring}
+- **Risk Assessment**: {Risks of not addressing this}
+
+## Acceptance Criteria **[REQUIRED]**
+
+- [ ] {Specific, testable requirement 1}
+- [ ] {Specific, testable requirement 2}
+- [ ] {Specific, testable requirement 3}
+
+## Test Cases **[CONDITIONAL: Testing Task]**
+
+{Delete unless this is a testing task}
+
+### Test Case 1: {Test Case Name}
+- **Test ID**: TC-001
+- **Preconditions**: {What must be true before testing}
+- **Steps**: 
+  1. {Step 1}
+  2. {Step 2}
+  3. {Step 3}
+- **Expected Results**: {What should happen}
+- **Actual Results**: {To be filled during execution}
+- **Status**: {Pass/Fail/Blocked}
+
+### Test Case 2: {Test Case Name}
+- **Test ID**: TC-002
+- **Preconditions**: {What must be true before testing}
+- **Steps**: 
+  1. {Step 1}
+  2. {Step 2}
+- **Expected Results**: {What should happen}
+- **Actual Results**: {To be filled during execution}
+- **Status**: {Pass/Fail/Blocked}
+
+## Documentation Sections **[CONDITIONAL: Documentation Task]**
+
+{Delete unless this is a documentation task}
+
+### User Guide Content
+- **Feature Description**: {What this feature does and why it's useful}
+- **Prerequisites**: {What users need before using this feature}
+- **Step-by-Step Instructions**:
+  1. {Step 1 with screenshots/examples}
+  2. {Step 2 with screenshots/examples}
+  3. {Step 3 with screenshots/examples}
+
+### Troubleshooting Guide
+- **Common Issue 1**: {Problem description and solution}
+- **Common Issue 2**: {Problem description and solution}
+- **Error Messages**: {List of error messages and what they mean}
+
+### API Documentation **[CONDITIONAL: API Documentation]**
+- **Endpoint**: {API endpoint description}
+- **Parameters**: {Required and optional parameters}
+- **Example Request**: {Code example}
+- **Example Response**: {Expected response format}
+
+## Implementation Notes **[CONDITIONAL: Technical Task]**
+
+{Keep for technical tasks, delete for non-technical. Technical details, approach, or important considerations}
+
+### Technical Approach
+{How this will be implemented}
+
+### Dependencies
+{Other tasks or systems this depends on}
+
+### Risk Considerations
+{Technical risks and mitigation strategies}
+
+## Status Updates **[REQUIRED]**
+
+*To be added during implementation*

--- a/.metis/initiatives/CLOACI-I-0134/tasks/CLOACI-T-0869.md
+++ b/.metis/initiatives/CLOACI-I-0134/tasks/CLOACI-T-0869.md
@@ -1,0 +1,136 @@
+---
+id: scaffold-pin-spike-decision-does-a
+level: task
+title: "Scaffold-pin spike + decision — does a 0.7-scaffolded package build against current injected deps"
+short_code: "CLOACI-T-0869"
+created_at: 2026-07-08T11:36:26.546877+00:00
+updated_at: 2026-07-08T11:36:26.546877+00:00
+parent: CLOACI-I-0134
+blocked_by: []
+archived: false
+
+tags:
+  - "#task"
+  - "#phase/todo"
+
+
+exit_criteria_met: false
+initiative_id: CLOACI-I-0134
+---
+
+# Scaffold-pin spike + decision — does a 0.7-scaffolded package build against current injected deps
+
+*This template includes sections for various types of tasks. Delete sections that don't apply to your specific use case.*
+
+## Parent Initiative **[CONDITIONAL: Assigned Task]**
+
+[[CLOACI-I-0134]]
+
+## Objective **[REQUIRED]**
+
+{Clear statement of what this task accomplishes}
+
+## Backlog Item Details **[CONDITIONAL: Backlog Item]**
+
+{Delete this section when task is assigned to an initiative}
+
+### Type
+- [ ] Bug - Production issue that needs fixing
+- [ ] Feature - New functionality or enhancement  
+- [ ] Tech Debt - Code improvement or refactoring
+- [ ] Chore - Maintenance or setup work
+
+### Priority
+- [ ] P0 - Critical (blocks users/revenue)
+- [ ] P1 - High (important for user experience)
+- [ ] P2 - Medium (nice to have)
+- [ ] P3 - Low (when time permits)
+
+### Impact Assessment **[CONDITIONAL: Bug]**
+- **Affected Users**: {Number/percentage of users affected}
+- **Reproduction Steps**: 
+  1. {Step 1}
+  2. {Step 2}
+  3. {Step 3}
+- **Expected vs Actual**: {What should happen vs what happens}
+
+### Business Justification **[CONDITIONAL: Feature]**
+- **User Value**: {Why users need this}
+- **Business Value**: {Impact on metrics/revenue}
+- **Effort Estimate**: {Rough size - S/M/L/XL}
+
+### Technical Debt Impact **[CONDITIONAL: Tech Debt]**
+- **Current Problems**: {What's difficult/slow/buggy now}
+- **Benefits of Fixing**: {What improves after refactoring}
+- **Risk Assessment**: {Risks of not addressing this}
+
+## Acceptance Criteria **[REQUIRED]**
+
+- [ ] {Specific, testable requirement 1}
+- [ ] {Specific, testable requirement 2}
+- [ ] {Specific, testable requirement 3}
+
+## Test Cases **[CONDITIONAL: Testing Task]**
+
+{Delete unless this is a testing task}
+
+### Test Case 1: {Test Case Name}
+- **Test ID**: TC-001
+- **Preconditions**: {What must be true before testing}
+- **Steps**: 
+  1. {Step 1}
+  2. {Step 2}
+  3. {Step 3}
+- **Expected Results**: {What should happen}
+- **Actual Results**: {To be filled during execution}
+- **Status**: {Pass/Fail/Blocked}
+
+### Test Case 2: {Test Case Name}
+- **Test ID**: TC-002
+- **Preconditions**: {What must be true before testing}
+- **Steps**: 
+  1. {Step 1}
+  2. {Step 2}
+- **Expected Results**: {What should happen}
+- **Actual Results**: {To be filled during execution}
+- **Status**: {Pass/Fail/Blocked}
+
+## Documentation Sections **[CONDITIONAL: Documentation Task]**
+
+{Delete unless this is a documentation task}
+
+### User Guide Content
+- **Feature Description**: {What this feature does and why it's useful}
+- **Prerequisites**: {What users need before using this feature}
+- **Step-by-Step Instructions**:
+  1. {Step 1 with screenshots/examples}
+  2. {Step 2 with screenshots/examples}
+  3. {Step 3 with screenshots/examples}
+
+### Troubleshooting Guide
+- **Common Issue 1**: {Problem description and solution}
+- **Common Issue 2**: {Problem description and solution}
+- **Error Messages**: {List of error messages and what they mean}
+
+### API Documentation **[CONDITIONAL: API Documentation]**
+- **Endpoint**: {API endpoint description}
+- **Parameters**: {Required and optional parameters}
+- **Example Request**: {Code example}
+- **Example Response**: {Expected response format}
+
+## Implementation Notes **[CONDITIONAL: Technical Task]**
+
+{Keep for technical tasks, delete for non-technical. Technical details, approach, or important considerations}
+
+### Technical Approach
+{How this will be implemented}
+
+### Dependencies
+{Other tasks or systems this depends on}
+
+### Risk Considerations
+{Technical risks and mitigation strategies}
+
+## Status Updates **[REQUIRED]**
+
+*To be added during implementation*

--- a/.metis/initiatives/CLOACI-I-0134/tasks/CLOACI-T-0869.md
+++ b/.metis/initiatives/CLOACI-I-0134/tasks/CLOACI-T-0869.md
@@ -4,14 +4,14 @@ level: task
 title: "Scaffold-pin spike + decision — does a 0.7-scaffolded package build against current injected deps"
 short_code: "CLOACI-T-0869"
 created_at: 2026-07-08T11:36:26.546877+00:00
-updated_at: 2026-07-08T11:36:26.546877+00:00
+updated_at: 2026-07-08T11:47:49.208714+00:00
 parent: CLOACI-I-0134
 blocked_by: []
 archived: false
 
 tags:
   - "#task"
-  - "#phase/todo"
+  - "#phase/completed"
 
 
 exit_criteria_met: false
@@ -28,7 +28,13 @@ initiative_id: CLOACI-I-0134
 
 ## Objective **[REQUIRED]**
 
-{Clear statement of what this task accomplishes}
+Spike (D-5): decide whether `CLOACINA_CRATE_VERSION` (scaffold pin for generated packages' `cloacina-*` deps) should TRACK the release or stay deliberately pinned, by finding out if it actually binds resolution.
+
+## Status Updates **[REQUIRED]**
+
+### 2026-07-08 — DONE — verdict: TRACK the release (it's load-bearing + a real bug)
+`crates/cloacinactl/src/nouns/package/new.rs:39` `CLOACINA_CRATE_VERSION = "0.7"` (comment: "Version pin for the generated Rust package's cloacina-* dependencies"), set at I-0119 (2026-06-14, commit da3f4e3f) and NEVER bumped for 0.8/0.9. The compiler does NOT patch/override the dep version — `build.rs` just runs cargo (optionally with a `--vendor-dir` CARGO_HOME + `--frozen`) against the generated `Cargo.toml`. So `cloacina-workflow = { version = "0.7" }` is a real `^0.7` requirement (`>=0.7.0,<0.8.0`) that WON'T resolve against a 0.9/0.10 crate (0.x minors are semver-incompatible) — offline it fails "not available", online it pulls a stale incompatible 0.7.x. Internal tests miss it because fixtures use `path` deps, not `cloacinactl package new` output; it bites real users only.
+**Decision:** the pin must TRACK the release. The bump command (T-0867) sets it to the release's `major.minor` (style stays minor-precision, e.g. `"0.10"`). The drift guard (T-0868) asserts `CLOACINA_CRATE_VERSION`'s minor == the workspace version's minor. (NOT deliberately pinned; no whitelist.)
 
 ## Backlog Item Details **[CONDITIONAL: Backlog Item]**
 
@@ -63,6 +69,10 @@ initiative_id: CLOACI-I-0134
 - **Current Problems**: {What's difficult/slow/buggy now}
 - **Benefits of Fixing**: {What improves after refactoring}
 - **Risk Assessment**: {Risks of not addressing this}
+
+## Acceptance Criteria
+
+## Acceptance Criteria
 
 ## Acceptance Criteria **[REQUIRED]**
 

--- a/.metis/initiatives/CLOACI-I-0134/tasks/CLOACI-T-0870.md
+++ b/.metis/initiatives/CLOACI-I-0134/tasks/CLOACI-T-0870.md
@@ -4,14 +4,14 @@ level: task
 title: "Dogfood — cut 0.10.0 through the bump command + guard, draft CHANGELOG 0.10.0"
 short_code: "CLOACI-T-0870"
 created_at: 2026-07-08T11:36:27.545977+00:00
-updated_at: 2026-07-08T11:36:27.545977+00:00
+updated_at: 2026-07-08T22:16:11.070183+00:00
 parent: CLOACI-I-0134
 blocked_by: []
 archived: false
 
 tags:
   - "#task"
-  - "#phase/todo"
+  - "#phase/completed"
 
 
 exit_criteria_met: false
@@ -63,6 +63,10 @@ initiative_id: CLOACI-I-0134
 - **Current Problems**: {What's difficult/slow/buggy now}
 - **Benefits of Fixing**: {What improves after refactoring}
 - **Risk Assessment**: {Risks of not addressing this}
+
+## Acceptance Criteria
+
+## Acceptance Criteria
 
 ## Acceptance Criteria **[REQUIRED]**
 
@@ -133,4 +137,6 @@ initiative_id: CLOACI-I-0134
 
 ## Status Updates **[REQUIRED]**
 
-*To be added during implementation*
+### 2026-07-08 — DONE (branch feat/i0134-version-single-source, commit bb635d48)
+Dogfooded the new machinery: `angreal release bump 0.10.0` set ALL 16 core touchpoints (Rust workspace version + 10 internal dep pins, npm×3, python×2, scaffold pin) from ONE input in one command, plus a CHANGELOG stub which I filled with the [0.10.0] release notes for the 18 feature merges since v0.9.0 (Secrets I-0133, compiler sandbox I-0105, embedded UI I-0130, constructors I-0132, parameterized instances I-0116, CG fleet dispatch, K8s fleet I-0127; breaking: authoring-shell minimization I-0125, ReactionMode/ReactionCriteria collapse, retired standalone Nginx UI container).
+**Verified: `version-lockstep` guard → 16 touchpoints all at 0.10.0 (exit 0); Cargo.lock synced (cargo check clean).** Proves the single-source works end to end: one command, whole repo at 0.10.0, no drift. The `git tag v0.10.0` stays a human step (I-0134 non-goal).

--- a/.metis/initiatives/CLOACI-I-0134/tasks/CLOACI-T-0870.md
+++ b/.metis/initiatives/CLOACI-I-0134/tasks/CLOACI-T-0870.md
@@ -1,0 +1,136 @@
+---
+id: dogfood-cut-0-10-0-through-the
+level: task
+title: "Dogfood — cut 0.10.0 through the bump command + guard, draft CHANGELOG 0.10.0"
+short_code: "CLOACI-T-0870"
+created_at: 2026-07-08T11:36:27.545977+00:00
+updated_at: 2026-07-08T11:36:27.545977+00:00
+parent: CLOACI-I-0134
+blocked_by: []
+archived: false
+
+tags:
+  - "#task"
+  - "#phase/todo"
+
+
+exit_criteria_met: false
+initiative_id: CLOACI-I-0134
+---
+
+# Dogfood — cut 0.10.0 through the bump command + guard, draft CHANGELOG 0.10.0
+
+*This template includes sections for various types of tasks. Delete sections that don't apply to your specific use case.*
+
+## Parent Initiative **[CONDITIONAL: Assigned Task]**
+
+[[CLOACI-I-0134]]
+
+## Objective **[REQUIRED]**
+
+{Clear statement of what this task accomplishes}
+
+## Backlog Item Details **[CONDITIONAL: Backlog Item]**
+
+{Delete this section when task is assigned to an initiative}
+
+### Type
+- [ ] Bug - Production issue that needs fixing
+- [ ] Feature - New functionality or enhancement  
+- [ ] Tech Debt - Code improvement or refactoring
+- [ ] Chore - Maintenance or setup work
+
+### Priority
+- [ ] P0 - Critical (blocks users/revenue)
+- [ ] P1 - High (important for user experience)
+- [ ] P2 - Medium (nice to have)
+- [ ] P3 - Low (when time permits)
+
+### Impact Assessment **[CONDITIONAL: Bug]**
+- **Affected Users**: {Number/percentage of users affected}
+- **Reproduction Steps**: 
+  1. {Step 1}
+  2. {Step 2}
+  3. {Step 3}
+- **Expected vs Actual**: {What should happen vs what happens}
+
+### Business Justification **[CONDITIONAL: Feature]**
+- **User Value**: {Why users need this}
+- **Business Value**: {Impact on metrics/revenue}
+- **Effort Estimate**: {Rough size - S/M/L/XL}
+
+### Technical Debt Impact **[CONDITIONAL: Tech Debt]**
+- **Current Problems**: {What's difficult/slow/buggy now}
+- **Benefits of Fixing**: {What improves after refactoring}
+- **Risk Assessment**: {Risks of not addressing this}
+
+## Acceptance Criteria **[REQUIRED]**
+
+- [ ] {Specific, testable requirement 1}
+- [ ] {Specific, testable requirement 2}
+- [ ] {Specific, testable requirement 3}
+
+## Test Cases **[CONDITIONAL: Testing Task]**
+
+{Delete unless this is a testing task}
+
+### Test Case 1: {Test Case Name}
+- **Test ID**: TC-001
+- **Preconditions**: {What must be true before testing}
+- **Steps**: 
+  1. {Step 1}
+  2. {Step 2}
+  3. {Step 3}
+- **Expected Results**: {What should happen}
+- **Actual Results**: {To be filled during execution}
+- **Status**: {Pass/Fail/Blocked}
+
+### Test Case 2: {Test Case Name}
+- **Test ID**: TC-002
+- **Preconditions**: {What must be true before testing}
+- **Steps**: 
+  1. {Step 1}
+  2. {Step 2}
+- **Expected Results**: {What should happen}
+- **Actual Results**: {To be filled during execution}
+- **Status**: {Pass/Fail/Blocked}
+
+## Documentation Sections **[CONDITIONAL: Documentation Task]**
+
+{Delete unless this is a documentation task}
+
+### User Guide Content
+- **Feature Description**: {What this feature does and why it's useful}
+- **Prerequisites**: {What users need before using this feature}
+- **Step-by-Step Instructions**:
+  1. {Step 1 with screenshots/examples}
+  2. {Step 2 with screenshots/examples}
+  3. {Step 3 with screenshots/examples}
+
+### Troubleshooting Guide
+- **Common Issue 1**: {Problem description and solution}
+- **Common Issue 2**: {Problem description and solution}
+- **Error Messages**: {List of error messages and what they mean}
+
+### API Documentation **[CONDITIONAL: API Documentation]**
+- **Endpoint**: {API endpoint description}
+- **Parameters**: {Required and optional parameters}
+- **Example Request**: {Code example}
+- **Example Response**: {Expected response format}
+
+## Implementation Notes **[CONDITIONAL: Technical Task]**
+
+{Keep for technical tasks, delete for non-technical. Technical details, approach, or important considerations}
+
+### Technical Approach
+{How this will be implemented}
+
+### Dependencies
+{Other tasks or systems this depends on}
+
+### Risk Considerations
+{Technical risks and mitigation strategies}
+
+## Status Updates **[REQUIRED]**
+
+*To be added during implementation*

--- a/.metis/initiatives/CLOACI-I-0135/initiative.md
+++ b/.metis/initiatives/CLOACI-I-0135/initiative.md
@@ -1,0 +1,148 @@
+---
+id: dal-twin-collapse-one-backend
+level: initiative
+title: "DAL twin collapse — one backend-agnostic interact seam, delete ~168 postgres/sqlite method twins"
+short_code: "CLOACI-I-0135"
+created_at: 2026-07-08T14:20:10.497021+00:00
+updated_at: 2026-07-08T14:20:10.497021+00:00
+parent: 
+blocked_by: []
+archived: false
+
+tags:
+  - "#initiative"
+  - "#phase/discovery"
+
+
+exit_criteria_met: false
+estimated_complexity: M
+initiative_id: dal-twin-collapse-one-backend
+---
+
+# DAL twin collapse — one backend-agnostic interact seam, delete ~168 postgres/sqlite method twins Initiative
+
+*This template includes sections for various types of initiatives. Delete sections that don't apply to your specific use case.*
+
+## Context **[REQUIRED]**
+
+> **Phase: discovery.** Surfaced by the 2026-07-08 architecture deepening review (candidate #1, rated Strong — the largest leverage). Not yet designed.
+
+**The shallowness.** ~**330 twin methods** — 167 `async fn *_postgres` + 168 `*_sqlite` — across `crates/cloacina/src/dal/unified/**` and `crates/cloacina/src/security/**` (a 27k-line subtree). The twins are MECHANICAL, not backend-specific: the 108-line pair `schedule/crud.rs::upsert_trigger_{postgres,sqlite}` differs by exactly **2 lines** (the connection accessor `.get_{postgres,sqlite}_connection()` + the `#[cfg]`); the whole diesel `interact` closure is byte-identical. `db_key_manager.rs` twins differ by ~3 lines. The backend choice LEAKS into all ~330 method bodies because each re-selects the connection by hand and re-writes the whole closure.
+
+**Why it exists (maintainer, load-bearing history):** this is a **vestigial trait from before the dual-DB abstraction existed.** When there was no MultiConnection/backend-agnostic crate to lean on, hand-writing the postgres/sqlite twin was the lesser of two evils. Now that the dual-DB seam exists (`database/connection` — both `get_{pg,sqlite}_connection()` return a deadpool `Object` exposing the same `.interact(closure)` API; `dispatch_backend!` already centralizes the cfg branch), the duplication is purely collapsible. **Record this so no one re-adds twins thinking they're required.**
+
+**The genuinely-divergent minority (stays explicit):** `task_execution/claiming.rs` (Postgres `FOR UPDATE SKIP LOCKED` vs SQLite `IMMEDIATE`), `schedule/crud.rs:713` (`SET TRANSACTION ISOLATION LEVEL SERIALIZABLE`), and the SQLite-lacks-`RETURNING` spots (`execution_event.rs`, `task_execution_metadata.rs`) — roughly **4 operations** where the twin actually earns its keep.
+
+**Deletion test — PASS:** deleting the sqlite twin bodies (routing through one backend-agnostic `interact_on_backend` seam) CONCENTRATES complexity at the connection seam where backend choice belongs; it does not move it. Compatible with [[CLOACI-A-0001]] (Diesel MultiConnection) — it deepens that decision. Same disease as the version drift [[CLOACI-I-0134]] fixes: hand-copied duplicates always cost more than the seam.
+
+## Goals & Non-Goals **[REQUIRED]**
+
+**Goals:**
+- One `interact_on_backend(dal, |conn| …diesel…)` adapter over the two connection accessors + `dispatch_backend!`, so a DAL method's query is written ONCE.
+- Migrate the ~330 twins to the single seam; the ~4 genuinely-divergent operations remain explicit twins (and become VISIBLE as the only things written twice).
+- Net: ~168 twin methods deletable; each query becomes testable once (the interface is the test surface).
+
+**Non-Goals:**
+- Re-litigating the backend-selection decision ([[CLOACI-A-0001]] MultiConnection stays).
+- Collapsing the genuinely backend-divergent SQL (SKIP LOCKED, RETURNING gaps, isolation) — those stay explicit by design.
+- Changing DAL public interfaces or query semantics — pure internal deepening, behavior-preserving.
+
+## Requirements **[CONDITIONAL: Requirements-Heavy Initiative]**
+
+{Delete if not a requirements-focused initiative}
+
+### User Requirements
+- **User Characteristics**: {Technical background, experience level, etc.}
+- **System Functionality**: {What users expect the system to do}
+- **User Interfaces**: {How users will interact with the system}
+
+### System Requirements
+- **Functional Requirements**: {What the system should do - use unique identifiers}
+  - REQ-001: {Functional requirement 1}
+  - REQ-002: {Functional requirement 2}
+- **Non-Functional Requirements**: {How the system should behave}
+  - NFR-001: {Performance requirement}
+  - NFR-002: {Security requirement}
+
+## Use Cases **[CONDITIONAL: User-Facing Initiative]**
+
+{Delete if not user-facing}
+
+### Use Case 1: {Use Case Name}
+- **Actor**: {Who performs this action}
+- **Scenario**: {Step-by-step interaction}
+- **Expected Outcome**: {What should happen}
+
+### Use Case 2: {Use Case Name}
+- **Actor**: {Who performs this action}
+- **Scenario**: {Step-by-step interaction}
+- **Expected Outcome**: {What should happen}
+
+## Architecture **[CONDITIONAL: Technically Complex Initiative]**
+
+{Delete if not technically complex}
+
+### Overview
+{High-level architectural approach}
+
+### Component Diagrams
+{Describe or link to component diagrams}
+
+### Class Diagrams
+{Describe or link to class diagrams - for OOP systems}
+
+### Sequence Diagrams
+{Describe or link to sequence diagrams - for interaction flows}
+
+### Deployment Diagrams
+{Describe or link to deployment diagrams - for infrastructure}
+
+## Detailed Design **[REQUIRED]**
+
+{Technical approach and implementation details}
+
+## UI/UX Design **[CONDITIONAL: Frontend Initiative]**
+
+{Delete if no UI components}
+
+### User Interface Mockups
+{Describe or link to UI mockups}
+
+### User Flows
+{Describe key user interaction flows}
+
+### Design System Integration
+{How this fits with existing design patterns}
+
+## Testing Strategy **[CONDITIONAL: Separate Testing Initiative]**
+
+{Delete if covered by separate testing initiative}
+
+### Unit Testing
+- **Strategy**: {Approach to unit testing}
+- **Coverage Target**: {Expected coverage percentage}
+- **Tools**: {Testing frameworks and tools}
+
+### Integration Testing
+- **Strategy**: {Approach to integration testing}
+- **Test Environment**: {Where integration tests run}
+- **Data Management**: {Test data strategy}
+
+### System Testing
+- **Strategy**: {End-to-end testing approach}
+- **User Acceptance**: {How UAT will be conducted}
+- **Performance Testing**: {Load and stress testing}
+
+### Test Selection
+{Criteria for determining what to test}
+
+### Bug Tracking
+{How defects will be managed and prioritized}
+
+## Alternatives Considered **[REQUIRED]**
+
+{Alternative approaches and why they were rejected}
+
+## Implementation Plan **[REQUIRED]**
+
+{Phases and timeline for execution}

--- a/.metis/initiatives/CLOACI-I-0136/initiative.md
+++ b/.metis/initiatives/CLOACI-I-0136/initiative.md
@@ -1,0 +1,149 @@
+---
+id: py-block-on-one-gil-safe-async
+level: initiative
+title: "py_block_on — one GIL-safe async→sync bridge module, retire the per-binding reimplementations"
+short_code: "CLOACI-I-0136"
+created_at: 2026-07-08T14:20:11.787079+00:00
+updated_at: 2026-07-08T14:20:11.787079+00:00
+parent: 
+blocked_by: []
+archived: false
+
+tags:
+  - "#initiative"
+  - "#phase/discovery"
+
+
+exit_criteria_met: false
+estimated_complexity: M
+initiative_id: py-block-on-one-gil-safe-async
+---
+
+# py_block_on — one GIL-safe async→sync bridge module, retire the per-binding reimplementations Initiative
+
+*This template includes sections for various types of initiatives. Delete sections that don't apply to your specific use case.*
+
+## Context **[REQUIRED]**
+
+> **Phase: discovery.** Surfaced by the 2026-07-08 architecture deepening review (candidate #2, rated Strong — highest CORRECTNESS leverage). Not yet designed.
+
+**The shallowness.** The bridge's INTERFACE is trivial — drive one async Rust future to completion from a sync PyO3 method, GIL-safely — but its correctness-critical IMPLEMENTATION is copied in **three non-equivalent shapes across 8 files** (`crates/cloacina-python/src/{context,task,trigger,constructor,computation_graph}.rs`, `bindings/{runner,admin,trigger}.rs`):
+- **The correct one** — `context.rs::block_on_secret_access`: `py.allow_threads(|| match Handle::try_current() { … block_on … })`. Its doc comment carries the load-bearing knowledge: the GIL is RELEASED before we block (the scenario-30/32/33 PyO3↔tokio deadlock history).
+- **Already drifted to UNSAFE** — `bindings/admin.rs`: a fresh `tokio::runtime::Runtime::new()?.block_on(...)` with **NO `py.allow_threads`** — holds the GIL across the blocking await, the exact footgun `context.rs` documents avoiding. This is a **latent deadlock bug shipping today.**
+- Two more shapes: `runner.rs` (a dedicated OS-thread actor loop) and `task.rs` (`Handle::current().block_on` + `spawn_blocking(with_gil)`).
+
+The GIL-correctness invariant lives as tribal knowledge in one file's comment, not in code the others call — so a binding already re-implemented it wrong.
+
+**Deletion test — PASS:** deleting admin.rs's & runner.rs's ad-hoc `Runtime::new().block_on` in favour of one `py_block_on(py, fut)` module CONCENTRATES GIL-deadlock correctness in one auditable place — and removes an already-unsafe copy. See [[project_scenario32_cg_invocation_deadlock]] for why this locality is valuable.
+
+## Goals & Non-Goals **[REQUIRED]**
+
+**Goals:**
+- One `py_block_on(py, fut)` module (context.rs's helper, generalized off "secret") that EVERY binding calls to drive an async future from sync PyO3.
+- The GIL-safety invariant (release GIL via `allow_threads`, reuse the ambient `Handle`, fall back to a transient runtime) becomes a LOCALITY property of one function — auditable once.
+- Fix the admin.rs latent deadlock in passing (route it through the safe door).
+
+**Non-Goals:**
+- Restructuring runner.rs's dedicated-thread actor loop unless it genuinely simplifies onto `py_block_on` (its OS-thread ownership may be load-bearing — investigate, don't force).
+- Changing any Python-facing API — pure internal correctness/locality deepening.
+- Re-opening the async execution model; this is only about the sync→async blocking bridge.
+
+## Requirements **[CONDITIONAL: Requirements-Heavy Initiative]**
+
+{Delete if not a requirements-focused initiative}
+
+### User Requirements
+- **User Characteristics**: {Technical background, experience level, etc.}
+- **System Functionality**: {What users expect the system to do}
+- **User Interfaces**: {How users will interact with the system}
+
+### System Requirements
+- **Functional Requirements**: {What the system should do - use unique identifiers}
+  - REQ-001: {Functional requirement 1}
+  - REQ-002: {Functional requirement 2}
+- **Non-Functional Requirements**: {How the system should behave}
+  - NFR-001: {Performance requirement}
+  - NFR-002: {Security requirement}
+
+## Use Cases **[CONDITIONAL: User-Facing Initiative]**
+
+{Delete if not user-facing}
+
+### Use Case 1: {Use Case Name}
+- **Actor**: {Who performs this action}
+- **Scenario**: {Step-by-step interaction}
+- **Expected Outcome**: {What should happen}
+
+### Use Case 2: {Use Case Name}
+- **Actor**: {Who performs this action}
+- **Scenario**: {Step-by-step interaction}
+- **Expected Outcome**: {What should happen}
+
+## Architecture **[CONDITIONAL: Technically Complex Initiative]**
+
+{Delete if not technically complex}
+
+### Overview
+{High-level architectural approach}
+
+### Component Diagrams
+{Describe or link to component diagrams}
+
+### Class Diagrams
+{Describe or link to class diagrams - for OOP systems}
+
+### Sequence Diagrams
+{Describe or link to sequence diagrams - for interaction flows}
+
+### Deployment Diagrams
+{Describe or link to deployment diagrams - for infrastructure}
+
+## Detailed Design **[REQUIRED]**
+
+{Technical approach and implementation details}
+
+## UI/UX Design **[CONDITIONAL: Frontend Initiative]**
+
+{Delete if no UI components}
+
+### User Interface Mockups
+{Describe or link to UI mockups}
+
+### User Flows
+{Describe key user interaction flows}
+
+### Design System Integration
+{How this fits with existing design patterns}
+
+## Testing Strategy **[CONDITIONAL: Separate Testing Initiative]**
+
+{Delete if covered by separate testing initiative}
+
+### Unit Testing
+- **Strategy**: {Approach to unit testing}
+- **Coverage Target**: {Expected coverage percentage}
+- **Tools**: {Testing frameworks and tools}
+
+### Integration Testing
+- **Strategy**: {Approach to integration testing}
+- **Test Environment**: {Where integration tests run}
+- **Data Management**: {Test data strategy}
+
+### System Testing
+- **Strategy**: {End-to-end testing approach}
+- **User Acceptance**: {How UAT will be conducted}
+- **Performance Testing**: {Load and stress testing}
+
+### Test Selection
+{Criteria for determining what to test}
+
+### Bug Tracking
+{How defects will be managed and prioritized}
+
+## Alternatives Considered **[REQUIRED]**
+
+{Alternative approaches and why they were rejected}
+
+## Implementation Plan **[REQUIRED]**
+
+{Phases and timeline for execution}

--- a/.metis/initiatives/CLOACI-I-0137/initiative.md
+++ b/.metis/initiatives/CLOACI-I-0137/initiative.md
@@ -1,0 +1,150 @@
+---
+id: cloaca-single-registrar-one
+level: initiative
+title: "Cloaca single registrar — one register_cloaca() source of truth, make wheel/server symbol drift impossible"
+short_code: "CLOACI-I-0137"
+created_at: 2026-07-08T14:20:13.910682+00:00
+updated_at: 2026-07-08T14:20:13.910682+00:00
+parent: 
+blocked_by: []
+archived: false
+
+tags:
+  - "#initiative"
+  - "#phase/discovery"
+
+
+exit_criteria_met: false
+estimated_complexity: M
+initiative_id: cloaca-single-registrar-one
+---
+
+# Cloaca single registrar — one register_cloaca() source of truth, make wheel/server symbol drift impossible Initiative
+
+*This template includes sections for various types of initiatives. Delete sections that don't apply to your specific use case.*
+
+## Context **[REQUIRED]**
+
+> **Phase: discovery. Maintainer flagged CLAMP IT DOWN NOW** (2026-07-08) — surfaced by the architecture deepening review (candidate #3, Strong). Small, mechanical, and a drift class we want closed before it bites again.
+
+**The shallowness.** The `cloaca` Python module is registered in TWO hand-synced places that must be kept identical by discipline:
+- `crates/cloacina-python/src/lib.rs:89–185` — the maturin `#[pymodule]` (what the pip WHEEL exposes).
+- `crates/cloacina-python/src/loader.rs:98–203` — a synthetic `ensure_cloaca_module` (`PyModule::new` injected into `sys.modules`, what the embedded SERVER exposes).
+
+Both carry literal `// keep BOTH in sync` comments — an admission the SEAM LEAKS. Evidence of real drift:
+- `py_var` / `py_var_or` are registered in `loader.rs` but **absent from `lib.rs`** — so `cloaca.var()` works on the embedded server but would be **missing from the wheel**. **This one is LATENT — it hasn't user-bitten yet (the maintainer's "hasn't hit us yet").**
+- `state_accumulator` was once omitted from `ensure_cloaca_module` and DID bite: a production reconciler failure `"module 'cloaca' has no attribute 'state_accumulator'"` ([[CLOACI-T-0688]]), patched with a `hasattr` regression guard bolted onto the drift — a symptom-suppressant, not a cure.
+
+**Deletion test — PASS:** deleting one of the two lists (both delegating to one shared registrar) makes drift STRUCTURALLY IMPOSSIBLE — the symbol set has one definition. Same disease as the version drift [[CLOACI-I-0134]] and the DAL twins [[CLOACI-I-0135]]: hand-synced duplicates always drift; the fix is one source, not more discipline.
+
+## Goals & Non-Goals **[REQUIRED]**
+
+**Goals:**
+- One `register_cloaca(m: &Bound<PyModule>)` function that adds every class/function to the module, called by BOTH the `#[pymodule]` and `ensure_cloaca_module`.
+- Wheel and embedded-server `cloaca` expose an identical symbol set BY CONSTRUCTION — you cannot add a symbol to one and forget the other.
+- Delete the `// keep BOTH in sync` comments and (once structurally safe) the `hasattr` regression guard.
+- Close the live `py_var`/`py_var_or` wheel gap as the first proof the collapse works.
+
+**Non-Goals:**
+- Changing WHICH symbols `cloaca` exposes — this is about the registration seam, not the surface.
+- The synthetic-module-injection mechanism itself (`ensure_cloaca_module` still injects into `sys.modules`; it just sources its symbols from the shared registrar).
+
+## Requirements **[CONDITIONAL: Requirements-Heavy Initiative]**
+
+{Delete if not a requirements-focused initiative}
+
+### User Requirements
+- **User Characteristics**: {Technical background, experience level, etc.}
+- **System Functionality**: {What users expect the system to do}
+- **User Interfaces**: {How users will interact with the system}
+
+### System Requirements
+- **Functional Requirements**: {What the system should do - use unique identifiers}
+  - REQ-001: {Functional requirement 1}
+  - REQ-002: {Functional requirement 2}
+- **Non-Functional Requirements**: {How the system should behave}
+  - NFR-001: {Performance requirement}
+  - NFR-002: {Security requirement}
+
+## Use Cases **[CONDITIONAL: User-Facing Initiative]**
+
+{Delete if not user-facing}
+
+### Use Case 1: {Use Case Name}
+- **Actor**: {Who performs this action}
+- **Scenario**: {Step-by-step interaction}
+- **Expected Outcome**: {What should happen}
+
+### Use Case 2: {Use Case Name}
+- **Actor**: {Who performs this action}
+- **Scenario**: {Step-by-step interaction}
+- **Expected Outcome**: {What should happen}
+
+## Architecture **[CONDITIONAL: Technically Complex Initiative]**
+
+{Delete if not technically complex}
+
+### Overview
+{High-level architectural approach}
+
+### Component Diagrams
+{Describe or link to component diagrams}
+
+### Class Diagrams
+{Describe or link to class diagrams - for OOP systems}
+
+### Sequence Diagrams
+{Describe or link to sequence diagrams - for interaction flows}
+
+### Deployment Diagrams
+{Describe or link to deployment diagrams - for infrastructure}
+
+## Detailed Design **[REQUIRED]**
+
+{Technical approach and implementation details}
+
+## UI/UX Design **[CONDITIONAL: Frontend Initiative]**
+
+{Delete if no UI components}
+
+### User Interface Mockups
+{Describe or link to UI mockups}
+
+### User Flows
+{Describe key user interaction flows}
+
+### Design System Integration
+{How this fits with existing design patterns}
+
+## Testing Strategy **[CONDITIONAL: Separate Testing Initiative]**
+
+{Delete if covered by separate testing initiative}
+
+### Unit Testing
+- **Strategy**: {Approach to unit testing}
+- **Coverage Target**: {Expected coverage percentage}
+- **Tools**: {Testing frameworks and tools}
+
+### Integration Testing
+- **Strategy**: {Approach to integration testing}
+- **Test Environment**: {Where integration tests run}
+- **Data Management**: {Test data strategy}
+
+### System Testing
+- **Strategy**: {End-to-end testing approach}
+- **User Acceptance**: {How UAT will be conducted}
+- **Performance Testing**: {Load and stress testing}
+
+### Test Selection
+{Criteria for determining what to test}
+
+### Bug Tracking
+{How defects will be managed and prioritized}
+
+## Alternatives Considered **[REQUIRED]**
+
+{Alternative approaches and why they were rejected}
+
+## Implementation Plan **[REQUIRED]**
+
+{Phases and timeline for execution}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,6 +38,19 @@ repos:
         language: system
         types: [rust]
         pass_filenames: false
+      # CLOACI-I-0134: single source of version truth. Fails if any core
+      # version touchpoint (Rust workspace, npm, python, scaffold pin) has
+      # drifted from [workspace.package] version. CI runs pre-commit, so drift
+      # cannot reach main. `language: python` uses a pre-commit-managed
+      # interpreter (stdlib-only script) so it never depends on the ambient
+      # python. Providers under examples/ are independently versioned (A-0010)
+      # and deliberately excluded.
+      - id: version-lockstep
+        name: Version lockstep (single source of truth)
+        entry: python .angreal/version_lockstep.py check
+        language: python
+        pass_filenames: false
+        always_run: true
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     # Ruff version.
     rev: v0.4.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0] - UNRELEASED
+
+### Added
+
+- **Secrets — encrypted named-field objects** (CLOACI-I-0133) — the encrypted sibling of parameters. A tenant-scoped `Secret` is a named object of named fields (`db_prod = { host, user, password }`), encrypted at rest under a per-tenant data key. A workflow declares required secrets (`#[workflow(secrets(...))]` / `@cloaca.workflow_secrets`) and reads them at run time via `context.secret(name)` / `secret_field(name, field)` (Rust **and** Python); an instance param binds one with the `{"$secret":"name"}` reference form. The resolved value **never** enters the durable `Context`, `schedules.params`, or the fires log (a leak test gates it). On the execution-agent fleet, secrets are delivered per-execution via RFC 9180 HPKE envelope wrap to a one-time agent key (true per-execution forward secrecy). Managed with `cloacinactl secret create/rotate/list/delete` and the embedded-UI Secrets view; the server reads its key encryption key from `CLOACINA_SECRET_KEK`. Authorization is by tenant scope. See [Secrets]({{< ref "/service/explanation/secrets" >}}).
+- **Compiler build sandbox** (CLOACI-I-0105) — `cargo build` runs attacker-controlled `build.rs` / proc-macros, so each build now runs under a fail-closed isolation ladder selected by `CLOACINA_COMPILER_SANDBOX = required|preferred|off`: bubblewrap namespaces (no network, cleared env, RO toolchain) or a landlock fallback. `required` refuses to boot when it can't sandbox. Templated into the Helm chart (`compiler.enabled`, `seccompProfile: Unconfined`). See [Compiler Build Sandbox]({{< ref "/service/compiler-sandbox" >}}).
+- **Embedded web UI** (CLOACI-I-0130) — a single `cloacina-server` binary now serves the engine, API, and the web UI (the `embedded-ui` feature; SPA embedded via `rust-embed`, same-origin by default). One container, no separate UI service.
+- **Constructors — reusable polyglot configured-instance factories** (CLOACI-I-0132) — author a WASM operator (task / trigger / accumulator / reactor) once, distribute it as a signed, independently-versioned **provider package** (rides Cargo's dependency model, ADR A-0010/A-0011), and instantiate it with bound config via `constructor!(from = "name@version", …)` (Rust and Python, embedded and packaged, including on the fleet). Capabilities/egress are tenant-granted at construction time, default-closed (ADR A-0009).
+- **Parameterized workflow instances** (CLOACI-I-0116) — register named, scheduled, param-bound instances of a workflow; the instance's declared params are snapshot at registration (immutable) and merged into each fire's context (reserved scheduler keys win).
+- **Computation graphs on the execution-agent fleet** (CLOACI-T-0722 / T-0841) — a whole-graph firing can dispatch to the fleet (Rust and Python), not just run in-process.
+- **Graph operational instrumentation & health API** (CLOACI-I-0117 / I-0131) — accumulator buffer/fill + events-rate, reactor fires log + per-minute cadence, surfaced in the health API and the graph view.
+- **Kubernetes-first execution-agent fleet** (CLOACI-I-0127) — UI-driven agent/tenant assignment, a pluggable `FleetActuator` (K8s + Docker), per-tenant autoscaling within limits, and K8s production-hardening (agent pod securityContext/probes, per-tenant NetworkPolicy, server PDB + anti-affinity).
+
+### Changed (breaking)
+
+- **Authoring-surface minimization** (CLOACI-I-0125) — a Rust package is now a 4-dependency shell (`cloacina-workflow` + `cloacina-workflow-plugin` + serde) with `cloacina_workflow_plugin::package!()`; the compiler injects the cdylib crate-type + `packaged` feature. **No more `build.rs`, `[lib] crate-type`, `[features]`, or `cloacina-build` in a package.** `package.toml` is minimized (name + version + `workflow_name`; the rest is defaulted/inferred). **Migration:** re-scaffold with `cloacinactl package new` or delete the retired ceremony.
+- **`ReactionMode` / `ReactionCriteria` collapsed** (CLOACI-T-0740) — the two enums merged; `criteria = when_any` with no accumulator list now means "all declared". Reactor declarations built against the split enums must update.
+- **Standalone Nginx UI container retired** (CLOACI-I-0130) — the web UI is served by the server (embedded). The separate `ui/Dockerfile` + `docker-compose.ui.yml` path is gone; deploy the embedded UI (or the `charts/cloacina-ui` chart for a standalone SPA).
+
+### Changed
+
+- **Single source of version truth** (CLOACI-I-0134) — the whole workspace version now lives in the root `Cargo.toml` `[workspace.package]` + `[workspace.dependencies]` (crates inherit via `{ workspace = true }`); `angreal release bump <version>` sets every core touchpoint (Rust / npm / python / scaffold) from one input, and a `version-lockstep` pre-commit hook fails CI on any drift. Providers version independently (ADR A-0010).
+
+### Fixed
+
+- Scaffold dependency pin (`cloacinactl package new`) tracked `cloacina-workflow = "0.7"`, three minors stale — generated packages couldn't resolve against the current toolchain. Now tracks the release (CLOACI-T-0869 / I-0134).
+- Web UI displayed a hardcoded, drifted version (shell showed `v0.8.0` while the release was 0.9.0); the version is now injected from `package.json` at build time (CLOACI-I-0134).
+
 ## [0.9.0] - 2026-06-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -733,7 +733,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cloacina"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -798,7 +798,7 @@ dependencies = [
 
 [[package]]
 name = "cloacina-agent"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -819,7 +819,7 @@ dependencies = [
 
 [[package]]
 name = "cloacina-api-types"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "base64 0.22.1",
  "serde",
@@ -830,14 +830,14 @@ dependencies = [
 
 [[package]]
 name = "cloacina-build"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "pyo3-build-config",
 ]
 
 [[package]]
 name = "cloacina-client"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "cloacina-compiler"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "cloacina-computation-graph"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "bincode",
  "once_cell",
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "cloacina-constructor-contract"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "cloacina-api-types",
  "serde",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "cloacina-macros"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "once_cell",
@@ -927,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "cloacina-python"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "cloacina-server"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1004,7 +1004,7 @@ dependencies = [
 
 [[package]]
 name = "cloacina-testing"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1018,7 +1018,7 @@ dependencies = [
 
 [[package]]
 name = "cloacina-workflow"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1037,7 +1037,7 @@ dependencies = [
 
 [[package]]
 name = "cloacina-workflow-plugin"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "cloacina-computation-graph",
  "cloacina-workflow",
@@ -1052,7 +1052,7 @@ dependencies = [
 
 [[package]]
 name = "cloacinactl"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,6 +614,17 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
@@ -621,6 +632,19 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20 0.9.1",
+ "cipher",
+ "poly1305",
+ "zeroize",
 ]
 
 [[package]]
@@ -655,6 +679,7 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common 0.1.7",
  "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -740,6 +765,7 @@ dependencies = [
  "fidius-macro",
  "futures",
  "hex",
+ "hpke",
  "inventory",
  "libloading",
  "libsqlite3-sys",
@@ -2365,6 +2391,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "hpke"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4917627a14198c3603282c5158b815ad5534795451d3c074b53cf3cee0960b11"
+dependencies = [
+ "aead",
+ "aes-gcm",
+ "chacha20poly1305",
+ "digest 0.10.7",
+ "generic-array",
+ "hkdf",
+ "hmac 0.12.1",
+ "rand_core 0.6.4",
+ "sha2 0.10.9",
+ "subtle",
+ "x25519-dalek",
+ "zeroize",
+]
+
+[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3921,6 +3967,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "polyval"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4309,7 +4366,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
- "chacha20",
+ "chacha20 0.10.0",
  "getrandom 0.4.2",
  "rand_core 0.10.1",
 ]
@@ -7370,6 +7427,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "xattr"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7448,6 +7515,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,13 +19,18 @@ async-trait = { version = "0.1" }
 inventory = { version = "0.3" }
 once_cell = { version = "1.19.0" }
 serde_json = { version = "1.0" }
-cloacina = { version = "0.10.0", path = "crates/cloacina" }
+# default-features = false: cloacina's defaults include postgres; every internal
+# consumer opts into its own backend. Setting it here (not just in the members)
+# is REQUIRED — Cargo ignores a member's `default-features = false` when the
+# workspace dep omits it, which silently leaks postgres/libpq into sqlite-only
+# builds (CLOACI-I-0134 follow-up).
+cloacina = { version = "0.10.0", path = "crates/cloacina", default-features = false }
 cloacina-api-types = { version = "0.10.0", path = "crates/cloacina-api-types" }
 cloacina-build = { version = "0.10.0", path = "crates/cloacina-build" }
 cloacina-client = { version = "0.10.0", path = "crates/cloacina-client" }
 cloacina-computation-graph = { version = "0.10.0", path = "crates/cloacina-computation-graph" }
 cloacina-macros = { version = "0.10.0", path = "crates/cloacina-macros" }
-cloacina-python = { version = "0.10.0", path = "crates/cloacina-python" }
+cloacina-python = { version = "0.10.0", path = "crates/cloacina-python", default-features = false }
 cloacina-workflow = { version = "0.10.0", path = "crates/cloacina-workflow" }
 cloacina-workflow-plugin = { version = "0.10.0", path = "crates/cloacina-workflow-plugin" }
 cloacina-constructor-contract = { version = "0.10.0", path = "crates/cloacina-constructor-contract" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,15 @@ async-trait = { version = "0.1" }
 inventory = { version = "0.3" }
 once_cell = { version = "1.19.0" }
 serde_json = { version = "1.0" }
+cloacina = { version = "0.9.0", path = "crates/cloacina" }
 cloacina-api-types = { version = "0.9.0", path = "crates/cloacina-api-types" }
+cloacina-build = { version = "0.9.0", path = "crates/cloacina-build" }
 cloacina-client = { version = "0.9.0", path = "crates/cloacina-client" }
+cloacina-computation-graph = { version = "0.9.0", path = "crates/cloacina-computation-graph" }
 cloacina-macros = { version = "0.9.0", path = "crates/cloacina-macros" }
+cloacina-python = { version = "0.9.0", path = "crates/cloacina-python" }
 cloacina-workflow = { version = "0.9.0", path = "crates/cloacina-workflow" }
+cloacina-workflow-plugin = { version = "0.9.0", path = "crates/cloacina-workflow-plugin" }
 cloacina-constructor-contract = { version = "0.9.0", path = "crates/cloacina-constructor-contract" }
 clap = { version = "4.0", features = ["derive", "env"] }
 anyhow = { version = "1.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["examples/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Dylan Storey <dylan.storey@gmail.com>"]
 license = "Apache-2.0"
 repository = "https://github.com/colliery-io/cloacina"
@@ -19,16 +19,16 @@ async-trait = { version = "0.1" }
 inventory = { version = "0.3" }
 once_cell = { version = "1.19.0" }
 serde_json = { version = "1.0" }
-cloacina = { version = "0.9.0", path = "crates/cloacina" }
-cloacina-api-types = { version = "0.9.0", path = "crates/cloacina-api-types" }
-cloacina-build = { version = "0.9.0", path = "crates/cloacina-build" }
-cloacina-client = { version = "0.9.0", path = "crates/cloacina-client" }
-cloacina-computation-graph = { version = "0.9.0", path = "crates/cloacina-computation-graph" }
-cloacina-macros = { version = "0.9.0", path = "crates/cloacina-macros" }
-cloacina-python = { version = "0.9.0", path = "crates/cloacina-python" }
-cloacina-workflow = { version = "0.9.0", path = "crates/cloacina-workflow" }
-cloacina-workflow-plugin = { version = "0.9.0", path = "crates/cloacina-workflow-plugin" }
-cloacina-constructor-contract = { version = "0.9.0", path = "crates/cloacina-constructor-contract" }
+cloacina = { version = "0.10.0", path = "crates/cloacina" }
+cloacina-api-types = { version = "0.10.0", path = "crates/cloacina-api-types" }
+cloacina-build = { version = "0.10.0", path = "crates/cloacina-build" }
+cloacina-client = { version = "0.10.0", path = "crates/cloacina-client" }
+cloacina-computation-graph = { version = "0.10.0", path = "crates/cloacina-computation-graph" }
+cloacina-macros = { version = "0.10.0", path = "crates/cloacina-macros" }
+cloacina-python = { version = "0.10.0", path = "crates/cloacina-python" }
+cloacina-workflow = { version = "0.10.0", path = "crates/cloacina-workflow" }
+cloacina-workflow-plugin = { version = "0.10.0", path = "crates/cloacina-workflow-plugin" }
+cloacina-constructor-contract = { version = "0.10.0", path = "crates/cloacina-constructor-contract" }
 clap = { version = "4.0", features = ["derive", "env"] }
 anyhow = { version = "1.0" }
 toml = { version = "0.8" }

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cloacina-client"
-version = "0.9.0"
+version = "0.10.0"
 description = "Python SDK for cloacina-server — typed REST client and WebSocket execution-event streams. Version-locked to the cloacina server release. (Service client; the embedded runtime is the separate `cloaca` package.)"
 readme = "README.md"
 license = "Apache-2.0"

--- a/clients/python/src/cloacina_client/__init__.py
+++ b/clients/python/src/cloacina_client/__init__.py
@@ -49,4 +49,4 @@ __all__ = [
     "models",
 ]
 
-__version__ = "0.9.0"
+__version__ = "0.10.0"

--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloacina/client",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "TypeScript SDK for cloacina-server — typed REST client and WebSocket execution-event streams. Version-locked to the cloacina server release.",
   "license": "Apache-2.0",
   "repository": {

--- a/crates/cloacina-agent/Cargo.toml
+++ b/crates/cloacina-agent/Cargo.toml
@@ -25,14 +25,14 @@ bincode = "1.3"
 # crate. See T-0632 status notes.
 # `constructors-wasm` explicit (CLOACI-T-0836): agents load packaged workflows too
 # and must resolve bundled constructor providers rather than fail closed.
-cloacina = { version = "0.9.0", path = "../cloacina", default-features = false, features = ["sqlite", "constructors-wasm"] }
+cloacina = { workspace = true, default-features = false, features = ["sqlite", "constructors-wasm"] }
 
 # Python runtime (PyO3) so the agent can run Python-packaged workflows, not just
 # Rust cdylibs — the agent fetches a Python package's source archive and imports
 # it via this runtime. `default-features = false` (NOT extension-module) embeds
 # the interpreter into the binary; the agent image carries libpython +
 # python3-dev. (CLOACI-T-0716)
-cloacina-python = { version = "0.9.0", path = "../cloacina-python", default-features = false }
+cloacina-python = { workspace = true, default-features = false }
 
 # HTTP client for REST endpoints (register/heartbeat/result/ws-ticket/artifact).
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }

--- a/crates/cloacina-compiler/Cargo.toml
+++ b/crates/cloacina-compiler/Cargo.toml
@@ -24,12 +24,12 @@ postgres = ["cloacina/postgres"]
 sqlite = ["cloacina/sqlite"]
 
 [dependencies]
-cloacina-workflow-plugin = { version = "0.9.0", path = "../cloacina-workflow-plugin" }
+cloacina-workflow-plugin = { workspace = true }
 # `constructor-packaging` (serde-only, no wasmtime): the build step discovers a
 # package's `constructor!` provider refs and bundles each provider into
 # `package_providers` (CLOACI-T-0836).
-cloacina = { version = "0.9.0", path = "../cloacina", default-features = false, features = ["constructor-packaging"] }
-cloacina-api-types = { version = "0.9.0", path = "../cloacina-api-types" }
+cloacina = { workspace = true, default-features = false, features = ["constructor-packaging"] }
+cloacina-api-types = { workspace = true }
 clap.workspace = true
 anyhow.workspace = true
 dirs = "6"

--- a/crates/cloacina-computation-graph/Cargo.toml
+++ b/crates/cloacina-computation-graph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cloacina-computation-graph"
-version = "0.9.0"
+version.workspace = true
 edition = "2021"
 description = "Core types for Cloacina computation graph plugins"
 license = "Apache-2.0"

--- a/crates/cloacina-python/Cargo.toml
+++ b/crates/cloacina-python/Cargo.toml
@@ -30,10 +30,10 @@ extension-module = ["pyo3/extension-module"]
 # `constructors-wasm` is ALWAYS on (CLOACI-T-0831 human decision: ship wasmtime in
 # the wheel) so `cloaca.constructor(...)` can resolve WASM provider members with
 # capability grants — Python is a core capability, no feature matrix.
-cloacina = { version = "0.9.0", path = "../cloacina", default-features = false, features = ["constructors-wasm"] }
-cloacina-computation-graph = { version = "0.9.0", path = "../cloacina-computation-graph" }
+cloacina = { workspace = true, default-features = false, features = ["constructors-wasm"] }
+cloacina-computation-graph = { workspace = true }
 cloacina-workflow = { workspace = true }
-cloacina-workflow-plugin = { version = "0.9.0", path = "../cloacina-workflow-plugin" }
+cloacina-workflow-plugin = { workspace = true }
 
 async-trait.workspace = true
 serde_json.workspace = true
@@ -53,7 +53,7 @@ url = { version = "2.5" }
 uuid = { version = "1.0", features = ["serde", "v4", "v5"] }
 
 [build-dependencies]
-cloacina-build = { version = "0.9.0", path = "../cloacina-build" }
+cloacina-build = { workspace = true }
 
 [dev-dependencies]
 fidius-core = "0.5.5"

--- a/crates/cloacina-server/Cargo.toml
+++ b/crates/cloacina-server/Cargo.toml
@@ -35,7 +35,7 @@ mime_guess = { version = "2", optional = true }
 # `constructors-wasm` is explicit (not just transitive via cloacina-python) so the
 # server can always resolve packaged constructor providers (reconciler Step 5b,
 # CLOACI-T-0836) — packaged workflows are the primary consumer window.
-cloacina = { version = "0.9.0", path = "../cloacina", default-features = false, features = ["constructors-wasm"] }
+cloacina = { workspace = true, default-features = false, features = ["constructors-wasm"] }
 # CLOACI-T-0811: the fleet control loop runs raw SQL (Postgres advisory locks for
 # leader election) over a pooled connection — the same `conn.interact` +
 # `diesel::sql_query` idiom the DAL uses. The Postgres backend is enabled via the
@@ -46,8 +46,8 @@ utoipa = { version = "5" }
 # Python runtime — server registers the impl at startup so uploaded
 # Python-language packages can be loaded by the reconciler. Compiler
 # service intentionally does not depend on this (T-0529).
-cloacina-python = { version = "0.9.0", path = "../cloacina-python", default-features = false }
-cloacina-workflow-plugin = { version = "0.9.0", path = "../cloacina-workflow-plugin" }
+cloacina-python = { workspace = true, default-features = false }
+cloacina-workflow-plugin = { workspace = true }
 clap.workspace = true
 anyhow.workspace = true
 dirs = "6"
@@ -99,4 +99,4 @@ serial_test = "3"
 tempfile = "3"
 
 [build-dependencies]
-cloacina-build = { version = "0.9.0", path = "../cloacina-build" }
+cloacina-build = { workspace = true }

--- a/crates/cloacina-workflow-plugin/Cargo.toml
+++ b/crates/cloacina-workflow-plugin/Cargo.toml
@@ -17,8 +17,8 @@ fidius-core = "0.5.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { workspace = true }
 inventory = "0.3"
-cloacina-computation-graph = { version = "0.9.0", path = "../cloacina-computation-graph" }
-cloacina-workflow = { version = "0.9.0", path = "../cloacina-workflow", default-features = false }
+cloacina-computation-graph = { workspace = true }
+cloacina-workflow = { workspace = true, default-features = false }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/cloacina/Cargo.toml
+++ b/crates/cloacina/Cargo.toml
@@ -55,8 +55,8 @@ serde_json.workspace = true
 cloacina-api-types = { workspace = true }
 cloacina-macros = { workspace = true, optional = true }
 cloacina-workflow = { workspace = true }
-cloacina-computation-graph = { version = "0.9.0", path = "../cloacina-computation-graph" }
-cloacina-workflow-plugin = { version = "0.9.0", path = "../cloacina-workflow-plugin" }
+cloacina-computation-graph = { workspace = true }
+cloacina-workflow-plugin = { workspace = true }
 
 # External dependencies
 chrono = { version = "0.4", features = ["serde"] }

--- a/crates/cloacinactl/Cargo.toml
+++ b/crates/cloacinactl/Cargo.toml
@@ -24,9 +24,9 @@ kafka = ["cloacina/kafka"]
 # `constructor-packaging` gives `cloacinactl constructor package` the provider
 # assembly/sign/pack path (CLOACI-T-0827). It is wasmtime-free (serde-only
 # contract crate) — it does NOT pull `constructors-wasm`, so the CLI stays light.
-cloacina = { version = "0.9.0", path = "../cloacina", default-features = false, features = ["constructor-packaging"] }
+cloacina = { workspace = true, default-features = false, features = ["constructor-packaging"] }
 cloacina-client = { workspace = true }
-cloacina-workflow-plugin = { version = "0.9.0", path = "../cloacina-workflow-plugin" }
+cloacina-workflow-plugin = { workspace = true }
 clap.workspace = true
 clap_complete = "4"
 anyhow.workspace = true

--- a/crates/cloacinactl/src/nouns/package/new.rs
+++ b/crates/cloacinactl/src/nouns/package/new.rs
@@ -36,7 +36,7 @@ use clap::ValueEnum;
 use crate::shared::error::CliError;
 
 /// Version pin for the generated Rust package's `cloacina-*` dependencies.
-const CLOACINA_CRATE_VERSION: &str = "0.7";
+const CLOACINA_CRATE_VERSION: &str = "0.9";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 pub enum ScaffoldLang {

--- a/crates/cloacinactl/src/nouns/package/new.rs
+++ b/crates/cloacinactl/src/nouns/package/new.rs
@@ -36,7 +36,7 @@ use clap::ValueEnum;
 use crate::shared::error::CliError;
 
 /// Version pin for the generated Rust package's `cloacina-*` dependencies.
-const CLOACINA_CRATE_VERSION: &str = "0.9";
+const CLOACINA_CRATE_VERSION: &str = "0.10";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 pub enum ScaffoldLang {

--- a/docs/static/openapi.json
+++ b/docs/static/openapi.json
@@ -11,7 +11,7 @@
       "name": "Apache-2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0"
     },
-    "version": "0.9.0"
+    "version": "0.10.0"
   },
   "paths": {
     "/health": {

--- a/ui/harness/package.json
+++ b/ui/harness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloacina/seed-harness",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "private": true,
   "type": "module",
   "description": "Cloacina UI seed/demo workload harness (CLOACI-I-0117 / T-0660). Drives a target cloacina-server — ensures a tenant, uploads fixtures, runs executions — in deterministic seed mode (for UAT) or continuous loop mode (for a live demo).",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloacina/ui",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "private": true,
   "type": "module",
   "description": "Cloacina web UI — tenant-scoped control plane (CLOACI-I-0117). React SPA over @cloacina/client.",

--- a/ui/src/components/Shell.tsx
+++ b/ui/src/components/Shell.tsx
@@ -187,7 +187,7 @@ export function Shell() {
             }}
           >
             <span style={{ width: 7, height: 7, borderRadius: "50%", background: serverDot }} />
-            server {serverWord} · v0.8.0
+            server {serverWord} · v{__APP_VERSION__}
           </Box>
         </Box>
 

--- a/ui/src/routes/Connect.tsx
+++ b/ui/src/routes/Connect.tsx
@@ -379,7 +379,7 @@ export function Connect() {
         </Box>
 
         <Box style={{ textAlign: "center", marginTop: 14, fontFamily: MONO, fontSize: 10.5, color: "var(--faint)" }}>
-          cloacina v0.9.0 · tenant-scoped control plane
+          cloacina v{__APP_VERSION__} · tenant-scoped control plane
         </Box>
       </Box>
     </Box>

--- a/ui/src/vite-env.d.ts
+++ b/ui/src/vite-env.d.ts
@@ -1,5 +1,9 @@
 /// <reference types="vite/client" />
 
+// CLOACI-I-0134 / T-0866 — build-time injected UI version (from ui/package.json,
+// via the Vite `define` in vite.config.ts). Single source of version truth (D-2).
+declare const __APP_VERSION__: string;
+
 interface CloacinaRuntimeConfig {
   /** Default server URL injected by the deploy container (T-0659). */
   defaultServerUrl?: string;

--- a/ui/tsconfig.node.json
+++ b/ui/tsconfig.node.json
@@ -7,6 +7,7 @@
 
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
     "isolatedModules": true,
     "moduleDetection": "force",
     "noEmit": true,

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -1,9 +1,15 @@
 /// <reference types="vitest/config" />
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+// CLOACI-I-0134 / T-0866 — single source of version truth: inject the UI version
+// from package.json at build time so no hand-typed literal can drift (design D-2).
+import pkg from "./package.json";
 
 // CLOACI-I-0117 / T-0651 — Vite config for the Cloacina web UI.
 export default defineConfig({
+  define: {
+    __APP_VERSION__: JSON.stringify(pkg.version),
+  },
   plugins: [react()],
   server: {
     port: 5173,


### PR DESCRIPTION
Kills the recurring version-drift class (the UI shell was displaying **v0.8.0** while the Connect page said v0.9.0 and package.json said 0.9.0 — three hand-typed versions in one app) and cuts **0.10.0** through the new machinery.

## What changed
- **Rust — one source** (T-0865): 10 internal crates defined once in `[workspace.dependencies]`; every per-crate path-dep now `{ workspace = true }`; the `cloacina-computation-graph` straggler fixed. Rust bumps at 2 points in one file.
- **UI — build-time inject** (T-0866): `vite.config.ts` injects `__APP_VERSION__` from `package.json`; the two hand-typed display literals are gone. No UI version literal can drift again.
- **`angreal release bump <version>`** (T-0867): one command sets all 16 core touchpoints (Rust / npm×3 / python×2 / scaffold pin) + a CHANGELOG stub.
- **Drift guard** (T-0868): a `version-lockstep` pre-commit hook (`language: python`, stdlib-only, ambient-python-independent) **fails on any touchpoint mismatch** with a readable report. CI runs pre-commit, so drift can't reach main. Logic lives in `.angreal/version_lockstep.py`; `angreal release check` wraps it.
- **Scaffold-pin spike** (T-0869): found `cloacinactl package new` pinned generated packages to `cloacina-workflow = "0.7"` — 3 minors stale, wouldn't resolve against the current toolchain. Now tracks the release (major.minor).
- **Dogfood → 0.10.0** (T-0870): bumped via the command; guard confirms **16 touchpoints all at 0.10.0**; CHANGELOG `[0.10.0]` written for the 18 feature merges since v0.9.0.

## Scope
Providers version independently (ADR A-0010) — the `examples/constructor-contract/cloacina-provider-*` crates are standalone, excluded from core's workspace, and the guard ignores them. Two follow-ups filed: **T-0871** (audit/promote first-party providers out of `examples/`) and **T-0872** (independent provider release path).

## Not automated (by design)
The `git tag v0.10.0` stays a deliberate human step — this initiative is about the version SOURCE, not the release pipeline (`unified_release.yml` unchanged).

Verified locally: guard green at 0.10.0, `cargo metadata` + `cargo check` clean, feature flags preserved through the `{ workspace = true }` conversion, hook passes-consistent / fails-on-injected-drift. Closes I-0134 (6/6).

https://claude.ai/code/session_01WSzihhQReYhXGJnNWyTCHt