### PR TITLE
fix(I-0140): round 2 — retry branch and executor error paths had the same swallowed-write hole

### DIFF
--- a/.metis/initiatives/CLOACI-I-0140/initiative.md
+++ b/.metis/initiatives/CLOACI-I-0140/initiative.md
@@ -177,6 +177,18 @@ Environment notes: failures concentrate in the **sqlite** lanes (both ubuntu and
 
 Rebuilt the wheel with the `retry_transient` fix (sqlite,macros lane) and ran the stress harness 500 iterations on scenario 30 with CI-parity flags: **`outcomes={'ok': 500}`** — zero hangs, zero assertion failures, zero signals. Against the measured 1-in-~25 baseline that's ~p 1e-9 of the fix being a no-op. Remaining: land the fix (branch `fix/i0140-terminal-state-writes`), let nightly soak, then shrink `KNOWN_FLAKY_HANG` and confirm the segfault class died with the hang class.
 
+### 2026-07-27 — Round 2: the retry branch had the same hole (nightly caught it)
+
+PR #201 squash-merged; manual nightly dispatched. **Audit of the job logs before shrinking the allowlist** (user's prompt — right call): 3 of 4 integration legs passed scenarios 30/32/33 outright, but **sqlite/ubuntu scenario 33 (retry_condition) hung 180s on attempt 1** and was rescued by the harness retry loop. Green-by-rescue, not green.
+
+Residual mechanism — same swallowed-terminal-write shape, in the branch round 1 didn't touch:
+- `result_handler.rs` retry branch: `schedule_task_retry` failure was warn-and-dropped → task Running forever. (`should_retry_task` is pure — its `unwrap_or(false)` is inert.)
+- `thread_task_executor.rs`: three more `let _ = mark_failed(...)` sites (invalid namespace / task not found / context build failed).
+
+Round-2 fix: `retry_transient` around `schedule_task_retry` with a **fail-instead-of-limbo fallback** (if scheduling still fails after retries: mark_failed + return failure — never leave the row Running); `mark_failed_reliably` helper in thread_task_executor for the three swallowed sites; `retry_transient`/`is_transient_db_error` now `pub(crate)`. Swept executor/scheduler/dispatcher for remaining `let _ =` DB writes — none left (rest are channel sends/gauges).
+
+Verification: 300-iter local stress on scenario 33 in flight (regression check — the 33 hang was only ever seen on ubuntu; macOS never repro'd it pre-fix, so the linux nightly is the real arbiter). Lesson: when a mechanism is confirmed, audit EVERY error path owning that state transition in one sweep — not just the site the stack trace names.
+
 ## UI/UX Design **[CONDITIONAL: Frontend Initiative]**
 
 {Delete if no UI components}

--- a/crates/cloacina/src/executor/result_handler.rs
+++ b/crates/cloacina/src/executor/result_handler.rs
@@ -42,7 +42,7 @@ use tracing::{debug, error, info, warn};
 /// `mark_failed` left the task Running FOREVER, which is the reproduced
 /// scenario-flake HANG (the workflow future never resolves, the Python
 /// `execute()` blocks on its oneshot, pytest-timeout is silenced).
-fn is_transient_db_error(msg: &str) -> bool {
+pub(crate) fn is_transient_db_error(msg: &str) -> bool {
     let m = msg.to_ascii_lowercase();
     m.contains("database is locked")
         || m.contains("database table is locked")
@@ -53,7 +53,7 @@ fn is_transient_db_error(msg: &str) -> bool {
 /// Retry an async DB write on transient contention errors: `attempts` tries,
 /// linear backoff (`base_delay * attempt`). Non-transient errors return
 /// immediately; exhaustion returns the last error.
-async fn retry_transient<T, E, F, Fut>(
+pub(crate) async fn retry_transient<T, E, F, Fut>(
     attempts: u32,
     base_delay: Duration,
     mut op: F,
@@ -197,15 +197,57 @@ impl TaskResultHandler {
                     .unwrap_or(false);
 
                 if should_retry {
-                    if let Err(e) = self.schedule_task_retry(claimed_task, retry_policy).await {
-                        warn!(
-                            task_id = %event.task_execution_id,
-                            error = %e,
-                            "Failed to schedule retry"
-                        );
+                    // CLOACI-I-0140: schedule_retry is a terminal state write too —
+                    // dropping it on sqlite-busy left the task Running forever (the
+                    // scenario-33 hang the first fix round missed). Retry it, and if
+                    // it STILL fails, fail the task rather than leave it in limbo.
+                    match retry_transient(5, Duration::from_millis(100), || {
+                        self.schedule_task_retry(claimed_task, retry_policy)
+                    })
+                    .await
+                    {
+                        Ok(()) => {
+                            self.total_executed.fetch_add(1, Ordering::SeqCst);
+                            ExecutionResult::retry(
+                                event.task_execution_id,
+                                error.to_string(),
+                                duration,
+                            )
+                        }
+                        Err(sched_err) => {
+                            warn!(
+                                task_id = %event.task_execution_id,
+                                error = %sched_err,
+                                "Failed to schedule retry after retries — failing task \
+                                 instead of leaving it Running"
+                            );
+                            self.total_failed.fetch_add(1, Ordering::SeqCst);
+                            let error_str =
+                                format!("{} (retry scheduling failed: {})", error, sched_err);
+                            if let Err(mark_err) =
+                                retry_transient(5, Duration::from_millis(100), || async {
+                                    self.dal
+                                        .task_execution()
+                                        .mark_failed(
+                                            event.task_execution_id,
+                                            &error_str,
+                                            self.runner_id,
+                                        )
+                                        .await
+                                })
+                                .await
+                            {
+                                error!(
+                                    task_id = %event.task_execution_id,
+                                    error = %mark_err,
+                                    "mark_failed FAILED after retries — task row stays Running \
+                                     until the stale-claim sweeper recovers it; workflow \
+                                     completion is delayed"
+                                );
+                            }
+                            ExecutionResult::failure(event.task_execution_id, error_str, duration)
+                        }
                     }
-                    self.total_executed.fetch_add(1, Ordering::SeqCst);
-                    ExecutionResult::retry(event.task_execution_id, error.to_string(), duration)
                 } else {
                     self.total_failed.fetch_add(1, Ordering::SeqCst);
                     // Mark failed in DB — executor owns all state transitions.

--- a/crates/cloacina/src/executor/thread_task_executor.rs
+++ b/crates/cloacina/src/executor/thread_task_executor.rs
@@ -128,6 +128,36 @@ pub struct ThreadTaskExecutor {
 }
 
 impl ThreadTaskExecutor {
+    /// CLOACI-I-0140: terminal state writes must never be silently dropped — a
+    /// lost `mark_failed` leaves the task row Running forever and hangs the
+    /// workflow. Retries transient DB contention; screams on exhaustion.
+    async fn mark_failed_reliably(
+        &self,
+        task_execution_id: UniversalUuid,
+        error_msg: &str,
+        runner_id: Option<UniversalUuid>,
+    ) {
+        let result = super::result_handler::retry_transient(
+            5,
+            std::time::Duration::from_millis(100),
+            || async {
+                self.dal
+                    .task_execution()
+                    .mark_failed(task_execution_id, error_msg, runner_id)
+                    .await
+            },
+        )
+        .await;
+        if let Err(e) = result {
+            tracing::error!(
+                task_id = %task_execution_id,
+                error = %e,
+                "mark_failed FAILED after retries — task row stays Running until \
+                 the stale-claim sweeper recovers it; workflow completion is delayed"
+            );
+        }
+    }
+
     /// Creates a new ThreadTaskExecutor instance.
     ///
     /// # Arguments
@@ -516,10 +546,7 @@ impl TaskExecutor for ThreadTaskExecutor {
             Err(e) => {
                 self.total_failed.fetch_add(1, Ordering::SeqCst);
                 let error_msg = format!("Invalid namespace: {}", e);
-                let _ = self
-                    .dal
-                    .task_execution()
-                    .mark_failed(event.task_execution_id, &error_msg, claim_runner_id)
+                self.mark_failed_reliably(event.task_execution_id, &error_msg, claim_runner_id)
                     .await;
                 return Ok(ExecutionResult::failure(
                     event.task_execution_id,
@@ -534,10 +561,7 @@ impl TaskExecutor for ThreadTaskExecutor {
             None => {
                 self.total_failed.fetch_add(1, Ordering::SeqCst);
                 let error_msg = format!("Task not found: {}", claimed_task.task_name);
-                let _ = self
-                    .dal
-                    .task_execution()
-                    .mark_failed(event.task_execution_id, &error_msg, claim_runner_id)
+                self.mark_failed_reliably(event.task_execution_id, &error_msg, claim_runner_id)
                     .await;
                 return Ok(ExecutionResult::failure(
                     event.task_execution_id,
@@ -554,10 +578,7 @@ impl TaskExecutor for ThreadTaskExecutor {
             Err(e) => {
                 self.total_failed.fetch_add(1, Ordering::SeqCst);
                 let error_msg = format!("Context build failed: {}", e);
-                let _ = self
-                    .dal
-                    .task_execution()
-                    .mark_failed(event.task_execution_id, &error_msg, claim_runner_id)
+                self.mark_failed_reliably(event.task_execution_id, &error_msg, claim_runner_id)
                     .await;
                 return Ok(ExecutionResult::failure(
                     event.task_execution_id,


### PR DESCRIPTION
## Why a round 2

The first unpreempted nightly after #201 came back green — but a job-log audit before shrinking the flaky allowlist showed **sqlite/ubuntu scenario 33 (retry_condition) hung 180s on attempt 1** and was rescued by the harness retry loop. Green-by-rescue, not fixed. Same lost-terminal-state mechanism as #201, in the paths that round didn't touch — and scenario 33 surviving is the tell: it's the one test that hammers retry scheduling.

## The holes

1. **`result_handler.rs` retry branch** — a failed `schedule_task_retry` was warn-and-dropped → task row stays `Running` forever → workflow never terminal → the same hang. Now retried via `retry_transient`, with a **fail-instead-of-limbo fallback**: if scheduling still fails after retries, the task is marked failed and a failure result returned — a visible failure beats an invisible hang. (`should_retry_task` was audited too: it's pure, its `unwrap_or(false)` is inert.)
2. **`thread_task_executor.rs`** — three swallowed `let _ = mark_failed(...)` sites (invalid namespace / task not found / context build failed), now routed through a `mark_failed_reliably` helper (retry + loud `error!` on exhaustion).
3. Swept executor/scheduler/dispatcher for any remaining discarded DB writes: **none left** (the rest are channel sends and in-memory inserts).

## Verification

- 300-iteration local stress on scenario 33 (sqlite, CI-parity flags) running at time of PR — will report on this thread. Caveat for honesty: the 33 hang was only ever observed on ubuntu; the linux nightly is the true arbiter.
- After this lands and a nightly passes **without any harness rescues** (verified by log audit, not job color), the follow-up is shrinking `KNOWN_FLAKY_HANG` so regressions can't hide.