### PR TITLE
fix(I-0140): round 3 — retry transient DB contention at the workflow scheduling entry

### DIFF
--- a/.metis/initiatives/CLOACI-I-0140/initiative.md
+++ b/.metis/initiatives/CLOACI-I-0140/initiative.md
@@ -189,6 +189,16 @@ Round-2 fix: `retry_transient` around `schedule_task_retry` with a **fail-instea
 
 Verification: 300-iter local stress on scenario 33 in flight (regression check — the 33 hang was only ever seen on ubuntu; macOS never repro'd it pre-fix, so the linux nightly is the real arbiter). Lesson: when a mechanism is confirmed, audit EVERY error path owning that state transition in one sweep — not just the site the stack trace names.
 
+### 2026-07-27 — Round 3: the scheduling ENTRY had the same exposure (nightly caught it again)
+
+Round-2 verified locally (scenario 33: **300/300 clean**, ~1.2s/iter vs ~3s pre-fix — retry scheduling visibly healthier), PR #202 squash-merged. Ops footnote: the post-merge nightly initially wedged — the `cloacina-tests-refs/heads/main` concurrency group jammed after the preemption dance (push CI queued 35+ min, runners available, GitHub all-operational); cancelling every run touching the group cleared it. If main CI ever sits queued mysteriously: look for a half-dead run holding `cloacina-tests`.
+
+The round-2 nightly's sqlite/ubuntu leg then failed BEFORE reaching the Python scenarios — in the RUST integration suite: `secret_no_leak`, `execute_async` → `schedule_workflow_execution` → `database table is locked: task_executions` (SQLITE_LOCKED, shared-cache class — busy_timeout does NOT cover it; same family as the July 15 unit-test flake). The disease at the ENTRY write, not the terminal write.
+
+Round-3 fix (`runner/default_runner/workflow_executor_impl.rs`): `retry_transient` around both `schedule_workflow_execution` call sites (execute / execute_async; context re-supplied via `clone_data()` per attempt), the `execute` status-poll read, and `get_execution_status` (backs every `wait_for_completion` loop). The failing test passes locally with the fix.
+
+Running tally of one mechanism, N surfaces: terminal writes (round 1) → retry scheduling + executor error paths (round 2) → workflow scheduling entry + status reads (round 3). The class is "any unretried DB access on the execution path, surfaced wherever a test unwraps or a state machine stalls."
+
 ## UI/UX Design **[CONDITIONAL: Frontend Initiative]**
 
 {Delete if no UI components}

--- a/crates/cloacina/src/runner/default_runner/workflow_executor_impl.rs
+++ b/crates/cloacina/src/runner/default_runner/workflow_executor_impl.rs
@@ -24,6 +24,7 @@ use std::time::Duration;
 use uuid::Uuid;
 
 use crate::dal::DAL;
+use crate::executor::result_handler::retry_transient;
 use crate::executor::workflow_executor::{
     WorkflowExecution, WorkflowExecutionError, WorkflowExecutionResult, WorkflowExecutor,
     WorkflowStatus,
@@ -57,14 +58,17 @@ impl WorkflowExecutor for DefaultRunner {
         workflow_name: &str,
         context: Context<serde_json::Value>,
     ) -> Result<WorkflowExecutionResult, WorkflowExecutionError> {
-        // Schedule execution
-        let execution_id = self
-            .scheduler
-            .schedule_workflow_execution(workflow_name, context)
-            .await
-            .map_err(|e| WorkflowExecutionError::ExecutionFailed {
-                message: format!("Failed to schedule workflow: {}", e),
-            })?;
+        // Schedule execution. CLOACI-I-0140: the entry write (execution +
+        // task_executions rows) is retried on transient sqlite busy/locked —
+        // same contention class as the executor's terminal-state writes.
+        let execution_id = retry_transient(5, Duration::from_millis(100), || {
+            self.scheduler
+                .schedule_workflow_execution(workflow_name, context.clone_data())
+        })
+        .await
+        .map_err(|e| WorkflowExecutionError::ExecutionFailed {
+            message: format!("Failed to schedule workflow: {}", e),
+        })?;
 
         // Wait for completion
         let start_time = std::time::Instant::now();
@@ -80,14 +84,17 @@ impl WorkflowExecutor for DefaultRunner {
                 }
             }
 
-            // Check status
-            let execution = dal
-                .workflow_execution()
-                .get_by_id(UniversalUuid(execution_id))
-                .await
-                .map_err(|e| WorkflowExecutionError::ExecutionFailed {
-                    message: format!("Failed to check execution status: {}", e),
-                })?;
+            // Check status — retried on transient DB contention so a single
+            // sqlite-busy read doesn't abort a wait that would have succeeded.
+            let execution = retry_transient(5, Duration::from_millis(100), || async {
+                dal.workflow_execution()
+                    .get_by_id(UniversalUuid(execution_id))
+                    .await
+            })
+            .await
+            .map_err(|e| WorkflowExecutionError::ExecutionFailed {
+                message: format!("Failed to check execution status: {}", e),
+            })?;
 
             match execution.status.as_str() {
                 "Completed" | "Failed" => {
@@ -116,14 +123,15 @@ impl WorkflowExecutor for DefaultRunner {
         workflow_name: &str,
         context: Context<serde_json::Value>,
     ) -> Result<WorkflowExecution, WorkflowExecutionError> {
-        // Schedule execution
-        let execution_id = self
-            .scheduler
-            .schedule_workflow_execution(workflow_name, context)
-            .await
-            .map_err(|e| WorkflowExecutionError::ExecutionFailed {
-                message: format!("Failed to schedule workflow: {}", e),
-            })?;
+        // Schedule execution — retried on transient DB contention (see execute).
+        let execution_id = retry_transient(5, Duration::from_millis(100), || {
+            self.scheduler
+                .schedule_workflow_execution(workflow_name, context.clone_data())
+        })
+        .await
+        .map_err(|e| WorkflowExecutionError::ExecutionFailed {
+            message: format!("Failed to schedule workflow: {}", e),
+        })?;
 
         Ok(WorkflowExecution::new(
             execution_id,
@@ -186,13 +194,17 @@ impl WorkflowExecutor for DefaultRunner {
         execution_id: Uuid,
     ) -> Result<WorkflowStatus, WorkflowExecutionError> {
         let dal = DAL::new(self.database.clone());
-        let execution = dal
-            .workflow_execution()
-            .get_by_id(UniversalUuid(execution_id))
-            .await
-            .map_err(|e| WorkflowExecutionError::ExecutionFailed {
-                message: format!("Failed to get execution status: {}", e),
-            })?;
+        // Retried on transient DB contention — this read backs every
+        // wait_for_completion poll loop (CLOACI-I-0140).
+        let execution = retry_transient(5, Duration::from_millis(100), || async {
+            dal.workflow_execution()
+                .get_by_id(UniversalUuid(execution_id))
+                .await
+        })
+        .await
+        .map_err(|e| WorkflowExecutionError::ExecutionFailed {
+            message: format!("Failed to get execution status: {}", e),
+        })?;
 
         // Fallible parse (COR-18). Unknown strings surface as typed
         // error rather than silently coercing to Failed.


### PR DESCRIPTION
## What the round-2 nightly caught

Not the scenario flake — the same disease at a **third surface**. The sqlite/ubuntu integration leg failed in the **Rust** suite before Python scenarios even ran: `secret_no_leak` died on `execute_async` → `schedule_workflow_execution` → `database table is locked: task_executions`. That's **SQLITE_LOCKED** (shared-cache table lock — `busy_timeout` does not cover it), on the workflow **entry** write, a path rounds 1–2 didn't touch. Same family as the July 15 unit-test flake, so it predates the recent changes — the nightly just keeps flushing out members of the class.

## The fix

`retry_transient` (same 5-attempt/backoff policy, transient-only match) around:
- both `schedule_workflow_execution` call sites (`execute` / `execute_async`; the input context is re-supplied via `clone_data()` per attempt),
- the `execute` status-poll read,
- `get_execution_status` — the read backing every `wait_for_completion` loop — so one transient locked read can't abort a wait that would have succeeded.

## Verification

- The exact failing test (`secret_no_leak…sqlite`) passes locally with the fix.
- Running tally of one mechanism, N surfaces: terminal writes (#201) → retry scheduling + executor error paths (#202) → scheduling entry + status reads (this PR).
- The round-2 nightly's sqlite/ubuntu leg never reached its Python scenarios (it died in the Rust stage), so the scenario-33-on-linux verdict comes from the next nightly after this lands. `KNOWN_FLAKY_HANG` shrink stays gated on that audit coming back with zero rescues.