### PR TITLE
fix(ui-e2e): pin the remaining ambiguous fleet.spec.ts locator

### DIFF
--- a/ui/e2e/fleet.spec.ts
+++ b/ui/e2e/fleet.spec.ts
@@ -33,11 +33,12 @@ test("tenant-admin scales the agent fleet up then down @smoke", async ({ page })
   // Fleet view → the stats + admin controls are visible.
   await page.goto("/fleet");
   await expect(page.getByRole("heading", { name: "Agent fleet" })).toBeVisible();
-  // exact: the "Provisioned vs running agents" chart subtitle also matches
-  // these as substrings (getByText is case-insensitive substring by default).
+  // exact: the "Provisioned vs running agents" subtitle and the
+  // "Effective limit N = …" breakdown line also match these as substrings
+  // (getByText is case-insensitive substring by default).
   await expect(page.getByText("Provisioned", { exact: true })).toBeVisible();
   await expect(page.getByText("Running", { exact: true })).toBeVisible();
-  await expect(page.getByText("Effective limit")).toBeVisible();
+  await expect(page.getByText("Effective limit", { exact: true })).toBeVisible();
 
   const provision = page.getByRole("button", { name: "Provision +1" });
   const deprovision = page.getByRole("button", { name: "Deprovision −1" });


### PR DESCRIPTION
Last night's scheduled nightly ([30189969168](https://github.com/colliery-io/cloacina/actions/runs/30189969168)) showed the #199 `exact: true` fix worked — `fleet.spec.ts` advanced past "Provisioned"/"Running" — and then hit the identical strict-mode violation one line later: `getByText("Effective limit")` also matches the page's "Effective limit N = …" breakdown line as a substring, alongside the exact stat label.

Pinned it with `exact: true` like its siblings, and audited the rest of the spec — this is the last bare-text locator; the button assertions use full role-name matching and are unambiguous. The Playwright suite was otherwise 19/20 green, so this should complete the ui-e2e lane.

Not addressed here (pre-existing, unrelated to this branch): the sqlite Python-binding lanes failed intermittently in the same run — `scenario_16_registry_management` assertion flake (passed on postgres in the same run) and CLOACI-T-0622 hang-retries in the Feature Build (sqlite-only) job. Three different intermittent native-binding failures across two nights suggest that family deserves its own issue/investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015sZK7ZM4E2XLdrkNXpXAs3

---
_Generated by [Claude Code](https://claude.ai/code/session_015sZK7ZM4E2XLdrkNXpXAs3)_