### PR TITLE
fix(nightly): repair the follow-up failures unmasked by the lane fixes

### DIFF
--- a/clients/python/src/cloacina_client/_generated/api/executions/execute_workflow.py
+++ b/clients/python/src/cloacina_client/_generated/api/executions/execute_workflow.py
@@ -59,6 +59,11 @@ def _parse_response(
 
         return response_403
 
+    if response.status_code == 404:
+        response_404 = ErrorBody.from_dict(response.json())
+
+        return response_404
+
     if response.status_code == 500:
         response_500 = ErrorBody.from_dict(response.json())
 

--- a/clients/python/tests/test_contract.py
+++ b/clients/python/tests/test_contract.py
@@ -201,10 +201,12 @@ def test_trigger_missing_404(client: Client) -> None:
 
 
 def test_execute_unknown_workflow(client: Client) -> None:
+    # I-0138 cross-tenant gate: a workflow not registered for THIS tenant
+    # fails closed with 404 (the `public` tenant is exempt).
     with pytest.raises(CloacinaApiError) as exc:
         client.execute_workflow("does-not-exist", {"k": "v"})
-    assert exc.value.status == 400
-    assert exc.value.code == "execution_failed"
+    assert exc.value.status == 404
+    assert exc.value.code == "workflow_not_found"
 
 
 def test_execution_list_and_iteration(client: Client, tenant_name: str) -> None:

--- a/clients/typescript/generated/types.ts
+++ b/clients/typescript/generated/types.ts
@@ -4806,6 +4806,15 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorBody"];
                 };
             };
+            /** @description Workflow not registered for this tenant (I-0138 cross-tenant gate; `public` is exempt) */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorBody"];
+                };
+            };
             /** @description Internal error */
             500: {
                 headers: {

--- a/clients/typescript/test/contract.test.ts
+++ b/clients/typescript/test/contract.test.ts
@@ -233,13 +233,15 @@ describe.skipIf(!RUN)("TS SDK live-server contract", () => {
   // ---- executions ----
 
   it("POST /v1/tenants/{t}/workflows/{name}/execute rejects unknown workflow with documented error", async () => {
+    // I-0138 cross-tenant gate: a workflow not registered for THIS tenant
+    // fails closed with 404 (the `public` tenant is exempt).
     const err = await client
       .executeWorkflow("does-not-exist", { context: { k: "v" } })
       .then(() => null)
       .catch((e: unknown) => e);
     expect(err).toBeInstanceOf(CloacinaApiError);
-    expect((err as CloacinaApiError).status).toBe(400);
-    expect((err as CloacinaApiError).code).toBe("execution_failed");
+    expect((err as CloacinaApiError).status).toBe(404);
+    expect((err as CloacinaApiError).code).toBe("workflow_not_found");
   });
 
   it("GET /v1/tenants/{t}/executions returns the paged envelope and honors filters", async () => {

--- a/crates/cloacina-client/tests/contract.rs
+++ b/crates/cloacina-client/tests/contract.rs
@@ -156,11 +156,13 @@ async fn full_rest_surface_contract() {
     assert!(matches!(no_trigger, Err(ClientError::NotFound(_))));
 
     // ---- executions ----
+    // I-0138 cross-tenant gate: a workflow not registered for THIS tenant
+    // fails closed with 404 (the `public` tenant is exempt).
     let exec_err = client
         .execute_workflow("does-not-exist", serde_json::json!({"k": "v"}))
         .await
         .expect_err("unknown workflow rejected");
-    assert!(matches!(exec_err, ClientError::InvalidRequest(_)));
+    assert!(matches!(exec_err, ClientError::NotFound(_)));
 
     let executions = client
         .list_executions(

--- a/crates/cloacina-server/src/routes/executions.rs
+++ b/crates/cloacina-server/src/routes/executions.rs
@@ -58,6 +58,7 @@ use crate::AppState;
         (status = 400, description = "Execution failed", body = cloacina_api_types::ErrorBody),
         (status = 401, description = "Missing or invalid API key", body = cloacina_api_types::ErrorBody),
         (status = 403, description = "Tenant access or role denied", body = cloacina_api_types::ErrorBody),
+        (status = 404, description = "Workflow not registered for this tenant (I-0138 cross-tenant gate; `public` is exempt)", body = cloacina_api_types::ErrorBody),
         (status = 500, description = "Internal error", body = cloacina_api_types::ErrorBody),
     ),
     security(("api_key" = []))

--- a/docs/static/openapi.json
+++ b/docs/static/openapi.json
@@ -3402,6 +3402,16 @@
               }
             }
           },
+          "404": {
+            "description": "Workflow not registered for this tenant (I-0138 cross-tenant gate; `public` is exempt)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            }
+          },
           "500": {
             "description": "Internal error",
             "content": {

--- a/ui/e2e/fleet.spec.ts
+++ b/ui/e2e/fleet.spec.ts
@@ -33,8 +33,10 @@ test("tenant-admin scales the agent fleet up then down @smoke", async ({ page })
   // Fleet view → the stats + admin controls are visible.
   await page.goto("/fleet");
   await expect(page.getByRole("heading", { name: "Agent fleet" })).toBeVisible();
-  await expect(page.getByText("Provisioned")).toBeVisible();
-  await expect(page.getByText("Running")).toBeVisible();
+  // exact: the "Provisioned vs running agents" chart subtitle also matches
+  // these as substrings (getByText is case-insensitive substring by default).
+  await expect(page.getByText("Provisioned", { exact: true })).toBeVisible();
+  await expect(page.getByText("Running", { exact: true })).toBeVisible();
   await expect(page.getByText("Effective limit")).toBeVisible();
 
   const provision = page.getByRole("button", { name: "Provision +1" });


### PR DESCRIPTION
With the static coverage gate and the ui-e2e build fixed (#198), the live SDK suites and the full Playwright suite ran for the first time since July 8 (nightly run [30171161101](https://github.com/colliery-io/cloacina/actions/runs/30171161101)) and surfaced two drifts that had accumulated behind the mask:

## 1. Execute-unknown-workflow contract drift

I-0138 (T-0901, #193) made `POST /v1/tenants/{t}/workflows/{name}/execute` fail closed with **404 `workflow_not_found`** for non-`public` tenants (the cross-tenant isolation gate), but the utoipa annotation and all three SDK contract suites still documented/expected 400. This PR:

- adds the 404 response to the execute endpoint's utoipa annotation
- regenerates the committed OpenAPI doc (`emit-openapi`; the only spec delta is the new 404 block)
- regenerates the TS generated types and the Python generated execute module
- updates the Rust/TS/Python contract-suite expectations to `404 workflow_not_found`

## 2. fleet.spec.ts locator ambiguity

The fleet page's new "Provisioned vs running agents" chart subtitle also matches `getByText("Provisioned")` and `getByText("Running")` (Playwright string matching is case-insensitive substring), tripping a strict-mode violation. Pinned both locators with `exact: true`.

## Not addressed here

`test_scenario_25_async_task_support.py` segfaulted (native crash in the cloaca binding during pytest setup) in the same nightly run but passed on identical code in the PR gate hours earlier — a pre-existing intermittent crash worth its own investigation/issue.

## Verification

Local: SDK coverage rule (55 ops × 3 SDKs), version lockstep, TS `check:generated` + typecheck + build, Rust client tests compile + `cargo fmt --check`, Python syntax — all green. The live proof is the next nightly run after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015sZK7ZM4E2XLdrkNXpXAs3

---
_Generated by [Claude Code](https://claude.ai/code/session_015sZK7ZM4E2XLdrkNXpXAs3)_