### PR TITLE
docs(release): date 0.10.0 — 2026-07-28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.10.0] - UNRELEASED
+## [0.10.0] - 2026-07-28
 
 ### Added
 


### PR DESCRIPTION
One-line changelog date stamp ahead of tagging v0.10.0.