### PR TITLE
fix(I-0140): sweeper reset — retry transient lock instead of misreading it as a CAS loss

### DIFF
--- a/crates/cloacina/src/delivery/sweeper.rs
+++ b/crates/cloacina/src/delivery/sweeper.rs
@@ -137,7 +137,18 @@ impl DeliverySweeper {
             // the envelope contract). Pending-past-threshold rows are left as-is
             // — the wake below tells the relay to re-drain.
             if row.state() == Some(DeliveryState::Delivered) {
-                match self.dal.delivery_outbox().reset_to_pending(row.id).await {
+                // CLOACI-I-0140: retry transient DB contention (sqlite
+                // busy/locked) so it isn't misread as a CAS loss — under
+                // concurrent sweepers a transient lock on BOTH meant NO ONE
+                // reset the row. A genuine CAS loss (row left `delivered`
+                // concurrently) is a different error shape and still skips.
+                match crate::executor::result_handler::retry_transient(
+                    5,
+                    std::time::Duration::from_millis(50),
+                    || async { self.dal.delivery_outbox().reset_to_pending(row.id).await },
+                )
+                .await
+                {
                     Ok(()) => reset += 1,
                     // Race with another sweeper or with an ack: row already
                     // moved out of `delivered`. Safe to ignore.


### PR DESCRIPTION
## The failure

The #206 merge's push CI failed `delivery::sweeper::tests::concurrent_sweepers_are_race_safe` on ubuntu: under the shared-cache sqlite test DB, **both** racing sweepers hit `database table is locked: delivery_outbox` on `reset_to_pending`, both logged *state changed concurrently* and skipped — so **no one** reset the row (`total == 0`, test expects exactly 1). Unrelated to #206's content (a Python-only harness change); it's another member of the I-0140 transient-contention family, and almost certainly the July 15 unit-lane flake.

Production shape of the same bug: a transient lock during a sweep is silently misread as "another sweeper won", deferring that redelivery by a full sweep interval.

## The fix

`retry_transient` (5 attempts, 50ms linear backoff) around `reset_to_pending`. The DAL already distinguishes the two outcomes — a genuine CAS loss surfaces as a `transition_result` error (0 rows affected), a transient lock as a Database error — so the retry classifier composes cleanly: lock/busy errors retry, CAS losses still take the existing debug-skip path untouched.

## Verification

- Sweeper suite: 4/4 green.
- The race test specifically: **60/60 consecutive clean runs**.

Continues the I-0140 running tally — one mechanism, N surfaces: executor terminal writes (#201) → retry scheduling + error paths (#202) → workflow scheduling entry + status reads (#203) → teardown races (#204) → allowlist emptied (#206) → delivery sweeper (this PR).