### PR TITLE
fix(T-0910): kill the getenv/setenv segfault race — gssencmode=disable + env-mutation hygiene

### DIFF
--- a/.metis/backlog/bugs/CLOACI-T-0910.md
+++ b/.metis/backlog/bugs/CLOACI-T-0910.md
@@ -125,4 +125,14 @@ Root-cause and fix the RESIDUAL native segfault that survived the I-0140 campaig
 
 ## Status Updates **[REQUIRED]**
 
-*To be added during implementation*
+### 2026-07-31 — ROOT CAUSE NAMED (symbolized): glibc getenv/setenv race via libpq's GSSAPI path. Never PyO3.
+
+The full forensics stack (#208 unstripped wheel + venv-survives-failure, #212 real-ELF resolution) paid off on the first double-kill (PR #218 CI, scenarios 10+17, postgres/ubuntu). Faulting thread, symbolized through the signal frame: `__GI_getenv("KRB5_TRACE")` ← k5_init_trace ← gss_acquire_cred ← PQconnectPoll/PQconnectdb ← diesel establish ← deadpool Manager::create ← tokio blocking thread.
+
+**Mechanism:** glibc's `getenv` walks `environ` unlocked; concurrent `setenv`/`putenv` from any thread can realloc the array → UAF → SIGSEGV. The mutator: conftest's `enable_rust_logging` was an **autouse fixture** running `os.environ['RUST_LOG']=...` before EVERY test — a setenv racing every pool-thread connection-establish, all session long. Explains everything: postgres-only (no libpq on sqlite), ubuntu-only (glibc unlocked getenv + distro libpq with GSSAPI; macOS libc differs; arm64-docker libpq lacked krb5), 2-core timing, scenario rotation (whichever test's fixture fired during an establish). Also explains the corrupted-looking earlier captures: faulthandler itself crashed AGAIN mid-dump (PyCode_Addr2Line co=0x0).
+
+**Fixes (branch fix/t0910-getenv-race):**
+1. Core: `build_postgres_url` (the single pg-URL funnel — verified nothing bypasses it) defaults `gssencmode=disable` (explicit caller value wins) — skips the krb5/getenv storm. Unit tests 4/4.
+2. Test hygiene: autouse fixture → one-time import-scope `os.environ.setdefault` + standing no-mutation-after-runner rule; scenario 13's inline duplicate removed.
+
+Smoke: scenarios 10+13 pass. Residual: the general glibc getenv/setenv hazard is inherent — the gssencmode default removes cloacina's hottest getenv path; embedders who mutate env at runtime remain exposed on their own paths.

--- a/.metis/backlog/tech-debt/CLOACI-T-0871.md
+++ b/.metis/backlog/tech-debt/CLOACI-T-0871.md
@@ -4,7 +4,7 @@ level: task
 title: "First-party provider audit + promotion out of examples/ — which are real providers, where do they live"
 short_code: "CLOACI-T-0871"
 created_at: 2026-07-08T11:43:20.369192+00:00
-updated_at: 2026-07-30T04:56:28.761478+00:00
+updated_at: 2026-07-31T01:46:27.091023+00:00
 parent:
 blocked_by: []
 archived: false
@@ -12,7 +12,7 @@ archived: false
 tags:
   - "#task"
   - "#tech-debt"
-  - "#phase/active"
+  - "#phase/completed"
 
 
 exit_criteria_met: false
@@ -66,6 +66,8 @@ Audit which of these are real first-party providers vs. purely illustrative exam
 - **Current Problems**: {What's difficult/slow/buggy now}
 - **Benefits of Fixing**: {What improves after refactoring}
 - **Risk Assessment**: {Risks of not addressing this}
+
+## Acceptance Criteria
 
 ## Acceptance Criteria
 

--- a/crates/cloacina/src/database/connection/mod.rs
+++ b/crates/cloacina/src/database/connection/mod.rs
@@ -485,6 +485,20 @@ impl Database {
         if !has_explicit_db {
             url.set_path(database_name);
         }
+        // CLOACI-T-0910: default `gssencmode=disable` (caller's explicit value
+        // wins). libpq's GSSAPI negotiation walks libkrb5 init on every new
+        // connection, which is getenv-heavy — and glibc's getenv is unlocked,
+        // so it segfaults if ANY other thread setenv/putenv's concurrently
+        // (e.g. Python `os.environ[...] = ...` while a pool thread opens a
+        // connection). This was the rotating CI segfault class: symbolized
+        // core showed SIGSEGV in __GI_getenv("KRB5_TRACE") under
+        // PQconnectdb ← deadpool Manager::create on a tokio blocking thread.
+        // Disabling GSS encryption skips the krb5 path entirely; anyone who
+        // actually needs GSSAPI sets gssencmode explicitly in their URL.
+        let has_gssencmode = url.query_pairs().any(|(k, _)| k == "gssencmode");
+        if !has_gssencmode {
+            url.query_pairs_mut().append_pair("gssencmode", "disable");
+        }
         Ok(url.to_string())
     }
 
@@ -892,6 +906,41 @@ mod tests {
         assert!(
             url.contains("/mydb") && !url.contains("/cloacina"),
             "explicit dbname must win: {url}"
+        );
+    }
+
+    // CLOACI-T-0910: gssencmode=disable is defaulted (skips libpq's krb5/getenv
+    // path — the getenv/setenv segfault race), but an explicit value wins.
+    #[test]
+    fn build_postgres_url_defaults_gssencmode_disable() {
+        let url =
+            Database::build_postgres_url("postgres://u:p@host:5432/mydb", "cloacina").unwrap();
+        assert!(
+            url.contains("gssencmode=disable"),
+            "gssencmode=disable should be defaulted: {url}"
+        );
+        // Appends correctly when a query string already exists.
+        let url2 = Database::build_postgres_url(
+            "postgres://u:p@host:5432/mydb?sslmode=require",
+            "cloacina",
+        )
+        .unwrap();
+        assert!(
+            url2.contains("sslmode=require") && url2.contains("gssencmode=disable"),
+            "should append to existing query: {url2}"
+        );
+    }
+
+    #[test]
+    fn build_postgres_url_respects_explicit_gssencmode() {
+        let url = Database::build_postgres_url(
+            "postgres://u:p@host:5432/mydb?gssencmode=prefer",
+            "cloacina",
+        )
+        .unwrap();
+        assert!(
+            url.contains("gssencmode=prefer") && !url.contains("gssencmode=disable"),
+            "explicit gssencmode must win: {url}"
         );
     }
 

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -171,10 +171,17 @@ def timeout_protection(seconds=15):
         signal.signal(signal.SIGALRM, old_handler)
 
 
-@pytest.fixture(autouse=True)
-def enable_rust_logging():
-    """Enable Rust logging for all tests."""
-    os.environ['RUST_LOG'] = 'cloacina=debug,cloaca_backend=debug'
+# CLOACI-T-0910: RUST_LOG is set ONCE at import time — NEVER from a fixture.
+# The old autouse fixture re-ran `os.environ[...] = ...` before EVERY test,
+# i.e. setenv() racing the live runner's pool threads, whose libpq connection
+# setup is getenv-heavy (krb5). glibc's getenv is unlocked, so that race
+# segfaults — this was the rotating CI segfault class (symbolized core:
+# SIGSEGV in __GI_getenv under PQconnectdb). Conftest imports before any
+# runner exists, so setting it here is safe; respect an externally-set value.
+#
+# Standing rule: NO os.environ mutation anywhere in this suite after a runner
+# has been created.
+os.environ.setdefault('RUST_LOG', 'cloacina=debug,cloaca_backend=debug')
 
 
 def pytest_sessionfinish(session, exitstatus):

--- a/tests/python/test_scenario_13_complex_dependency_chains.py
+++ b/tests/python/test_scenario_13_complex_dependency_chains.py
@@ -14,8 +14,8 @@ class TestComplexDependencyChains:
 
     def test_comprehensive_complex_dependency_patterns(self, shared_runner):
         """Test comprehensive complex dependency chain patterns including diamond, fan-out, fan-in, and multi-level chains."""
-        import os
-        os.environ['RUST_LOG'] = 'cloacina=debug,cloaca_backend=debug'
+        # (RUST_LOG is set once in conftest at import time — mutating
+        # os.environ mid-test races the runner's threads; CLOACI-T-0910.)
         import cloaca
 
         # Test 1: Diamond dependency pattern


### PR DESCRIPTION
## The residual segfault class, root-caused with named frames

The forensics stack built for exactly this moment (#208 unstripped wheels + venv survival, #212 real-ELF resolution) delivered on the first double-kill (#218's CI run, scenarios 10 + 17):

```
#8  __GI_getenv("KRB5_TRACE")        ← SIGSEGV
#9  k5_init_trace → gss_acquire_cred  (libkrb5 / GSSAPI)
#15-19 PQconnectPoll → PQconnectdb    (libpq, new connection)
#20-24 diesel establish ← deadpool Manager::create ← tokio blocking thread
```

**The classic glibc `getenv`/`setenv` race**: `getenv` walks `environ` unlocked; any concurrent `setenv` can realloc it → UAF. Our mutator: conftest's `enable_rust_logging` was an **autouse fixture** — `os.environ['RUST_LOG'] = ...` before *every test*, racing every pool-thread connection-establish for the whole session. This explains the entire observed profile: postgres-only (no libpq on sqlite), ubuntu-only (glibc's unlocked getenv + GSSAPI-built distro libpq; macOS libc differs; my arm64-docker libpq lacked krb5), 2-core timing sensitivity, and the scenario rotation. **It was never PyO3.**

## The fixes

1. **Core**: `build_postgres_url` — the single pg-URL funnel (verified nothing bypasses it) — now defaults `gssencmode=disable`, skipping libpq's krb5/getenv storm entirely; an explicit `gssencmode` in the caller's URL wins. This protects every embedder, not just our tests. Unit tests: default applied / appends to existing query string / explicit value respected.
2. **Test hygiene**: the autouse fixture is gone — `RUST_LOG` is set once at conftest import (before any runner exists) via `setdefault`, with a standing rule comment: no `os.environ` mutation after a runner exists. Scenario 13's inline duplicate removed.

## Verification

- URL unit tests 4/4; scenarios 10 + 13 smoke-pass.
- The real verification is longitudinal: with both the trigger (env mutation per test) and the vulnerable path (GSSAPI negotiation) removed, the postgres/ubuntu segfault should never recur — and if anything native ever does kill a lane, it now self-symbolizes.

Metis: T-0910 journaled with the full evidence chain; T-0871 closed (providers landed in #218).