### PR TITLE
chore(providers): inaugural wave prep — flip publish=false on kafka + fs

### DIFF
--- a/providers/cloacina-provider-fs/Cargo.toml
+++ b/providers/cloacina-provider-fs/Cargo.toml
@@ -23,7 +23,6 @@ exclude = ["certify"]
 name = "cloacina-provider-fs"
 version = "0.1.0"
 edition = "2021"
-publish = false
 
 [lib]
 # cdylib → the wasm component; rlib → so `emit_manifest` (host) can link it.

--- a/providers/cloacina-provider-kafka/Cargo.toml
+++ b/providers/cloacina-provider-kafka/Cargo.toml
@@ -11,8 +11,8 @@
 # `call_streaming` → `ChunkStream` → the accumulator boundary channel (T-0904).
 #
 # Standalone crate (empty [workspace], under examples/*, excluded from the
-# cloacina workspace). Ship-form version deps (crates.io); `publish = false`
-# until the first provider release wave flips it (CLOACI-T-0872).
+# cloacina workspace). Ship-form version deps (crates.io); published to
+# crates.io by the provider release wave (CLOACI-T-0872).
 [workspace]
 
 [package]
@@ -22,7 +22,6 @@ exclude = ["certify"]
 name = "cloacina-provider-kafka"
 version = "0.1.0"
 edition = "2021"
-publish = false
 
 # CLOACI-T-0907: tells the provider BUNDLER (compiler `pack_providers` /
 # `bundle_providers`) to build this provider as a NATIVE host cdylib —


### PR DESCRIPTION
The last gate before the first provider wave: removes `publish = false` from both promoted providers (and updates kafka's now-stale manifest comment).

Verified: `provider_wave.py guard` passes for both (changelog entries, ship-form deps, contract pins), and both hold locally-earned certifications against crates.io core (COMPAT.toml, wave 2026.07-preflight).

This PR should also be the **Provider Guard workflow's first live firing** (it touches `providers/*/Cargo.toml`) — note the guard's expected verdict: both providers are at 0.1.0 vs *unpublished* on crates.io, which counts as a version bump, so it should pass.

After merge, the inaugural wave: `git tag providers-v2026.08 && git push origin providers-v2026.08` → certifies both in CI (kafka against its own broker container), publishes both to crates.io, opens the compat PR, cuts the wave release — closing T-0872's final acceptance criterion.