### PR TITLE
ci(I-0140): symbolized crash forensics — unstripped test wheels, right binary, venv survives failure

### DIFF
--- a/.angreal/test/integration.py
+++ b/.angreal/test/integration.py
@@ -306,6 +306,15 @@ def integration(
             raise RuntimeError(f"{failed} Python pytest scenario file(s) failed")
 
         print_final_success("All integration tests passed!")
+
+        # CLOACI-I-0140: clean the venv ONLY on success. On failure it must
+        # survive — CI's core-dump analysis step needs the (unstripped)
+        # cloaca .so inside it to symbolize backtraces; the old finally-block
+        # cleanup was exactly why every nightly segfault core came out
+        # symbol-less.
+        if py_venv is not None and venv_path.exists():
+            print(f"\nCleaning up Python test environment: {venv_name}")
+            shutil.rmtree(venv_path, ignore_errors=True)
     except subprocess.CalledProcessError as e:
         print(f"Integration tests failed with error: {e}", file=sys.stderr)
         raise RuntimeError(f"Integration tests failed with return code {e.returncode}")
@@ -313,6 +322,3 @@ def integration(
         if not skip_docker and run_postgres:
             docker_down()
             docker_clean()
-        if py_venv is not None and venv_path.exists():
-            print(f"\nCleaning up Python test environment: {venv_name}")
-            shutil.rmtree(venv_path, ignore_errors=True)

--- a/.github/workflows/cloacina.yml
+++ b/.github/workflows/cloacina.yml
@@ -231,13 +231,15 @@ jobs:
           compose-file: ".angreal/docker-compose.yaml"
 
       - name: Install debugging tools (Ubuntu)
-        if: matrix.backend == 'postgres' && matrix.os == 'ubuntu-latest'
+        # CLOACI-I-0140: all ubuntu legs, not just postgres — the segfault class
+        # historically rotated across BOTH backends' lanes.
+        if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
           sudo apt-get install -y gdb libpq-dev
 
       - name: Enable core dumps (Ubuntu)
-        if: matrix.backend == 'postgres' && matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-latest'
         run: |
           ulimit -c unlimited
           # Set core pattern to a predictable location
@@ -280,9 +282,10 @@ jobs:
             # Running under act - use host's PostgreSQL, skip docker
             ulimit -c unlimited
             setarch $(uname -m) -R angreal test integration --backend ${{ matrix.backend }} --skip-docker
-          elif [ "${{ matrix.os }}" = "ubuntu-latest" ] && [ "${{ matrix.backend }}" = "postgres" ]; then
-            # Disable ASLR to get consistent crash addresses for debugging
-            # Enable core dumps in this shell
+          elif [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
+            # Both ubuntu backends (CLOACI-I-0140): disable ASLR for consistent
+            # crash addresses; ulimit must be re-set here — the earlier step's
+            # ulimit does not persist across workflow steps.
             ulimit -c unlimited
             setarch $(uname -m) -R angreal test integration --backend ${{ matrix.backend }}
           else
@@ -290,33 +293,44 @@ jobs:
           fi
 
       - name: Analyze core dump on failure (Ubuntu)
-        if: failure() && matrix.backend == 'postgres' && matrix.os == 'ubuntu-latest'
+        if: failure() && matrix.os == 'ubuntu-latest'
         run: |
           echo "=== Checking for core dumps ==="
           ls -la /tmp/core.* 2>/dev/null || echo "No core dumps found in /tmp"
 
-          # Try to find the test binary
-          TEST_BINARY=$(find target/debug/deps -name 'integration-*' -type f -executable 2>/dev/null | head -1)
-
-          if [ -n "$TEST_BINARY" ]; then
-            echo "=== Test binary: $TEST_BINARY ==="
-
-            # Analyze any core dumps found
-            for core in /tmp/core.*; do
-              if [ -f "$core" ]; then
-                echo "=== Analyzing core dump: $core ==="
-                gdb -batch \
-                  -ex "set pagination off" \
-                  -ex "bt full" \
-                  -ex "info registers" \
-                  -ex "info threads" \
-                  -ex "thread apply all bt" \
-                  "$TEST_BINARY" "$core" 2>&1 | head -300
-              fi
-            done
-          else
-            echo "Could not find test binary for gdb analysis"
-          fi
+          # CLOACI-I-0140: cores come from DIFFERENT executables — the rust
+          # `integration-*` test binary AND the venv python running scenario
+          # tests (the rotating-segfault class). The old version hardcoded the
+          # rust binary, producing garbage backtraces for python cores. Detect
+          # the crashing executable per-core from the core file itself; the
+          # unstripped cloaca wheel (pyproject strip=false) makes the frames
+          # inside the extension resolve.
+          for core in /tmp/core.*; do
+            [ -f "$core" ] || continue
+            echo "=== Analyzing core dump: $core ==="
+            EXE=$(file "$core" | grep -oP "execfn: '\K[^']+" || true)
+            if [ -z "$EXE" ] || [ ! -f "$EXE" ]; then
+              # Fallback: %e in the core pattern is the executable basename.
+              BASE=$(basename "$core" | cut -d. -f2)
+              case "$BASE" in
+                python*) EXE=$(find "$PWD/test-env-unified/bin" -name 'python*' -type f 2>/dev/null | head -1) ;;
+                *) EXE=$(find target/debug/deps -name "${BASE}*" -type f -executable 2>/dev/null | head -1) ;;
+              esac
+            fi
+            if [ -z "$EXE" ]; then
+              echo "Could not determine executable for $core; trying rust test binary"
+              EXE=$(find target/debug/deps -name 'integration-*' -type f -executable 2>/dev/null | head -1)
+            fi
+            echo "=== Executable: ${EXE:-unknown} ==="
+            [ -n "$EXE" ] || continue
+            gdb -batch \
+              -ex "set pagination off" \
+              -ex "info sharedlibrary" \
+              -ex "thread apply all bt" \
+              -ex "bt full" \
+              -ex "info registers" \
+              "$EXE" "$core" 2>&1 | head -400
+          done
 
       - name: Report compiled workflow sizes
         if: always()

--- a/.github/workflows/unified_release.yml
+++ b/.github/workflows/unified_release.yml
@@ -195,7 +195,9 @@ jobs:
         run: pip install maturin
 
       - name: Build wheel
-        run: maturin build --release --target ${{ matrix.target }} --manifest-path crates/cloacina-python/Cargo.toml
+        # --strip: pyproject sets strip=false so dev/CI wheels keep symbols for
+        # crash forensics (CLOACI-I-0140); shipped wheels stay stripped/lean.
+        run: maturin build --release --strip --target ${{ matrix.target }} --manifest-path crates/cloacina-python/Cargo.toml
 
       - name: Upload wheel artifact
         uses: actions/upload-artifact@v4

--- a/.metis/initiatives/CLOACI-I-0140/initiative.md
+++ b/.metis/initiatives/CLOACI-I-0140/initiative.md
@@ -215,6 +215,15 @@ Running tally of one mechanism, N surfaces: terminal writes (round 1) → retry 
 
 **Still open for the segfault class:** CI symbolization fix (unstripped nightly test wheel + gdb pointed at the python binary) so any post-derisk kill self-documents.
 
+### 2026-07-28 — Rounds 5+6 landed; MILESTONE: first nightly with the allowlist EMPTY, genuinely green
+
+- **#206 (round 5):** `KNOWN_FLAKY_HANG` emptied — gate was the 2026-07-28 scheduled nightly: all four legs, 29/29 scenarios, zero rescue markers on rounds 1-3 alone. Comment block in `_python_utils.py` records the story and forbids re-allowlisting over root-causing. Machinery kept but inert (keys off the empty set; rescued infra flakes still print auditable TIMEOUT markers).
+- **#207 (round 6):** the #206 merge's push CI flushed out surface #6 — delivery sweeper: `concurrent_sweepers_are_race_safe` failed when BOTH racing sweepers hit `database table is locked: delivery_outbox` and misread the transient lock as a CAS loss → nobody reset the row (prod shape: redelivery silently deferred a sweep interval; likely the July 15 unit-lane flake). Fix: `retry_transient` around `reset_to_pending` — CAS losses are a distinct error shape and still skip. Race test 60/60 clean.
+- **MILESTONE nightly (30380037247, full stack + EMPTY allowlist):** all four integration legs 29/29, zero rescue markers, zero segfaults — the first unassisted-green nightly. All initiative goals now met: mechanism identified + fixed (6 surfaces), local repro harness built, allowlist empty, nightly genuinely green.
+- Ops noise for the record: #206's `Discover Examples` job was runner-cancelled mid-disk-cleanup and its auto-requeue wedged in `queued` limbo — cancel + fresh rerun fixed it (second wedge instance; pattern noted round 3).
+
+**Remaining before close:** CI symbolization insurance (unstripped nightly wheel + gdb at the python binary), a few scheduled-nightly soaks, then phase transitions + close-out.
+
 ## UI/UX Design **[CONDITIONAL: Frontend Initiative]**
 
 {Delete if no UI components}

--- a/crates/cloacina-python/pyproject.toml
+++ b/crates/cloacina-python/pyproject.toml
@@ -35,4 +35,8 @@ Documentation = "https://cloacina.dev"
 [tool.maturin]
 module-name = "cloaca"
 features = ["postgres", "sqlite", "macros", "extension-module"]
-strip = true
+# CLOACI-I-0140: keep the symbol table in dev/CI wheels so a native crash in a
+# test lane produces a SYMBOLIZED backtrace (the rotating-segfault hunt spent a
+# day defeated by stripped .so files). PyPI wheels are still stripped — the
+# release workflow passes maturin's `--strip` flag explicitly.
+strip = false


### PR DESCRIPTION
## Why every nightly segfault core came out as garbage

Three independent causes, each sufficient to ruin the backtrace, all fixed here:

1. **Every wheel was stripped** — `[tool.maturin] strip = true` applied to dev/CI builds too. Now pyproject sets `strip = false` (CI/dev wheels keep the symbol table; ~symbol names in frames, no DWARF bloat) and the **release workflow passes `maturin build --strip` explicitly**, so PyPI wheels ship exactly as lean as before.
2. **gdb decoded cores against the wrong binary** — the analyze step hardcoded the Rust `integration-*` test binary, but the rotating-segfault cores come from the **venv python process**. Now the crashing executable is detected per-core (`execfn` embedded in the core, `%e`-basename fallback), and `thread apply all bt` runs first so the true faulting frames beneath faulthandler's signal re-raise are visible.
3. **The `.so` was deleted before gdb ran** — the angreal integration harness `rmtree`'d the venv in a `finally:` block *even on failure*, removing `cloaca.abi3.so` before the analyze step. (This is the "the .so is cleaned before gdb runs" note from the I-0140 initiative doc, finally traced to its source.) Venv cleanup now happens **only on success**.

Also widened coverage: gdb install, core-pattern setup, and `ulimit -c` now arm on **both** ubuntu backends — the flake class historically rotated across both lanes, and the sqlite leg had never produced a core because its test step never set `ulimit` (the separate setup step's `ulimit` doesn't persist across workflow steps).

## Effect

If anything native ever kills a test lane again — despite the six fix rounds (#201–#204, #206, #207) — the nightly produces a fully symbolized all-threads backtrace naming the exact cloaca frame, instead of four anonymous addresses. This is the insurance policy that lets I-0140 close.

## Verification

- Both workflow YAMLs parse (pyyaml + yamllint pre-commit).
- `integration.py` compiles; cleanup logic moved from `finally` to the success path only (docker teardown stays in `finally`).
- Local wheels built with `strip = false` throughout the I-0140 hunt measured ~108k symbols and produced the backtraces that cracked the hang class — same recipe CI now gets.