### PR TITLE
test(I-0140): empty the KNOWN_FLAKY_HANG allowlist — hangs are real regressions again

### DIFF
--- a/.angreal/test/_python_utils.py
+++ b/.angreal/test/_python_utils.py
@@ -10,18 +10,22 @@ import re
 import subprocess
 
 
-# CLOACI-T-0622: scenarios with a known *intermittent* PyO3<->tokio GIL hang on
-# the callback / CG-invocation path. When one of these times out on ALL retry
-# attempts we record it as XFAIL (logged, non-blocking) instead of failing the
-# suite — otherwise a transient infra hang blocks CI and releases. The same GIL
-# issue also surfaces as a native crash (SIGSEGV), so XFAIL covers both the hang
-# (timeout) and the crash form. A genuine pytest assertion FAILURE (rc 1, no
-# crash marker) still fails the suite, so real regressions are never masked.
-KNOWN_FLAKY_HANG = {
-    "test_scenario_30_task_callbacks.py",
-    "test_scenario_32_task_invokes_computation_graph.py",
-    "test_scenario_33_retry_condition.py",
-}
+# CLOACI-I-0140: EMPTY by design — keep it that way.
+#
+# This allowlist (born as T-0622) once xfail'd scenarios 30/32/33 for an
+# "intermittent PyO3<->tokio GIL hang". I-0140 root-caused the whole rotating
+# flake class: it was never the GIL — swallowed/unretried DB writes on the
+# execution path left task rows Running forever (hangs) or failed tasks that
+# succeeded (assertions), fixed in rounds 1-3 (retry_transient on every
+# terminal/entry write); the separate teardown segfault class was structurally
+# derisked in round 4 (atexit joins all runtime threads before interpreter
+# finalization). Verified: 500/500 + 300/300 + 800/800 local stress runs and a
+# fully-clean nightly with zero rescue markers across all four legs.
+#
+# A scenario hang/crash is now a REAL regression — do not re-add entries here
+# to make CI green; find the unretried write or teardown race instead (the
+# I-0140 initiative doc is the playbook, .angreal/gil_stress.py the harness).
+KNOWN_FLAKY_HANG: set = set()
 
 
 def _looks_like_crash(returncode, stdout, stderr) -> bool:


### PR DESCRIPTION
## Gate met

The user-set bar for this change was a nightly that's green because the tests **actually passed**, not because the harness rescued them. The 2026-07-28 scheduled nightly delivered it: all four integration legs (sqlite/postgres × ubuntu/macos), **29/29 scenarios each, zero rescue markers** in the logs — no timeouts, no retries, no xfails, no segfaults. That ran on the rounds-1–3 fixes (#201/#202/#203), with the round-4 teardown derisk (#204) merged on top since.

## The change

`KNOWN_FLAKY_HANG` (born as T-0622, xfail'ing scenarios 30/32/33) is now an **empty set, by design**. The replacement comment records the I-0140 story in place: the "intermittent PyO3↔tokio GIL hang" was never the GIL — swallowed/unretried DB writes on the execution path caused the hangs and false-failure assertions, and a separate interpreter-teardown race caused the segfaults, now structurally derisked via the atexit backstop.

From this change forward, a scenario hang or crash **fails the suite loudly**. The comment explicitly directs future maintainers to root-cause via the I-0140 playbook (initiative doc + `.angreal/gil_stress.py`) instead of re-adding allowlist entries.

The xfail machinery itself (`_looks_like_crash`, the retry loop, the marker logging) stays — it keys off the set, so it's inert while the set is empty, and the retry loop still shields CI from pure infra flakes without masking product bugs (a hang that passes on retry still prints the TIMEOUT marker we audit for).