### PR TITLE
fix(I-0140): round 4 — structurally derisk interpreter-teardown races (segfault class)

### DIFF
--- a/.angreal/gil_stress.py
+++ b/.angreal/gil_stress.py
@@ -130,6 +130,19 @@ def main() -> int:
         log = art_dir / f"iter{i:04d}-{kind}.log"
         out = out or ""
         err = err or ""
+        # On a native crash, harvest the macOS crash report (.ips) — it carries
+        # the full native stacks of every thread, symbolized (CLOACI-I-0140
+        # segfault-class hunt).
+        if kind.startswith("signal"):
+            time.sleep(3)  # ReportCrash needs a beat to write the file
+            reports = sorted(
+                Path.home().glob("Library/Logs/DiagnosticReports/[Pp]ython*.ips"),
+                key=lambda p: p.stat().st_mtime,
+                reverse=True,
+            )
+            if reports and time.time() - reports[0].stat().st_mtime < 60:
+                err += f"\n--- CRASH REPORT ({reports[0].name}) ---\n"
+                err += reports[0].read_text(errors="replace")
         log.write_text(
             f"# {scenario.name} iter {i} -> {kind} after {dt:.1f}s\n\n"
             f"--- STDOUT ---\n{out}\n--- STDERR ---\n{err}\n"

--- a/.metis/initiatives/CLOACI-I-0140/initiative.md
+++ b/.metis/initiatives/CLOACI-I-0140/initiative.md
@@ -199,6 +199,22 @@ Round-3 fix (`runner/default_runner/workflow_executor_impl.rs`): `retry_transien
 
 Running tally of one mechanism, N surfaces: terminal writes (round 1) → retry scheduling + executor error paths (round 2) → workflow scheduling entry + status reads (round 3). The class is "any unretried DB access on the execution path, surfaced wherever a test unwraps or a state machine stalls."
 
+### 2026-07-28 — Segfault class: hunt results + structural derisk (round 4)
+
+**Hunt results:** the segfault class does NOT reproduce locally — 400/400 clean on macOS/postgres (scenario 16) and 400/400 clean on arm64-linux/postgres in docker (scenarios 27+16, unstripped wheel, gdb armed). Two CI kills in two days meanwhile (scenario 16, then 27 — postgres/ubuntu both). Remaining differentiators: x86_64 and GitHub's 2-core runner timing. CI evidence pins the crash *site*: faulthandler shows the main thread inside pytest's `collect_unraisable` — a finalizer raised, and processing the exception touched freed memory → refcount corruption/UAF from the extension during teardown (audit B2 shape). The nightly's gdb core capture is useless today (stripped wheel + gdb loads the wrong binary + it catches the signal re-raise frame).
+
+**Decision (user): derisk the teardown race structurally instead of chasing an environment-specific repro.**
+
+**Round-4 changes (branch fix/i0140-teardown-derisk):**
+1. `_shutdown_all_runners` atexit backstop — every live runtime registers in a global `LIVE_RUNNERS` (Weak refs); the wheel's pymodule init registers an atexit hook joining ALL runtime threads before interpreter finalization begins. Invariant: no runtime thread outlives the interpreter; no PyObject decref into a finalizing interpreter. Forgetting `runner.shutdown()` is now SAFE — a product fix, not a test fix.
+2. `AsyncRuntimeHandle::drop` guards: no-op (zero GIL) when already joined; after `ATEXIT_FIRED`, degrades to a best-effort shutdown signal WITHOUT join/GIL — leak-on-exit is strictly safer than a decref into a dying interpreter.
+3. conftest.py: removed the SIGALRM abandon-on-timeout machinery — it interrupted `shutdown()` mid-join and left runtime threads alive going into finalization (a live instance of the exact race; predates the I-0140 shutdown fixes).
+4. gil_stress.py: harvests macOS `.ips` crash reports on signal exits.
+
+**Verified:** leak test (create runner, exit WITHOUT shutdown) → atexit fires, "Received shutdown signal" logged, clean rc 0. Scenarios 30+16 smoke-pass on the new wheel.
+
+**Still open for the segfault class:** CI symbolization fix (unstripped nightly test wheel + gdb pointed at the python binary) so any post-derisk kill self-documents.
+
 ## UI/UX Design **[CONDITIONAL: Frontend Initiative]**
 
 {Delete if no UI components}

--- a/crates/cloacina-python/src/bindings/runner.rs
+++ b/crates/cloacina-python/src/bindings/runner.rs
@@ -195,6 +195,40 @@ struct AsyncRuntimeHandle {
     thread_handle: Option<thread::JoinHandle<()>>,
 }
 
+/// CLOACI-I-0140 (segfault class): every live runtime is registered here so the
+/// module's `atexit` hook can join ALL runtime threads BEFORE interpreter
+/// finalization begins. The invariant this enforces: no runtime thread may
+/// outlive the interpreter, and no `PyObject` may be dropped after finalization
+/// starts — the teardown race behind the rotating CI segfaults.
+static LIVE_RUNNERS: Mutex<Vec<std::sync::Weak<Mutex<AsyncRuntimeHandle>>>> =
+    Mutex::new(Vec::new());
+
+/// Set once the atexit hook has drained `LIVE_RUNNERS`. Any `Drop` that fires
+/// after this point is running during interpreter exit: acquiring the GIL or
+/// joining a thread that might need it is unsafe, so Drop degrades to a
+/// best-effort shutdown signal without a join.
+static ATEXIT_FIRED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// Shut down every still-live runner. Registered with Python's `atexit` by the
+/// wheel's `#[pymodule]` init; also callable directly (idempotent — shutdown of
+/// an already-joined handle is a no-op).
+#[pyfunction]
+pub fn _shutdown_all_runners(py: Python) -> PyResult<()> {
+    let handles: Vec<_> = {
+        let mut reg = LIVE_RUNNERS.lock().unwrap();
+        reg.drain(..).filter_map(|w| w.upgrade()).collect()
+    };
+    py.allow_threads(|| {
+        for h in &handles {
+            if let Err(e) = h.lock().unwrap().shutdown() {
+                warn!("atexit runner shutdown reported: {}", e);
+            }
+        }
+    });
+    ATEXIT_FIRED.store(true, std::sync::atomic::Ordering::SeqCst);
+    Ok(())
+}
+
 impl AsyncRuntimeHandle {
     /// Shutdown the runtime thread and wait for it to complete
     fn shutdown(&mut self) -> Result<(), ShutdownError> {
@@ -249,6 +283,20 @@ impl AsyncRuntimeHandle {
 
 impl Drop for AsyncRuntimeHandle {
     fn drop(&mut self) {
+        // Already joined (explicit shutdown() or the atexit hook) — nothing to
+        // do, and crucially NO GIL acquisition on this path.
+        if self.thread_handle.is_none() {
+            return;
+        }
+        // CLOACI-I-0140 (segfault class): after the atexit hook has fired the
+        // interpreter is exiting — acquiring the GIL or joining a thread that
+        // may need it is unsafe. Degrade to a best-effort shutdown signal and
+        // deliberately leak the join; the process is dying anyway and a leaked
+        // thread is strictly safer than a decref into a finalizing interpreter.
+        if ATEXIT_FIRED.load(std::sync::atomic::Ordering::SeqCst) {
+            let _ = self.tx.send(RuntimeMessage::Shutdown);
+            return;
+        }
         // CLOACI-I-0140 (B1): when Python GC drops PyDefaultRunner this Drop
         // runs WITH THE GIL HELD, and shutdown() joins the runtime thread —
         // whose in-flight work (task callbacks, deferred decrefs) may need the
@@ -844,11 +892,19 @@ where
         }
     }
 
+    let handle = Arc::new(Mutex::new(AsyncRuntimeHandle {
+        tx,
+        thread_handle: Some(thread_handle),
+    }));
+    // CLOACI-I-0140: register for the atexit drain (prune dead entries while
+    // holding the lock so the registry can't grow unboundedly).
+    {
+        let mut reg = LIVE_RUNNERS.lock().unwrap();
+        reg.retain(|w| w.strong_count() > 0);
+        reg.push(Arc::downgrade(&handle));
+    }
     Ok(PyDefaultRunner {
-        runtime_handle: Mutex::new(AsyncRuntimeHandle {
-            tx,
-            thread_handle: Some(thread_handle),
-        }),
+        runtime_handle: handle,
     })
 }
 
@@ -859,7 +915,7 @@ where
 /// Python wrapper for DefaultRunner
 #[pyclass(name = "DefaultRunner")]
 pub struct PyDefaultRunner {
-    runtime_handle: Mutex<AsyncRuntimeHandle>,
+    runtime_handle: Arc<Mutex<AsyncRuntimeHandle>>,
 }
 
 /// Internal (non-Python) helpers.

--- a/crates/cloacina-python/src/lib.rs
+++ b/crates/cloacina-python/src/lib.rs
@@ -208,6 +208,17 @@ fn cloaca(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<bindings::runner::PyWorkflowResult>()?;
     m.add_class::<bindings::context::PyDefaultRunnerConfig>()?;
 
+    // CLOACI-I-0140 (segfault class): join ALL runtime threads via atexit,
+    // BEFORE interpreter finalization begins. This is the structural guarantee
+    // that no runtime thread can decref a PyObject into a finalizing
+    // interpreter — a user forgetting `runner.shutdown()` is now safe.
+    m.add_function(wrap_pyfunction!(
+        bindings::runner::_shutdown_all_runners,
+        m
+    )?)?;
+    let atexit = m.py().import("atexit")?;
+    atexit.call_method1("register", (m.getattr("_shutdown_all_runners")?,))?;
+
     #[cfg(feature = "postgres")]
     {
         m.add_class::<bindings::admin::PyDatabaseAdmin>()?;

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -67,26 +67,20 @@ def shared_runner():
 
     yield _shared_runner
 
-    # Cleanup at session end
+    # Cleanup at session end.
+    #
+    # CLOACI-I-0140: the old SIGALRM machinery here interrupted shutdown()
+    # mid-join and ABANDONED it on timeout — leaving runtime threads alive
+    # while the interpreter proceeded into finalization, which is the exact
+    # teardown race behind the rotating CI segfaults. Shutdown is reliable
+    # now (the runner also registers an atexit backstop that joins every
+    # runtime thread before finalization), so: plain shutdown, no alarm,
+    # never abandon a live runner.
     if _shared_runner is not None:
         print("DEBUG: Shutting down shared runner at session end")
         try:
-            # Set a timeout for shutdown
-            def timeout_handler(signum, frame):
-                print("WARNING: Shared runner shutdown timed out")
-                raise TimeoutError("Shutdown timeout")
-
-            signal.signal(signal.SIGALRM, timeout_handler)
-            signal.alarm(10)  # 10 second timeout
-
-            try:
-                _shared_runner.shutdown()
-                signal.alarm(0)  # Cancel timeout
-                print("DEBUG: Shared runner shutdown completed")
-            except TimeoutError:
-                print("WARNING: Forced shutdown due to timeout")
-                signal.alarm(0)
-
+            _shared_runner.shutdown()
+            print("DEBUG: Shared runner shutdown completed")
         except Exception as e:
             print(f"WARNING: Error during shared runner shutdown: {e}")
 


### PR DESCRIPTION
## The segfault class, and why we stopped chasing it

The rotating `Fatal Python error: Segmentation fault` (two postgres/ubuntu CI kills in two days — scenarios 16 and 27) refused to reproduce locally: **400/400 clean on macOS/postgres and 400/400 clean on arm64-linux docker** with an unstripped wheel and gdb armed. Remaining differentiators are x86_64 and GitHub's 2-core runner timing — a poor ROI chase.

What CI evidence does pin down: faulthandler shows the crash landing while pytest processes an *unraisable exception* (`collect_unraisable`) — a finalizer raised, and touching the exception hit freed memory. That's refcount corruption / UAF during interpreter teardown: the GIL audit's B2 finding (PyObjects held by runtime threads, decref'd into a finalizing interpreter).

So: make the race structurally impossible instead.

## The derisk

1. **atexit backstop (product fix, not test fix)** — every live runtime registers in a global `LIVE_RUNNERS` registry; the wheel's pymodule init registers `_shutdown_all_runners` with Python's `atexit`, joining ALL runtime threads **before interpreter finalization begins**. Invariant: no runtime thread outlives the interpreter; no PyObject decref into a finalizing interpreter. Forgetting `runner.shutdown()` is now safe for every user.
2. **`AsyncRuntimeHandle::drop` guards** — already-joined handles drop with zero GIL traffic; drops after `ATEXIT_FIRED` degrade to a best-effort shutdown signal with no join/GIL (leaking a thread in a dying process is strictly safer than the UAF).
3. **conftest.py** — removed the SIGALRM abandon-on-timeout shutdown, which interrupted `shutdown()` mid-join and left runtime threads alive going into finalization: a live instance of the exact race, predating the I-0140 shutdown fixes.
4. **gil_stress.py** — harvests macOS `.ips` crash reports on signal exits.

## Verification

- Leak test: create a runner, exit **without** shutdown → atexit hook fires ("Received shutdown signal"), runtime joins cleanly, rc 0.
- Scenarios 30 + 16 smoke-pass on the new wheel; 800 clean stress iterations on the pre-change hunt establish no regression baseline concern.

## Follow-up (last open I-0140 item)

CI symbolization: ship the nightly lane an unstripped test wheel and point gdb at the python binary, so any post-derisk kill self-documents instead of producing another anonymous core.