### PR TITLE
feat(T-0913): python cron scaffold template for package new

### DIFF
--- a/.metis/backlog/tech-debt/CLOACI-T-0913.md
+++ b/.metis/backlog/tech-debt/CLOACI-T-0913.md
@@ -4,15 +4,15 @@ level: task
 title: "Python cron scaffold template for cloacinactl package new"
 short_code: "CLOACI-T-0913"
 created_at: 2026-08-02T15:02:16.233117+00:00
-updated_at: 2026-08-02T15:02:16.233117+00:00
+updated_at: 2026-08-02T15:21:01.387529+00:00
 parent:
 blocked_by: []
 archived: false
 
 tags:
   - "#task"
-  - "#phase/backlog"
   - "#tech-debt"
+  - "#phase/active"
 
 
 exit_criteria_met: false
@@ -40,11 +40,12 @@ Add a Python template for `cloacinactl package new --kind cron --language python
 
 ## Acceptance Criteria
 
-- [ ] `cloacinactl package new my-cron --language python --kind cron` produces an uploadable package (mirror examples/features/workflows/python-cron: bare `@cloaca.task` tasks + `@cloaca.trigger(on=..., cron=...)`, package.toml with PythonRuntime fields)
-- [ ] `ScaffoldKind::Cron => unreachable!(...)` python arm in new.rs replaced by the real template writer; refusal + corrected error text removed
-- [ ] Scaffold unit test alongside the existing rust_cron/graph scaffold tests
-- [ ] Docs touch-up: reference/cli.md package-new kind table + reference/python-api/trigger.md hint updated to drop the template-missing caveat
+- [x] `cloacinactl package new my-cron --language python --kind cron` produces an uploadable package (mirrors python-cron example: bare `@cloaca.task` + `@cloaca.trigger(on=..., cron=...)`, minimal manifest — resolver infers language/entry from layout, so no explicit PythonRuntime keys needed, same as the example)
+- [x] `ScaffoldKind::Cron => unreachable!(...)` python arm replaced by scaffold_python_cron; refusal removed
+- [x] Scaffold unit test alongside the existing rust_cron/graph scaffold tests
+- [ ] Docs touch-up: reference/cli.md package-new kind table + reference/python-api/trigger.md hint updated to drop the template-missing caveat (blocked until #225/#226 merge — those files live in PR #225 content)
 
 ## Status Updates
 
 - 2026-08-02: Filed per user request while executing CLOACI-T-0912 (which only corrected the misleading error text).
+- 2026-08-02: Implemented on feat/t-0913-python-cron-scaffold (stacked on the T-0912 branch since it replaces that branch's corrected refusal). scaffold_python_cron mirrors examples/features/workflows/python-cron: minimal manifest (workflow_name = module), empty __init__.py, tasks.py with one bare @cloaca.task + @cloaca.trigger(on=module, cron="* * * * *") and body-unused comment. Module doc kind list now language-neutral. Old python_cron_is_rejected test replaced with python_cron_scaffold_binds_via_on_with_cron_schedule (asserts on=/cron= binding, no poll_interval, no WorkflowBuilder, layout). REMAINING before PR: rebase onto main after #225/#226 merge, then the docs touch-ups on this branch.

--- a/.metis/backlog/tech-debt/CLOACI-T-0913.md
+++ b/.metis/backlog/tech-debt/CLOACI-T-0913.md
@@ -43,9 +43,10 @@ Add a Python template for `cloacinactl package new --kind cron --language python
 - [x] `cloacinactl package new my-cron --language python --kind cron` produces an uploadable package (mirrors python-cron example: bare `@cloaca.task` + `@cloaca.trigger(on=..., cron=...)`, minimal manifest — resolver infers language/entry from layout, so no explicit PythonRuntime keys needed, same as the example)
 - [x] `ScaffoldKind::Cron => unreachable!(...)` python arm replaced by scaffold_python_cron; refusal removed
 - [x] Scaffold unit test alongside the existing rust_cron/graph scaffold tests
-- [ ] Docs touch-up: reference/cli.md package-new kind table + reference/python-api/trigger.md hint updated to drop the template-missing caveat (blocked until #225/#226 merge — those files live in PR #225 content)
+- [x] Docs touch-up: reference/cli.md kind table (also fixed its stale cannot-declare-cron claim), reference/python-api/trigger.md hint (now describes the scaffold), embed/how-to/running-the-daemon.md note — all updated post-merge
 
 ## Status Updates
 
 - 2026-08-02: Filed per user request while executing CLOACI-T-0912 (which only corrected the misleading error text).
+- 2026-08-02 (later): Rebased onto main (post #225/#226 squash merges) via rebase --onto, resolving the expected new.rs test conflict in favor of the scaffold-success test. Docs touch-ups applied (three files incl. a stale cli.md claim that predated the adjudication). PR opened; merge on green.
 - 2026-08-02: Implemented on feat/t-0913-python-cron-scaffold (stacked on the T-0912 branch since it replaces that branch's corrected refusal). scaffold_python_cron mirrors examples/features/workflows/python-cron: minimal manifest (workflow_name = module), empty __init__.py, tasks.py with one bare @cloaca.task + @cloaca.trigger(on=module, cron="* * * * *") and body-unused comment. Module doc kind list now language-neutral. Old python_cron_is_rejected test replaced with python_cron_scaffold_binds_via_on_with_cron_schedule (asserts on=/cron= binding, no poll_interval, no WorkflowBuilder, layout). REMAINING before PR: rebase onto main after #225/#226 merge, then the docs touch-ups on this branch.

--- a/crates/cloacinactl/src/nouns/package/new.rs
+++ b/crates/cloacinactl/src/nouns/package/new.rs
@@ -21,10 +21,9 @@
 //! hand-assembly. `--kind` selects the package shape:
 //! - `workflow` — `@cloaca.task` / `#[workflow]` tasks.
 //! - `graph` — a computation graph (`ComputationGraphBuilder` / `#[computation_graph]`).
-//! - `cron` — a workflow fired by a cron trigger. Only a Rust template exists;
-//!   Python packages fully support cron via `@cloaca.trigger(on=..., cron=...)`
-//!   declared in a `--kind workflow` package (see
-//!   `examples/features/workflows/python-cron`).
+//! - `cron` — a workflow fired by a cron trigger (`#[trigger(on, cron)]` /
+//!   `@cloaca.trigger(on=..., cron=...)`); the cron scheduler fires the `on`
+//!   workflow directly on the schedule.
 //!
 //! Python packages use bare decorators (the loader builds the workflow/graph
 //! context from `workflow_name`/`graph_name`); Rust packages depend on the
@@ -68,20 +67,6 @@ pub fn run(
     // The Python module / Rust workflow identifier derived from the package
     // name: hyphens aren't valid identifiers, so map them to underscores.
     let module = name.replace('-', "_");
-
-    // No Python cron TEMPLATE exists yet — the capability does. Python packages
-    // support cron triggers via `@cloaca.trigger(on=..., cron=...)` (routed to
-    // the cron scheduler by the reconciler); see
-    // examples/features/workflows/python-cron for a working packaged example.
-    if lang == ScaffoldLang::Python && kind == ScaffoldKind::Cron {
-        return Err(CliError::UserError(
-            "no Python cron scaffold template yet. Python packages DO support cron \
-             triggers: scaffold `--kind workflow` and declare \
-             `@cloaca.trigger(name=..., on=<workflow>, cron=\"<expr>\")` \
-             (see examples/features/workflows/python-cron)."
-                .to_string(),
-        ));
-    }
 
     let dir = path
         .map(Path::to_path_buf)
@@ -163,7 +148,7 @@ fn scaffold_python(
     match kind {
         ScaffoldKind::Workflow => scaffold_python_workflow(dir, name, module),
         ScaffoldKind::Graph => scaffold_python_graph(dir, name, module),
-        ScaffoldKind::Cron => unreachable!("python cron rejected in run()"),
+        ScaffoldKind::Cron => scaffold_python_cron(dir, name, module),
     }
 }
 
@@ -203,6 +188,48 @@ def goodbye(context):
     write(&dir.join("package.toml"), &package_toml)?;
     write(&dir.join(format!("workflow/{module}/__init__.py")), "")?;
     write(&dir.join(format!("workflow/{module}/tasks.py")), tasks_py)?;
+    Ok(())
+}
+
+fn scaffold_python_cron(dir: &Path, name: &str, module: &str) -> Result<(), CliError> {
+    // Mirrors examples/features/workflows/python-cron: bare @cloaca.task
+    // decorators plus a `@cloaca.trigger(on=..., cron=...)` declaration. The
+    // cron scheduler fires the `on` workflow directly on the schedule — the
+    // trigger function body is unused; its presence at import IS the
+    // declaration (there is no triggers section in package.toml).
+    let package_toml = format!(
+        r#"[package]
+name = "{name}"
+version = "0.1.0"
+
+[metadata]
+workflow_name = "{module}"
+description = "{name} cron workflow"
+"#
+    );
+
+    let tasks_py = format!(
+        r#"import cloaca
+
+
+@cloaca.task(id="beat", dependencies=[])
+def beat(context):
+    context.set("beat", True)
+    return context
+
+
+# Fires `{module}` on the schedule (5-field cron, optional leading seconds
+# field; add `timezone="..."` for non-UTC). The cron scheduler fires the `on`
+# workflow directly — this function body is unused.
+@cloaca.trigger(on="{module}", cron="* * * * *")
+def {module}_cron():
+    pass
+"#
+    );
+
+    write(&dir.join("package.toml"), &package_toml)?;
+    write(&dir.join(format!("workflow/{module}/__init__.py")), "")?;
+    write(&dir.join(format!("workflow/{module}/tasks.py")), &tasks_py)?;
     Ok(())
 }
 
@@ -645,20 +672,29 @@ mod tests {
     }
 
     #[test]
-    fn python_cron_is_rejected() {
+    fn python_cron_scaffold_binds_via_on_with_cron_schedule() {
         let tmp = TempDir::new().unwrap();
-        let err = run(
-            "x",
+        let dir = tmp.path().join("nightly-py");
+        run(
+            "nightly-py",
             ScaffoldLang::Python,
             ScaffoldKind::Cron,
-            Some(tmp.path()),
+            Some(&dir),
         )
-        .unwrap_err();
-        // T-0912: the refusal must say the TEMPLATE is missing (the capability
-        // exists) and point at the working @cloaca.trigger(cron=...) path.
-        let msg = format!("{err:?}");
-        assert!(msg.contains("no Python cron scaffold template"));
-        assert!(msg.contains("cron="));
+        .unwrap();
+
+        let manifest = fs::read_to_string(dir.join("package.toml")).unwrap();
+        assert!(manifest.contains("workflow_name = \"nightly_py\""));
+
+        let tasks = fs::read_to_string(dir.join("workflow/nightly_py/tasks.py")).unwrap();
+        // Cron binds the workflow via `on` + `cron` on the trigger decorator;
+        // mutually exclusive with poll_interval (crates/cloacina-python
+        // trigger.rs), so the scaffold must emit neither poll_interval nor a
+        // WorkflowBuilder (packaged loaders use bare decorators).
+        assert!(tasks.contains("@cloaca.trigger(on=\"nightly_py\", cron="));
+        assert!(!tasks.contains("poll_interval"));
+        assert!(!tasks.contains("WorkflowBuilder"));
+        assert!(dir.join("workflow/nightly_py/__init__.py").exists());
     }
 
     #[test]

--- a/docs/content/embed/how-to/running-the-daemon.md
+++ b/docs/content/embed/how-to/running-the-daemon.md
@@ -201,7 +201,7 @@ Configuration reload complete.
 
 ### Cron Schedule Not Firing
 
-1. Confirm the schedule was registered by looking for `registered cron schedule` in the logs. Cron schedules come from `#[trigger(cron = "...")]` / `@cloaca.trigger(cron=..., on=...)` declarations compiled into the package — if the package has no cron trigger in code, nothing is registered. (Note: `cloacinactl package new --kind cron` only scaffolds a Rust template, but Python packages declare cron triggers the same way in code — see the `python-cron` example.)
+1. Confirm the schedule was registered by looking for `registered cron schedule` in the logs. Cron schedules come from `#[trigger(cron = "...")]` / `@cloaca.trigger(cron=..., on=...)` declarations compiled into the package — if the package has no cron trigger in code, nothing is registered. (`cloacinactl package new --kind cron` scaffolds this shape for both languages — see the `python-cron` example for a worked Python package.)
 2. Check that `cron_max_catchup` is not set too low if the daemon was down for a period. When omitted, the runner default of 100 catchup executions applies.
 3. Verify the cron expression is valid: 5-field format (minute, hour, day-of-month, month, day-of-week), with an optional leading seconds field for 6-field expressions.
 4. If the daemon was recently restarted, recovery runs after `cron_recovery_interval_s` seconds (default 300).

--- a/docs/content/reference/cli.md
+++ b/docs/content/reference/cli.md
@@ -324,7 +324,7 @@ Scaffolds a canonical package source tree. Local-only.
 | Flag | Default | Description |
 |---|---|---|
 | `--lang <python\|rust>` | `python` | Source language to scaffold. |
-| `--kind <workflow\|graph\|cron>` | `workflow` | Package shape. **`cron` is Rust-only** — `--lang python --kind cron` errors (Python packages cannot declare cron triggers; use a poll trigger). |
+| `--kind <workflow\|graph\|cron>` | `workflow` | Package shape. All three kinds scaffold for both languages; `cron` emits a workflow bound to a cron trigger (`#[trigger(on, cron)]` in Rust, `@cloaca.trigger(on=..., cron=...)` in Python). |
 | `--path <DIR>` | `./<name>` | Directory to create. |
 
 ### `package build <DIR> [--release]`

--- a/docs/content/reference/python-api/trigger.md
+++ b/docs/content/reference/python-api/trigger.md
@@ -43,11 +43,11 @@ CLOACI-T-0688):
 Setting both `cron` and `poll_interval`, or `cron` without `on`, raises
 `ValueError`.
 
-{{< hint type="note" title="Cron scaffolding is Rust-only; cron triggers are not" >}}
-`cloacinactl package new --kind cron` only generates a Rust template and
-refuses `--language python` (`crates/cloacinactl/src/nouns/package/new.rs`).
-Packaged Python workflows still fully support cron: declare
-`@cloaca.trigger(cron=..., on=...)` in a `--kind workflow` package — see
+{{< hint type="note" title="Scaffolding a cron package" >}}
+`cloacinactl package new <name> --language python --kind cron` scaffolds a
+ready-to-pack package with this shape: one bare `@cloaca.task` plus a
+`@cloaca.trigger(on=..., cron=...)` declaration
+(`crates/cloacinactl/src/nouns/package/new.rs`). A worked example lives at
 `examples/features/workflows/python-cron`.
 {{< /hint >}}
 


### PR DESCRIPTION
## Summary

Completes the kind × language scaffold matrix: `cloacinactl package new <name> --language python --kind cron` now emits a working package instead of refusing. The capability always existed (`@cloaca.trigger(cron=…, on=…)` is fully supported, packaged included — `examples/features/workflows/python-cron` is CI-wired); only the template was missing, a gap T-0912 (#226) had downgraded from a false "cron is Rust-only" error to an accurate template-missing one. This removes it entirely.

- `scaffold_python_cron` mirrors the CI-wired example: minimal manifest (`workflow_name = <module>`; resolver infers language/entry from layout), empty `__init__.py`, and `tasks.py` with one bare `@cloaca.task` plus `@cloaca.trigger(on=<module>, cron="* * * * *")` — with the body-unused convention explained in comments.
- The refusal and its `unreachable!` arm are gone; the module doc's kind list is language-neutral.
- `python_cron_is_rejected` is replaced by `python_cron_scaffold_binds_via_on_with_cron_schedule` (asserts the `on=`/`cron=` binding, no `poll_interval`, no `WorkflowBuilder`, canonical layout).
- Docs caveats dropped in three places, including a stale `cli.md` claim ("Python packages cannot declare cron triggers") that predated the T-0911 adjudication.

Tracked in CLOACI-T-0913.

## Test plan
- New scaffold unit test alongside the existing rust_cron/graph scaffold tests
- Pre-commit cargo check (both backends) passed