### PR TITLE
docs(providers): compat table for wave 2026.08.2

### DIFF
--- a/providers/COMPAT.toml
+++ b/providers/COMPAT.toml
@@ -7,10 +7,10 @@
 name = "cloacina-provider-fs"
 version = "0.1.0"
 certified_core = "0.10"
-wave = "2026.07-preflight"
+wave = "2026.08.2"
 
 [[provider]]
 name = "cloacina-provider-kafka"
 version = "0.1.0"
 certified_core = "0.10"
-wave = "2026.07-preflight"
+wave = "2026.08.2"


### PR DESCRIPTION
Machine-generated by the provider wave (run 30710898176). Both providers certified against crates.io core 0.10 and published: cloacina-provider-kafka 0.1.0 + cloacina-provider-fs 0.1.0 — the inaugural successful wave. (Opened manually: the workflow's GITHUB_TOKEN cannot create PRs until 'Allow GitHub Actions to create pull requests' is enabled in repo settings — noted for the wave workflow's ops docs.)