### PR TITLE
fix(examples): fs-grant-demo drift — ProviderPackageOptions.runtime (T-0903 API)

### DIFF
--- a/examples/constructor-contract/fs-grant-demo/src/main.rs
+++ b/examples/constructor-contract/fs-grant-demo/src/main.rs
@@ -176,6 +176,10 @@ fn stage_constructor(work_dir: &std::path::Path, providers: &PathBuf) {
         sign_key: None,
         manifest_bin: "emit_manifest".to_string(),
         release: true,
+        // CLOACI-T-0903 added per-runtime packaging; this demo is the WASM path.
+        // (Drift caught by the T-0872 crates.io certification dry-run — this demo
+        // is in no CI lane, T-0892.)
+        runtime: cloacina::packaging::constructor_provider::ProviderRuntime::Wasm,
     };
     println!("==> Packaging cloacina-provider-fs to a WASM provider (slow on first run)...");
     package_constructor_provider(&opts).expect("package_constructor_provider");


### PR DESCRIPTION
One-field fix caught by the first **T-0872 certification dry-run**: `fs-grant-demo` (in no CI lane — T-0892's dark matter) had rotted against I-0139's `ProviderPackageOptions.runtime` addition.

The dry-run that caught it then **passed fully**: `cloacina`/`cloacina-workflow`/`cloacina-build` resolved *entirely from crates.io 0.10.0*, the ship-form fs provider packaged → loaded → executed all three grant cases (granted read ✓, default-closed denial ✓, granted write ✓) in a scratch directory containing zero repo code. First functional proof of the published provider story, and a live demonstration of why waves re-certify unchanged providers.