### PR TITLE
fix(release): v0.10.0 postmortem — missing crates in publish tiers, retired ui-image job

### DIFF
--- a/.github/workflows/unified_release.yml
+++ b/.github/workflows/unified_release.yml
@@ -123,6 +123,11 @@ jobs:
           sleep 30
           publish cloacina-testing
           sleep 30
+          # v0.10.0 postmortem: born this cycle (I-0132/I-0139) but never added
+          # here — `cloacina` depends on it, so the whole Tier-2+ chain failed
+          # with "no matching package named cloacina-constructor-contract".
+          publish cloacina-constructor-contract
+          sleep 30
 
           # Tier 2: engine.
           publish cloacina
@@ -144,6 +149,10 @@ jobs:
           publish cloacinactl
           sleep 30
           publish cloacina-compiler
+          sleep 30
+          # v0.10.0 postmortem: cloacina-server grew a dep on cloacina-agent
+          # (fleet work, I-0127) — the agent crate must publish first.
+          publish cloacina-agent
           sleep 30
           publish cloacina-server
         env:
@@ -542,88 +551,12 @@ jobs:
           docker run --rm "${IMAGE}:latest" --version
 
   # -----------------------------------------------------------------------
-  # Step 5c-ui: Build + push cloacina-ui image (CLOACI-I-0117 / T-0659)
-  #
-  # Multi-arch build via buildx, pushed to ghcr.io/<owner>/cloacina-ui.
-  # Built in lockstep with cloacina-server (NFR-004) — same tag scheme
-  # (<semver>, <major>.<minor>, latest) so the UI and server images stay
-  # version-matched. Context is the repo root because ui/Dockerfile builds
-  # the sibling @cloacina/client SDK before the Vite bundle.
+  # (Step 5c-ui removed, v0.10.0 postmortem: the standalone cloacina-ui image
+  # was retired in CLOACI-I-0130 — the web UI ships embedded in the server
+  # image — but this job survived, pointing at the deleted ui/Dockerfile, and
+  # failed the release train. The charts/cloacina-ui standalone-SPA path is
+  # deployed from source, not a first-party image.)
   # -----------------------------------------------------------------------
-
-  publish-docker-ui:
-    name: Publish cloacina-ui image
-    needs: [verify-version]
-    if: startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Compute tags
-        id: tags
-        env:
-          TAG_REF: ${{ github.ref }}
-          REPO_OWNER: ${{ github.repository_owner }}
-        run: |
-          set -euo pipefail
-          tag="${TAG_REF#refs/tags/}"     # vX.Y.Z
-          version="${tag#v}"              # X.Y.Z
-          major_minor="${version%.*}"     # X.Y
-          owner_lc=$(echo "${REPO_OWNER}" | tr '[:upper:]' '[:lower:]')
-          image="ghcr.io/${owner_lc}/cloacina-ui"
-          echo "image=${image}" >> "$GITHUB_OUTPUT"
-          {
-            echo "tag_list<<EOF"
-            echo "${image}:${version}"
-            echo "${image}:${major_minor}"
-            echo "${image}:latest"
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to ghcr.io
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build + push (linux/amd64, linux/arm64)
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: ui/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.tags.outputs.tag_list }}
-          provenance: false
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: Smoke test (runtime config + SPA serve, linux/amd64)
-        env:
-          IMAGE: ${{ steps.tags.outputs.image }}
-        run: |
-          set -euo pipefail
-          # Verifies the entrypoint renders index.html with the injected
-          # server URL and nginx serves it (the SPA's only runtime contract).
-          docker run -d --name ui-smoke -e CLOACINA_SERVER_URL=http://smoke.test:8080 \
-            -p 8099:80 "${IMAGE}:latest"
-          for i in $(seq 1 15); do
-            if curl -fsS http://localhost:8099/ >/dev/null; then break; fi
-            sleep 1
-          done
-          body=$(curl -fsS http://localhost:8099/)
-          echo "${body}" | grep -q 'defaultServerUrl: "http://smoke.test:8080"'
-          docker rm -f ui-smoke
 
   # -----------------------------------------------------------------------
   # Step 5d: Publish Helm chart (CLOACI-I-0111 / T-0605)
@@ -635,7 +568,7 @@ jobs:
 
   publish-helm:
     name: Publish Helm chart
-    needs: [verify-version, publish-docker, publish-docker-ui]
+    needs: [verify-version, publish-docker]
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     permissions:
@@ -708,7 +641,7 @@ jobs:
 
   prune-tag-caches:
     name: Prune Tag-Scoped Caches
-    needs: [publish-cargo, publish-pypi, build-release-binaries, publish-docker, publish-docker-ui, publish-helm]
+    needs: [publish-cargo, publish-pypi, build-release-binaries, publish-docker, publish-helm]
     if: always() && startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
The v0.10.0 train's validation gate passed on rerun (attempt 2 — the scenario-03 segfault did not strike twice), unlocking the publish cascade, which then failed at three jobs:

1. **crates.io tier gap #1**: `cloacina-constructor-contract` (born this cycle, I-0132/I-0139) was never added to the publish tiers — `cloacina` depends on it, so Tier 2 onward died with *no matching package named cloacina-constructor-contract*. Added to Tier 1 with a postmortem comment.
2. **crates.io tier gap #2 (latent)**: `cloacina-server` now depends on `cloacina-agent` (I-0127 fleet work) — also unpublished, and it would have failed the train again one tier later. Added before `cloacina-server`.
3. **Retired job**: `publish-docker-ui` survived I-0130's retirement of the standalone UI container, pointed at the deleted `ui/Dockerfile`, and failed. Job removed; `needs` lists updated; tombstone comment left in place.

Went right: **seven Tier-1 crates published** (api-types, macros, workflow, build, computation-graph, workflow-plugin, testing at 0.10.0) — idempotently skipped on the next run ('already published' = success). Server image + wheels + binaries were mid-publish on attempt 2 independently.

**Not fixed here**: npm `@cloacina/client` E404 on first scoped publish — the workflow's own comments document first-publish of a scoped package as needing manual bootstrap (org/scope creation or a by-hand first publish).

After merge: delete + re-push the `v0.10.0` tag to run the corrected train end-to-end.