### PR TITLE
ci(I-0140): core analyzer — resolve the real python ELF, not the pytest script

### DIFF
--- a/.github/workflows/cloacina.yml
+++ b/.github/workflows/cloacina.yml
@@ -305,20 +305,37 @@ jobs:
           # the crashing executable per-core from the core file itself; the
           # unstripped cloaca wheel (pyproject strip=false) makes the frames
           # inside the extension resolve.
+          # Lessons from the 2026-07-29 v0.10.0 release-gate core (the first
+          # capture with the venv intact): `execfn` records the exec'd FILE,
+          # which for pytest is a python SCRIPT (not ELF — gdb rejects it and
+          # then loads no symbol tables at all); and `%e` in the core pattern
+          # is the crashing THREAD's name (e.g. `tokio-rt-worker`), not the
+          # binary. So: resolve execfn, then if it isn't a real ELF, follow a
+          # script's shebang / fall back to the venv's REAL python binary
+          # (readlink through the symlink chain), then the rust test binary.
+          resolve_elf() {
+            local cand="$1"
+            [ -n "$cand" ] && [ -f "$cand" ] || return 1
+            cand=$(readlink -f "$cand")
+            if file "$cand" | grep -q ELF; then echo "$cand"; return 0; fi
+            # Script: try its shebang interpreter.
+            local interp
+            interp=$(head -1 "$cand" | grep -oP '^#!\K\S+' || true)
+            if [ -n "$interp" ] && [ -f "$interp" ]; then
+              interp=$(readlink -f "$interp")
+              file "$interp" | grep -q ELF && echo "$interp" && return 0
+            fi
+            return 1
+          }
           for core in /tmp/core.*; do
             [ -f "$core" ] || continue
             echo "=== Analyzing core dump: $core ==="
-            EXE=$(file "$core" | grep -oP "execfn: '\K[^']+" || true)
-            if [ -z "$EXE" ] || [ ! -f "$EXE" ]; then
-              # Fallback: %e in the core pattern is the executable basename.
-              BASE=$(basename "$core" | cut -d. -f2)
-              case "$BASE" in
-                python*) EXE=$(find "$PWD/test-env-unified/bin" -name 'python*' -type f 2>/dev/null | head -1) ;;
-                *) EXE=$(find target/debug/deps -name "${BASE}*" -type f -executable 2>/dev/null | head -1) ;;
-              esac
+            EXE=$(resolve_elf "$(file "$core" | grep -oP "execfn: '\K[^']+" || true)" || true)
+            if [ -z "$EXE" ]; then
+              EXE=$(resolve_elf "$PWD/test-env-unified/bin/python" || true)
             fi
             if [ -z "$EXE" ]; then
-              echo "Could not determine executable for $core; trying rust test binary"
+              echo "Could not resolve a python ELF; trying rust test binary"
               EXE=$(find target/debug/deps -name 'integration-*' -type f -executable 2>/dev/null | head -1)
             fi
             echo "=== Executable: ${EXE:-unknown} ==="

--- a/.metis/backlog/bugs/CLOACI-T-0910.md
+++ b/.metis/backlog/bugs/CLOACI-T-0910.md
@@ -1,0 +1,128 @@
+---
+id: residual-segfault-class-mid
+level: task
+title: "Residual segfault class — mid-scenario native crash on tokio-rt-worker (postgres/ubuntu)"
+short_code: "CLOACI-T-0910"
+created_at: 2026-07-29T01:57:16.426726+00:00
+updated_at: 2026-07-29T01:57:16.426726+00:00
+parent:
+blocked_by: []
+archived: false
+
+tags:
+  - "#task"
+  - "#phase/backlog"
+  - "#bug"
+
+
+exit_criteria_met: false
+initiative_id: NULL
+---
+
+# Residual segfault class — mid-scenario native crash on tokio-rt-worker (postgres/ubuntu)
+
+*This template includes sections for various types of tasks. Delete sections that don't apply to your specific use case.*
+
+## Parent Initiative **[CONDITIONAL: Assigned Task]**
+
+[[Parent Initiative]]
+
+## Objective **[REQUIRED]**
+
+Root-cause and fix the RESIDUAL native segfault that survived the I-0140 campaign. The 2026-07-29 v0.10.0 release gate reproduced it: `test_scenario_03_function_based_dag_topology.py` (postgres/ubuntu) died `Fatal Python error: Segmentation fault` **mid-scenario** — outside the interpreter-teardown window that round 4's atexit backstop closed. Core `core.tokio-rt-worker.80177`: the crash is on a **tokio runtime worker thread**, with multiple workers parked inside `cloaca.abi3.so` frames (thread shape from the first venv-intact capture; frames still unsymbolized due to the exe-detection bug fixed in PR #212).
+
+## Backlog Item Details **[CONDITIONAL: Backlog Item]**
+
+### Type
+- [x] Bug - Production issue that needs fixing
+
+### Priority
+- [ ] P1 - High (important for user experience)
+
+### Impact Assessment **[CONDITIONAL: Bug]**
+- **Affected Users**: CI lanes (rotating scenario failures: 03, 16, 20, 27 sighted); risk profile for production embedders unknown until the faulting frame is named — mid-execution worker-thread crash is potentially production-relevant, unlike the teardown class.
+- **Reproduction**: never reproduced locally — 800+ clean iterations across macOS/postgres and arm64-linux/postgres (docker). All 4 sightings: GitHub runners, ubuntu, x86_64, 2-core. Suspected differentiators: x86_64 and/or tight-core scheduling. Candidate next repro attempts: `--cpus 2` docker throttle; x86_64 emulation; or simply wait — CI now self-symbolizes (unstripped wheel #208 + venv survives failure #208 + real-ELF resolution #212), so the NEXT natural kill names the frame.
+- **Expected vs Actual**: scenarios run to completion; instead an intermittent (~1-in-tens-of-lane-runs) SIGSEGV on a tokio-rt-worker mid-scenario.
+
+**Prior art / evidence trail:** I-0140 Status Updates (GIL audit findings B2/D = PyObject lifecycle on runtime threads — still prime suspects for a refcount/UAF race); `.angreal/gil_stress.py` is the harness; the 2026-07-29 release-gate log is the best capture to date.
+
+### Business Justification **[CONDITIONAL: Feature]**
+- **User Value**: {Why users need this}
+- **Business Value**: {Impact on metrics/revenue}
+- **Effort Estimate**: {Rough size - S/M/L/XL}
+
+### Technical Debt Impact **[CONDITIONAL: Tech Debt]**
+- **Current Problems**: {What's difficult/slow/buggy now}
+- **Benefits of Fixing**: {What improves after refactoring}
+- **Risk Assessment**: {Risks of not addressing this}
+
+## Acceptance Criteria **[REQUIRED]**
+
+- [ ] {Specific, testable requirement 1}
+- [ ] {Specific, testable requirement 2}
+- [ ] {Specific, testable requirement 3}
+
+## Test Cases **[CONDITIONAL: Testing Task]**
+
+{Delete unless this is a testing task}
+
+### Test Case 1: {Test Case Name}
+- **Test ID**: TC-001
+- **Preconditions**: {What must be true before testing}
+- **Steps**:
+  1. {Step 1}
+  2. {Step 2}
+  3. {Step 3}
+- **Expected Results**: {What should happen}
+- **Actual Results**: {To be filled during execution}
+- **Status**: {Pass/Fail/Blocked}
+
+### Test Case 2: {Test Case Name}
+- **Test ID**: TC-002
+- **Preconditions**: {What must be true before testing}
+- **Steps**:
+  1. {Step 1}
+  2. {Step 2}
+- **Expected Results**: {What should happen}
+- **Actual Results**: {To be filled during execution}
+- **Status**: {Pass/Fail/Blocked}
+
+## Documentation Sections **[CONDITIONAL: Documentation Task]**
+
+{Delete unless this is a documentation task}
+
+### User Guide Content
+- **Feature Description**: {What this feature does and why it's useful}
+- **Prerequisites**: {What users need before using this feature}
+- **Step-by-Step Instructions**:
+  1. {Step 1 with screenshots/examples}
+  2. {Step 2 with screenshots/examples}
+  3. {Step 3 with screenshots/examples}
+
+### Troubleshooting Guide
+- **Common Issue 1**: {Problem description and solution}
+- **Common Issue 2**: {Problem description and solution}
+- **Error Messages**: {List of error messages and what they mean}
+
+### API Documentation **[CONDITIONAL: API Documentation]**
+- **Endpoint**: {API endpoint description}
+- **Parameters**: {Required and optional parameters}
+- **Example Request**: {Code example}
+- **Example Response**: {Expected response format}
+
+## Implementation Notes **[CONDITIONAL: Technical Task]**
+
+{Keep for technical tasks, delete for non-technical. Technical details, approach, or important considerations}
+
+### Technical Approach
+{How this will be implemented}
+
+### Dependencies
+{Other tasks or systems this depends on}
+
+### Risk Considerations
+{Technical risks and mitigation strategies}
+
+## Status Updates **[REQUIRED]**
+
+*To be added during implementation*

--- a/.metis/backlog/tech-debt/CLOACI-T-0872.md
+++ b/.metis/backlog/tech-debt/CLOACI-T-0872.md
@@ -69,9 +69,12 @@ Design + build a release path for first-party providers that lets them publish/t
 
 ## Acceptance Criteria **[REQUIRED]**
 
-- [ ] {Specific, testable requirement 1}
-- [ ] {Specific, testable requirement 2}
-- [ ] {Specific, testable requirement 3}
+- [ ] `provider_release.yml` wave workflow exists (tag `providers-v<YYYY.MM[.n]>` or dispatch) implementing classify → guard → certify → publish → record → wave notes, with per-provider-atomic failure semantics.
+- [ ] Certification compiles + E2E-runs each provider's consumer fixture against **crates.io** core (no local patching) for BOTH candidates and unchanged providers.
+- [ ] Compat table (in-repo, machine-readable: provider × version × certified core × wave) is regenerated and committed by the wave.
+- [ ] PR guard fails any change to `providers/<name>/src` that doesn't bump the version + add a changelog entry.
+- [ ] `angreal providers wave` front door exists (prep checks + tag cut); post-core-release prep PR flow (pin bumps + compat patch releases) documented.
+- [ ] Inaugural wave publishes `cloacina-provider-kafka` (publish=false flipped) and the compat table records it certified against core 0.10.
 
 ## Test Cases **[CONDITIONAL: Testing Task]**
 
@@ -123,16 +126,39 @@ Design + build a release path for first-party providers that lets them publish/t
 
 ## Implementation Notes **[CONDITIONAL: Technical Task]**
 
-{Keep for technical tasks, delete for non-technical. Technical details, approach, or important considerations}
+### Design — the provider WAVE model (blessed by user 2026-07-28; supersedes the per-provider-tag sketch in the Objective)
 
-### Technical Approach
-{How this will be implemented}
+**What a provider release IS:** a verified claim with four parts — (1) an immutable source crate at version X on crates.io; (2) a **machine-earned compatibility claim** ("tested against released core Y" — the release gate compiles + E2E-runs the provider's consumer fixture against crates.io core, never the working tree); (3) the provider's own semver where the API surface is the **config schema** (renaming a config key is breaking even if no Rust signature moved — changelogs written in config-schema terms); (4) a row in the tested-set **compat table**. NOT part of a release: binaries or signing — the compiler builds native cdylibs from source at workflow-compile time (validated 2026-07-28), so providers are source releases.
+
+**Cadence model (Airflow-style waves):** provider versions stay independent (A-0010) but release ceremony is BATCHED — one wave trigger covers every provider. (Airflow's actual model for ~90 providers: independent versions + periodic release waves + published constraint files recording the tested combination. We adopt all three at small scale.)
+
+**Standing state between waves:**
+- Providers live in `providers/` (post-T-0871), each: standalone crate, own `[workspace]`, own version, per-provider CHANGELOG.md, a consumer fixture, core deps PINNED to an exact released minor (`= "0.10"`); ship-form version deps with harness local-patching for dev (same mechanism as ship-form examples).
+- PR guard: any PR touching `providers/<name>/src` with manifest version == last PUBLISHED version FAILS (must bump + changelog). Main is self-describing by wave time.
+
+**The wave (`provider_release.yml`, triggered by `providers-v<YYYY.MM[.n]>` tag or dispatch; `angreal providers wave` as the front door):**
+1. **Classify** each provider: manifest version > crates.io published → RELEASE CANDIDATE; equal → RE-CERTIFY ONLY.
+2. **Guards (candidates only):** changelog entry for the new version exists; core deps are published versions (no path deps); version increased.
+3. **Certify (BOTH classes, identical step — the heart):** clean env, NO local patching — compile the consumer fixture resolving core from crates.io, run it E2E (kafka: broker service container). This step manufactures the compat claim; unchanged providers RE-EARN theirs rather than assume it.
+4. **Publish (candidates only):** `cargo publish` from `providers/<name>` (existing crates.io token).
+5. **Record (everyone):** regenerate + commit the compat table (in-repo, machine-readable: provider × version × certified core × wave).
+6. **Wave release notes:** one GH release on the wave tag — "published: X (changelog excerpt); re-certified: Y, Z".
+
+**Failure semantics:** waves are per-provider atomic — a failing candidate drops out with a report, the rest proceed. An UNCHANGED provider failing re-certification is the contract-drift alarm: it keeps its old compat row (visibly not certified for current core) and becomes the next wave's top work item. No silent rot.
+
+**Core-release coupling (emergent from the pin policy):** pinned deps make every provider a mechanical candidate after a core release — one prep PR bumps all pins + patch versions + "compat: core 0.N" changelog lines, then a wave publishes compat releases for all. Providers therefore ride core's cadence plus ad-hoc feature waves between. Loosen pins to ranges only if/when the roster grows enough for this to hurt.
+
+**Key property:** bumped and unbumped providers run the IDENTICAL pipeline differing at exactly one step (publish) — because the claim, not the upload, is what a release means.
 
 ### Dependencies
-{Other tasks or systems this depends on}
+- [[CLOACI-T-0871]] first: audit roster (kafka + fs real; sensor/quorum/extract stay illustrative examples) and move real providers to `providers/`.
+- Core 0.10.0 published on crates.io (v0.10.0 train, 2026-07-28) — providers must version-dep against released core.
+- Flip `publish = false` off the real providers as part of their first wave prep.
 
 ### Risk Considerations
-{Technical risks and mitigation strategies}
+- Consumer-fixture E2E against crates.io core IS the certification — a shallow fixture means a shallow compat claim. Fixtures must instantiate constructors and execute, not just compile.
+- The nightly contract-drift lane (build providers against MAIN's contract crates) complements waves: early warning that the NEXT core release breaks providers, before release day.
+- First wave is the plumbing shakedown: expect crates.io first-publish quirks (mirror the core train's soft-fail handling).
 
 ## Status Updates **[REQUIRED]**
 


### PR DESCRIPTION
The v0.10.0 release-gate segfault (scenario 03, postgres/ubuntu) was the first core captured with the venv intact (#208's fixes) — and it exposed the last two bugs in executable detection:

1. `execfn` records the exec'd **file**, which for pytest is a python **script** — gdb rejects it ("not in executable format") and then loads no symbol tables at all, so every frame stayed `?? ()` even with the unstripped `cloaca.abi3.so` present.
2. `%e` in the core pattern is the crashing **thread's** name (`tokio-rt-worker`), not the binary name, so the basename fallback matched nothing.

`resolve_elf()` now: follows symlinks, verifies ELF-ness with `file`, chases a script's shebang interpreter, then falls back to the venv's real python binary (`readlink -f test-env-unified/bin/python`), then the rust test binary.

Even symbol-less, this capture confirmed the crash shape: **mid-scenario segfault on a `tokio-rt-worker` thread**, multiple workers parked in cloaca frames — the residual I-0140 segfault class, now outside the teardown window round 4 covered. Next kill gets named frames.