### PR TITLE
docs(metis): close out CLOACI-I-0139 and CLOACI-I-0140

### DIFF
--- a/.metis/initiatives/CLOACI-I-0139/initiative.md
+++ b/.metis/initiatives/CLOACI-I-0139/initiative.md
@@ -4,14 +4,14 @@ level: initiative
 title: "First-party Kafka event-source provider — the flagship provider authoring story"
 short_code: "CLOACI-I-0139"
 created_at: 2026-07-15T02:15:31.122534+00:00
-updated_at: 2026-07-15T12:14:45.111644+00:00
-parent: 
+updated_at: 2026-07-28T20:14:56.277423+00:00
+parent:
 blocked_by: []
 archived: false
 
 tags:
   - "#initiative"
-  - "#phase/active"
+  - "#phase/completed"
 
 
 exit_criteria_met: false

--- a/.metis/initiatives/CLOACI-I-0140/initiative.md
+++ b/.metis/initiatives/CLOACI-I-0140/initiative.md
@@ -4,14 +4,14 @@ level: initiative
 title: "Root-cause the PyO3-tokio GIL instability — end the rotating Python scenario flake class"
 short_code: "CLOACI-I-0140"
 created_at: 2026-07-27T01:12:10.161328+00:00
-updated_at: 2026-07-27T01:12:10.161328+00:00
+updated_at: 2026-07-28T20:15:17.011269+00:00
 parent:
 blocked_by: []
 archived: false
 
 tags:
   - "#initiative"
-  - "#phase/discovery"
+  - "#phase/completed"
 
 
 exit_criteria_met: false


### PR DESCRIPTION
Metis bookkeeping only — transitions both initiatives to `completed`:

- **CLOACI-I-0139** (first-party Kafka event-source provider): all tasks landed via #194/#196, two-arch validation done.
- **CLOACI-I-0140** (rotating Python scenario flake root-cause): mechanism identified and fixed across six surfaces (#201–#204, #206–#208) — unretried DB writes on the execution path plus an interpreter-teardown race, never the GIL; `KNOWN_FLAKY_HANG` emptied; first genuinely-green nightly recorded; CI crash forensics now self-symbolizing. Full evidence trail in the initiative's Status Updates.