### PR TITLE
fix(T-0915): CG runtime defects — CEL tenant stub, reactor state restore, lock-free supervisor backoff

### DIFF
--- a/.metis/backlog/bugs/CLOACI-T-0914.md
+++ b/.metis/backlog/bugs/CLOACI-T-0914.md
@@ -4,7 +4,7 @@ level: task
 title: "Execution-core crash-edge defects — unsweepable claim window, dead Abandoned machinery, fail-open claim errors"
 short_code: "CLOACI-T-0914"
 created_at: 2026-08-02T16:33:13.496800+00:00
-updated_at: 2026-08-02T18:36:21.576816+00:00
+updated_at: 2026-08-02T22:55:39.932740+00:00
 parent:
 blocked_by: []
 archived: false
@@ -12,7 +12,7 @@ archived: false
 tags:
   - "#task"
   - "#bug"
-  - "#phase/active"
+  - "#phase/completed"
 
 
 exit_criteria_met: false
@@ -43,13 +43,16 @@ Close the crash-edge recovery gaps in the execution core found by the 2026-08-02
 
 ## Acceptance Criteria
 
-- [ ] Crash-in-claim-window test passes: task is re-dispatched/reclaimed within one sweep interval, never stuck
-- [ ] Re-Ready recycling is capped (or the cap is explicitly documented as a non-goal and the dead Abandoned code is removed)
-- [ ] Claim-write error path fails closed with retries
-- [ ] task_outbox has an owner: consumed or pruned or removed
-- [ ] Long-workflow cron duplicate-fire covered by a test
+## Acceptance Criteria
+
+- [x] Crash-in-claim-window test passes (test_sweep_recovers_ready_claimed_task incl. re-claimability; terminal-row immunity also pinned)
+- [x] Re-Ready recycling capped at 3 via revived reset_task_for_recovery + mark_abandoned (ABANDONED: Failed convention); get_orphaned_tasks deleted
+- [x] Claim-write error path fails closed (skip + re-select next tick; outcome=error metric)
+- [x] task_outbox REMOVED end to end (043_drop_task_outbox migrations both backends; no-duplicate-dispatch rests on claim_for_runner CAS)
+- [x] Long-workflow cron duplicate-fire covered (test_long_running_cron_workflow_not_duplicate_fired + genuinely-lost re-fire test)
 
 ## Status Updates
 
 - 2026-08-02: Filed from the architecture deep dive (execution-core report; DEEPDIVE.md risk register R-high entries). Findings verified against main @ 5216e632.
 - 2026-08-02: ACTIVE on fix/t-0914-execution-crash-edges. Verified plan: (a) heartbeat starts AT CLAIM (claim_for_runner sets heartbeat_at; heartbeat loop spawns before semaphore acquire) so stale heartbeat on Ready+claimed is a true death signal — broadening find_stale_claims is safe, BUT must be status IN (Running, Ready), never claim-only: a crash after mark_completed leaves a claim on a terminal row that must not be re-Readied. (b) Terminal set is exactly {Completed, Failed, Skipped} (queries.rs:85, state_manager.rs:135) — a literal Abandoned status would hang workflows; HOWEVER mark_abandoned already writes status=Failed + ABANDONED: error prefix + TaskAbandoned event transactionally (state.rs:421-469), and check_workflow_failure already queries that convention — the machinery was designed for this cap and never wired. PLAN: sweeper gains max_recovery_attempts (default 3, mirroring cron); StaleClaim carries recovery_attempts; per claim: release + (attempts >= cap ? mark_abandoned : reset_task_for_recovery — which Ready-resets AND increments, replacing mark_ready). Delete get_orphaned_tasks (misleading, zero callers). Sweeper writes stay warn+continue (30s re-sweep = natural retry). (c) Claim Err at thread_task_executor.rs:424-430 -> return skipped (stays Ready+unclaimed, re-selected next tick) + metric outcome=error. (d) task_outbox: verify no non-test readers, stop writing + prune (no schema migration). (e) cron: link audit row at handoff. Implementing a,b,c then d,e.
+- 2026-08-02: DONE — merged to main in PR #229 (squash). Plan deltas from implementation: (d) went further than prune — full subsystem removal incl. 043_drop_task_outbox migrations (down.sql restores 011/012 DDL incl. pg notify trigger), which also collapsed the mark_ready pg/sqlite twins (I-0135). (e) verified WORSE than filed: find_lost_executions checked only completed_at IS NULL + age, so EVERY cron workflow >10min was re-fired; bonus bug — successful recovery never complete()d the audit row, re-entering it into the lost set each sweep. Fixed via execute_async handoff-time linking + recovery consulting the live execution + re-fires completing the row. RESIDUALS (open): cron recovery attempt cap still in-memory (schedule_executions needs an attempts column — follow-up migration candidate); multi-instance recovery has no CAS on the audit row (pre-existing); scheduler completion waits no longer bounded by workflow_timeout (intentional — the old bound was itself a duplicate-fire vector).

--- a/.metis/backlog/bugs/CLOACI-T-0915.md
+++ b/.metis/backlog/bugs/CLOACI-T-0915.md
@@ -4,15 +4,15 @@ level: task
 title: "CG runtime defects — CEL tenant stub, sequential-queue restore, lock-held supervisor backoff"
 short_code: "CLOACI-T-0915"
 created_at: 2026-08-02T16:33:18.144884+00:00
-updated_at: 2026-08-02T16:33:18.144884+00:00
+updated_at: 2026-08-02T22:23:04.124639+00:00
 parent:
 blocked_by: []
 archived: false
 
 tags:
   - "#task"
-  - "#phase/backlog"
   - "#bug"
+  - "#phase/active"
 
 
 exit_criteria_met: false
@@ -40,6 +40,10 @@ Fix three localized bug-shaped defects in the computation-graph runtime found by
 3. SUPERVISOR SLEEPS BACKOFF HOLDING THE REACTORS WRITE LOCK. Restart backoff (up to 60s, 5-failure circuit breaker) sleeps while holding the scheduler's reactors write lock (crates/cloacina/src/computation_graph/scheduler.rs:1165, 1222, 1405), so during a restart storm all loads, listings, and /v1/health/* graph reads block behind it — the health surface goes dark exactly when operators need it. Fix: drop the lock before sleeping; re-acquire for the restart attempt.
 
 Related but tracked elsewhere: cross-replica reactive state is T-0851; the crashed-CG-503s-/ready-replica-wide behavior is noted in T-0916.
+
+## Acceptance Criteria
+
+## Acceptance Criteria
 
 ## Acceptance Criteria
 

--- a/.metis/backlog/bugs/CLOACI-T-0916.md
+++ b/.metis/backlog/bugs/CLOACI-T-0916.md
@@ -4,15 +4,15 @@ level: task
 title: "Server HA truthfulness — in-memory agent roster and WS tickets contradict the chart HA claim"
 short_code: "CLOACI-T-0916"
 created_at: 2026-08-02T16:33:28.701827+00:00
-updated_at: 2026-08-02T16:33:28.701827+00:00
+updated_at: 2026-08-02T23:13:55.174712+00:00
 parent:
 blocked_by: []
 archived: false
 
 tags:
   - "#task"
-  - "#phase/backlog"
   - "#bug"
+  - "#phase/active"
 
 
 exit_criteria_met: false
@@ -41,6 +41,10 @@ Make the server's multi-replica story truthful. The deep dive found HA is "80% r
 4. charts/cloacina-server presents itself as HA-safe (deliberately no HPA but replica-count friendly) with no documented session-affinity requirement.
 
 Fix options (choose per component): move roster + tickets to DB rows (both are tiny, TTL-friendly; the delivery outbox pattern already exists), or gate replicas>1 in the chart behind documented sticky-session requirements. For /ready: scope readiness to platform health, report tenant-workload health via /v1/health/* instead. Reactive-layer HA (reactor state) stays T-0851 — reference, not duplicated here.
+
+## Acceptance Criteria
+
+## Acceptance Criteria
 
 ## Acceptance Criteria
 

--- a/crates/cloacina/src/computation_graph/reactor.rs
+++ b/crates/cloacina/src/computation_graph/reactor.rs
@@ -614,12 +614,19 @@ impl Reactor {
             let _ = health.send(ReactorHealth::Starting);
         }
 
-        // Load cache from DAL if available (instant recovery)
+        // Load cache from DAL if available (instant recovery). Dirty flags
+        // and the sequential queue are restored too (CLOACI-T-0915): they
+        // were persisted before every drain precisely so a crash mid-drain
+        // doesn't lose items, but the restore path used to discard both —
+        // making Sequential's no-loss promise and WhenAll's accumulated
+        // dirty state per-process-lifetime only.
         let cache = self.cache.clone();
+        let mut restored_dirty: Option<HashMap<SourceName, bool>> = None;
+        let mut restored_seq: Option<VecDeque<(SourceName, Vec<u8>)>> = None;
         if let Some(ref dal) = self.dal {
             if !self.graph_name.is_empty() {
                 match dal.checkpoint().load_reactor_state(&self.graph_name).await {
-                    Ok(Some((cache_data, _dirty_data, _seq_queue))) => {
+                    Ok(Some((cache_data, dirty_data, seq_data))) => {
                         // Restore cache — deserialize the entries map
                         if let Ok(entries) =
                             serde_json::from_slice::<HashMap<SourceName, Vec<u8>>>(&cache_data)
@@ -629,6 +636,30 @@ impl Reactor {
                                 c.update(source, bytes);
                             }
                             tracing::info!(graph = %self.graph_name, "reactor cache restored from DAL");
+                        }
+                        match serde_json::from_slice::<HashMap<SourceName, bool>>(&dirty_data) {
+                            Ok(flags) => restored_dirty = Some(flags),
+                            Err(e) => {
+                                tracing::warn!(graph = %self.graph_name, "persisted dirty flags unreadable (starting clean): {}", e);
+                            }
+                        }
+                        if let Some(seq_bytes) = seq_data {
+                            match serde_json::from_slice::<VecDeque<(SourceName, Vec<u8>)>>(
+                                &seq_bytes,
+                            ) {
+                                Ok(q) if !q.is_empty() => {
+                                    tracing::info!(
+                                        graph = %self.graph_name,
+                                        items = q.len(),
+                                        "sequential queue restored from DAL"
+                                    );
+                                    restored_seq = Some(q);
+                                }
+                                Ok(_) => {}
+                                Err(e) => {
+                                    tracing::warn!(graph = %self.graph_name, "persisted sequential queue unreadable (starting empty): {}", e);
+                                }
+                            }
                         }
                     }
                     Ok(None) => {
@@ -641,12 +672,23 @@ impl Reactor {
             }
         }
 
-        let dirty = if self.expected_sources.is_empty() {
-            Arc::new(RwLock::new(DirtyFlags::new()))
-        } else {
-            Arc::new(RwLock::new(DirtyFlags::with_sources(
-                &self.expected_sources,
-            )))
+        let dirty = {
+            let mut flags = if self.expected_sources.is_empty() {
+                DirtyFlags::new()
+            } else {
+                DirtyFlags::with_sources(&self.expected_sources)
+            };
+            if let Some(restored) = restored_dirty {
+                // Overlay restored flags. When an expected-source list exists,
+                // only overlay sources still expected — a stale flag for a
+                // de-scoped source must not poison `all_set()`.
+                for (source, set) in restored {
+                    if self.expected_sources.is_empty() || flags.flags.contains_key(&source) {
+                        flags.set(source, set);
+                    }
+                }
+            }
+            Arc::new(RwLock::new(flags))
         };
 
         // Startup gating — wait for all accumulators to become healthy before going Live
@@ -770,7 +812,9 @@ impl Reactor {
         let input_strategy = self.input_strategy.clone();
 
         // Sequential queue — only used when InputStrategy::Sequential
-        let seq_queue: SeqQueue = Arc::new(RwLock::new(VecDeque::new()));
+        // Seed with any queue restored from the last checkpoint (T-0915):
+        // items persisted before a crash mid-drain resume from here.
+        let seq_queue: SeqQueue = Arc::new(RwLock::new(restored_seq.unwrap_or_default()));
 
         let (strategy_tx, mut strategy_rx) = mpsc::channel::<StrategySignal>(64);
 

--- a/crates/cloacina/src/computation_graph/scheduler.rs
+++ b/crates/cloacina/src/computation_graph/scheduler.rs
@@ -430,6 +430,37 @@ const BACKOFF_MAX_SECS: u64 = 60;
 /// Duration of successful operation before failure counter resets.
 const SUCCESS_RESET_SECS: u64 = 60;
 
+/// A restart decided in phase 1 of
+/// [`ComputationGraphScheduler::check_and_restart_failed`] (under the
+/// reactors write lock) and executed afterwards with the lock released
+/// (CLOACI-T-0915): the backoff sleep and recovery-event write must never
+/// happen while the lock is held, or every list/health reader blocks behind
+/// them for up to [`BACKOFF_MAX_SECS`] during a restart storm.
+enum PlannedRestart {
+    /// The reactor task exited — full-graph restart (new channels,
+    /// re-spawned accumulators + reactor).
+    Reactor {
+        reactor_name: String,
+        /// `"{reactor}::reactor"` — recovery-event component key.
+        component_key: String,
+        /// Failure count at detection time (drives the recovery event).
+        attempt: u32,
+        backoff_secs: u64,
+        /// The finished handle, taken in phase 1 so phase 2 can classify
+        /// panic-vs-error without holding the lock.
+        dead: JoinHandle<()>,
+    },
+    /// An accumulator task exited — in-place respawn.
+    Accumulator {
+        reactor_name: String,
+        acc_name: String,
+        component_key: String,
+        attempt: u32,
+        backoff_secs: u64,
+        dead: JoinHandle<()>,
+    },
+}
+
 /// The computation graph scheduler: loads reactors and computation graphs,
 /// supervises them, and routes operational commands to running instances.
 pub struct ComputationGraphScheduler {
@@ -1161,222 +1192,97 @@ impl ComputationGraphScheduler {
     /// Individual accumulators are restarted in-place without tearing down the
     /// reactor. Reactor crashes trigger a full-graph restart. Failure counting
     /// with exponential backoff prevents infinite restart loops.
+    ///
+    /// Runs in three phases (CLOACI-T-0915): crash detection and
+    /// failure-count bookkeeping happen under the reactors write lock; the
+    /// recovery-event write and the exponential-backoff sleep happen with
+    /// the lock RELEASED so list/health readers (`list_graphs`,
+    /// `/v1/health/graphs`, package loads) stay responsive during a restart
+    /// storm; each restart then re-acquires the lock and re-validates that
+    /// the component is still down before acting.
     pub async fn check_and_restart_failed(&self) -> usize {
         let mut restarted = 0;
-        let mut graphs = self.reactors.write().await;
         let now = std::time::Instant::now();
 
-        for (graph_name, running) in graphs.iter_mut() {
-            // Reset failure counts for components that have been running successfully
-            let success_threshold = std::time::Duration::from_secs(SUCCESS_RESET_SECS);
-            let names_to_reset: Vec<String> = running
-                .last_success
-                .iter()
-                .filter(|(_, ts)| now.duration_since(**ts) >= success_threshold)
-                .map(|(name, _)| name.clone())
-                .collect();
-            for name in names_to_reset {
-                running.failure_counts.remove(&name);
-                running.last_success.remove(&name);
-            }
+        // Phase 1 — under the write lock: reset success bookkeeping, detect
+        // crashed components, take their dead handles, and collect a restart
+        // plan. NO sleeps and NO DB writes happen while the lock is held.
+        let plans: Vec<PlannedRestart> = {
+            let mut graphs = self.reactors.write().await;
+            let mut plans = Vec::new();
 
-            // Check reactor
-            if running.reactor_handle.is_finished() {
-                let reactor_key = format!("{}::reactor", graph_name);
-                let failures = running
-                    .failure_counts
-                    .entry(reactor_key.clone())
-                    .or_insert(0);
-                *failures += 1;
-
-                // Take ownership of the finished handle so we can inspect the
-                // JoinError (panic vs ordinary exit) without blocking. The
-                // handle is replaced by `tokio::spawn(reactor.run())` below;
-                // the dummy stays in place only briefly while we read the
-                // result.
-                let dead = std::mem::replace(&mut running.reactor_handle, tokio::spawn(async {}));
-                let reason = classify_join_result(dead.await);
-
-                if *failures > MAX_RECOVERY_ATTEMPTS {
-                    error!(
-                        graph = %graph_name,
-                        failures = *failures,
-                        "reactor permanently failed — circuit breaker open"
-                    );
-                    emit_component_health(graph_name, "reactor", "crashed");
-                    continue;
-                }
-
-                let backoff_secs =
-                    (BACKOFF_BASE_SECS * 2u64.pow(*failures - 1)).min(BACKOFF_MAX_SECS);
-                let backoff = std::time::Duration::from_secs(backoff_secs);
-                warn!(
-                    graph = %graph_name,
-                    attempt = *failures,
-                    backoff_secs = backoff_secs,
-                    "reactor crashed, restarting (full graph restart)"
-                );
-
-                // Record recovery event and wait for backoff
-                self.record_recovery_event(&reactor_key, *failures, backoff_secs)
-                    .await;
-                tokio::time::sleep(backoff).await;
-
-                // Full graph restart: new channels, re-spawn everything
-                let (shutdown_tx, shutdown_rx) = shutdown_signal();
-                let stored_shutdown_rx = shutdown_rx.clone();
-                let (boundary_tx, boundary_rx) = mpsc::channel(256);
-                let stored_boundary_tx = boundary_tx.clone();
-
-                let expected_sources: Vec<SourceName> = running
-                    .declaration
-                    .accumulators
+            for (graph_name, running) in graphs.iter_mut() {
+                // Reset failure counts for components that have been running successfully
+                let success_threshold = std::time::Duration::from_secs(SUCCESS_RESET_SECS);
+                let names_to_reset: Vec<String> = running
+                    .last_success
                     .iter()
-                    .map(|a| SourceName::new(&a.name))
+                    .filter(|(_, ts)| now.duration_since(**ts) >= success_threshold)
+                    .map(|(name, _)| name.clone())
                     .collect();
+                for name in names_to_reset {
+                    running.failure_counts.remove(&name);
+                    running.last_success.remove(&name);
+                }
 
-                let mut new_acc_handles = Vec::new();
-                let mut restart_acc_health_rxs: Vec<(
-                    String,
-                    watch::Receiver<super::accumulator::AccumulatorHealth>,
-                )> = Vec::new();
-                for acc_decl in &running.declaration.accumulators {
-                    let (health_tx, health_rx) = health_channel();
-                    restart_acc_health_rxs.push((acc_decl.name.clone(), health_rx.clone()));
-                    let freshness = super::accumulator::FreshnessHandle::new();
-                    let spawn_config = AccumulatorSpawnConfig {
-                        dal: self.dal.clone(),
-                        health_tx: Some(health_tx),
-                        graph_name: graph_name.clone(),
-                        freshness: freshness.clone(),
-                    };
-                    let (socket_tx, handle) = acc_decl.factory.spawn(
-                        acc_decl.name.clone(),
-                        boundary_tx.clone(),
-                        shutdown_rx.clone(),
-                        spawn_config,
+                // Check reactor
+                if running.reactor_handle.is_finished() {
+                    let reactor_key = format!("{}::reactor", graph_name);
+                    let failures = running
+                        .failure_counts
+                        .entry(reactor_key.clone())
+                        .or_insert(0);
+                    *failures += 1;
+
+                    // Take ownership of the finished handle so phase 2 can
+                    // inspect the JoinError (panic vs ordinary exit) without
+                    // blocking. The dummy stays in place until the phase-3
+                    // restart swaps in the re-spawned reactor.
+                    let dead =
+                        std::mem::replace(&mut running.reactor_handle, tokio::spawn(async {}));
+
+                    if *failures > MAX_RECOVERY_ATTEMPTS {
+                        error!(
+                            graph = %graph_name,
+                            failures = *failures,
+                            "reactor permanently failed — circuit breaker open"
+                        );
+                        emit_component_health(graph_name, "reactor", "crashed");
+                        drop(dead);
+                        continue;
+                    }
+
+                    let backoff_secs =
+                        (BACKOFF_BASE_SECS * 2u64.pow(*failures - 1)).min(BACKOFF_MAX_SECS);
+                    warn!(
+                        graph = %graph_name,
+                        attempt = *failures,
+                        backoff_secs = backoff_secs,
+                        "reactor crashed, restarting (full graph restart)"
                     );
-                    self.registry
-                        .register_accumulator(acc_decl.name.clone(), socket_tx)
-                        .await;
-                    self.registry
-                        .register_accumulator_health(acc_decl.name.clone(), health_rx)
-                        .await;
-                    self.registry
-                        .register_accumulator_freshness(acc_decl.name.clone(), freshness)
-                        .await;
-                    // CLOACI-I-0128 follow-up: re-register discoverability meta
-                    // on the restart path too (graph + tenant).
-                    self.registry
-                        .register_accumulator_meta(
-                            acc_decl.name.clone(),
-                            super::registry::AccumulatorDescriptor {
-                                reactor: graph_name.clone(),
-                                tenant_id: running.declaration.tenant_id.clone(),
-                            },
-                        )
-                        .await;
-                    new_acc_handles.push((acc_decl.name.clone(), handle));
-                }
 
-                let (manual_tx, manual_rx) = mpsc::channel(64);
-                let (reactor_health_tx, reactor_health_rx) = reactor_health_channel();
-                // Reuse the same subscriber map across restart so subscribers
-                // bound mid-life don't get dropped when the reactor restarts.
-                let restart_dispatcher =
-                    make_subscriber_dispatcher(graph_name.clone(), running.subscribers.clone());
-                let mut reactor = Reactor::new(
-                    restart_dispatcher,
-                    running.declaration.reactor.criteria.clone(),
-                    running.declaration.reactor.strategy.clone(),
-                    boundary_rx,
-                    manual_rx,
-                    shutdown_rx,
-                )
-                .with_graph_name(graph_name.clone())
-                .with_health(reactor_health_tx)
-                .with_expected_sources(expected_sources)
-                .with_accumulator_health(restart_acc_health_rxs)
-                .with_tenant_id(running.declaration.tenant_id.clone())
-                .with_graph_executor(self.graph_executor.read().await.clone());
-                // CLOACI-T-0830: re-install the reactor-constructor decider on
-                // restart. The decider was resolved once at load and is shared
-                // (`Arc<dyn ReactorFireDecider>`, `Send + Sync`), so the restart
-                // reuses it rather than re-loading the WASM component.
-                if let Some(ref ev) = running.evaluator {
-                    reactor = reactor.with_evaluator(ev.clone());
-                }
-                if let Some(ref dal) = self.dal {
-                    reactor = reactor.with_dal(dal.clone());
-                }
-                let reactor_shared = reactor.handle();
-                let reactor_handle = tokio::spawn(reactor.run());
-
-                // Re-register every endpoint-registry key the reactor was
-                // originally registered under (its own name + any back-compat
-                // aliases for bundled-form callers; T-0545 M1 stores these
-                // explicitly on RunningGraph instead of recovering from
-                // declaration.name).
-                for key in &running.endpoint_registry_keys {
-                    self.registry
-                        .register_reactor(key.clone(), manual_tx.clone(), reactor_shared.clone())
-                        .await;
-                }
-
-                // Re-set auth policies after restart
-                let restart_acc_policy = match &running.declaration.tenant_id {
-                    Some(tid) => AccumulatorAuthPolicy::for_tenant(tid),
-                    None => AccumulatorAuthPolicy::allow_all(),
-                };
-                let restart_reactor_policy = match &running.declaration.tenant_id {
-                    Some(tid) => ReactorAuthPolicy::for_tenant(tid),
-                    None => ReactorAuthPolicy::allow_all(),
-                };
-                for acc_decl in &running.declaration.accumulators {
-                    self.registry
-                        .set_accumulator_policy(acc_decl.name.clone(), restart_acc_policy.clone())
-                        .await;
-                }
-                for key in &running.endpoint_registry_keys {
-                    self.registry
-                        .set_reactor_policy(key.clone(), restart_reactor_policy.clone())
-                        .await;
-                }
-
-                running.shutdown_tx = shutdown_tx;
-                running.shutdown_rx = stored_shutdown_rx;
-                running.boundary_tx = stored_boundary_tx;
-                running.accumulator_handles = new_acc_handles;
-                running.reactor_handle = reactor_handle;
-                running.reactor_shared = reactor_shared;
-                running.reactor_health_rx = Some(reactor_health_rx);
-                running.last_success.insert(reactor_key, now);
-
-                metrics::counter!(
-                    "cloacina_supervisor_restarts_total",
-                    "graph" => graph_name.clone(),
-                    "component" => "reactor",
-                    "reason" => reason,
-                )
-                .increment(1);
-                emit_component_health(graph_name, "reactor", "starting");
-                restarted += 1;
-                info!(graph = %graph_name, "reactor restarted successfully");
-            } else {
-                // Check individual accumulators — restart them in-place
-                let mut new_handles = Vec::new();
-                let mut changed = false;
-
-                for (acc_name, handle) in running.accumulator_handles.drain(..) {
-                    if handle.is_finished() {
+                    plans.push(PlannedRestart::Reactor {
+                        reactor_name: graph_name.clone(),
+                        component_key: reactor_key,
+                        attempt: *failures,
+                        backoff_secs,
+                        dead,
+                    });
+                } else {
+                    // Check individual accumulators — plan in-place restarts.
+                    // Circuit-broken accumulators are dropped (abandoned)
+                    // right here; crashed-but-recoverable ones get a dummy
+                    // swapped into their slot and a plan entry.
+                    let mut idx = 0;
+                    while idx < running.accumulator_handles.len() {
+                        if !running.accumulator_handles[idx].1.is_finished() {
+                            idx += 1;
+                            continue;
+                        }
+                        let acc_name = running.accumulator_handles[idx].0.clone();
                         let acc_key = format!("{}::{}", graph_name, acc_name);
                         let failures = running.failure_counts.entry(acc_key.clone()).or_insert(0);
                         *failures += 1;
-
-                        // Non-blocking — handle is already finished. Inspect
-                        // JoinError to attribute panic vs error in the
-                        // restart counter label.
-                        let reason = classify_join_result(handle.await);
 
                         if *failures > MAX_RECOVERY_ATTEMPTS {
                             error!(
@@ -1386,7 +1292,8 @@ impl ComputationGraphScheduler {
                                 "accumulator permanently failed — circuit breaker open"
                             );
                             emit_component_health(graph_name, &acc_name, "crashed");
-                            // Don't add handle back — accumulator is abandoned
+                            // Remove the slot — accumulator is abandoned.
+                            running.accumulator_handles.remove(idx);
                             continue;
                         }
 
@@ -1400,97 +1307,370 @@ impl ComputationGraphScheduler {
                             "accumulator crashed, restarting individually"
                         );
 
-                        // Record recovery event and wait for backoff
-                        self.record_recovery_event(&acc_key, *failures, backoff_secs)
-                            .await;
-                        tokio::time::sleep(std::time::Duration::from_secs(backoff_secs)).await;
-
-                        // Find the declaration for this accumulator
-                        if let Some(acc_decl) = running
-                            .declaration
-                            .accumulators
-                            .iter()
-                            .find(|d| d.name == *acc_name)
-                        {
-                            // Re-spawn with existing boundary_tx and shutdown_rx
-                            let (health_tx, health_rx) = health_channel();
-                            let freshness = super::accumulator::FreshnessHandle::new();
-                            let spawn_config = AccumulatorSpawnConfig {
-                                dal: self.dal.clone(),
-                                health_tx: Some(health_tx),
-                                graph_name: graph_name.clone(),
-                                freshness: freshness.clone(),
-                            };
-                            let (socket_tx, new_handle) = acc_decl.factory.spawn(
-                                acc_name.clone(),
-                                running.boundary_tx.clone(),
-                                running.shutdown_rx.clone(),
-                                spawn_config,
-                            );
-
-                            // Re-register socket, health, and auth policy in endpoint registry
-                            self.registry
-                                .register_accumulator(acc_name.clone(), socket_tx)
-                                .await;
-                            self.registry
-                                .register_accumulator_health(acc_name.clone(), health_rx)
-                                .await;
-                            self.registry
-                                .register_accumulator_freshness(acc_name.clone(), freshness)
-                                .await;
-                            let ind_acc_policy = match &running.declaration.tenant_id {
-                                Some(tid) => AccumulatorAuthPolicy::for_tenant(tid),
-                                None => AccumulatorAuthPolicy::allow_all(),
-                            };
-                            self.registry
-                                .set_accumulator_policy(acc_name.clone(), ind_acc_policy)
-                                .await;
-
-                            running.last_success.insert(acc_key, now);
-                            let restarted_name = acc_name.clone();
-                            metrics::counter!(
-                                "cloacina_supervisor_restarts_total",
-                                "graph" => graph_name.clone(),
-                                "component" => restarted_name.clone(),
-                                "reason" => reason,
-                            )
-                            .increment(1);
-                            emit_component_health(graph_name, &restarted_name, "starting");
-                            new_handles.push((acc_name, new_handle));
-                            restarted += 1;
-                            changed = true;
-
-                            info!(
-                                graph = %graph_name,
-                                accumulator = %restarted_name,
-                                "accumulator restarted individually"
-                            );
-                        } else {
-                            let lost_name = acc_name.clone();
-                            error!(
-                                graph = %graph_name,
-                                accumulator = %lost_name,
-                                "cannot restart: declaration not found"
-                            );
-                        }
-                    } else {
-                        new_handles.push((acc_name, handle));
+                        // Take the finished handle; the dummy stays in the
+                        // slot until the phase-3 respawn replaces it.
+                        let dead = std::mem::replace(
+                            &mut running.accumulator_handles[idx].1,
+                            tokio::spawn(async {}),
+                        );
+                        plans.push(PlannedRestart::Accumulator {
+                            reactor_name: graph_name.clone(),
+                            acc_name,
+                            component_key: acc_key,
+                            attempt: *failures,
+                            backoff_secs,
+                            dead,
+                        });
+                        idx += 1;
                     }
                 }
+            }
 
-                running.accumulator_handles = new_handles;
+            plans
+        };
 
-                if changed {
-                    // Mark accumulators that are still running as successful
-                    for (acc_name, _) in &running.accumulator_handles {
-                        let acc_key = format!("{}::{}", graph_name, acc_name);
-                        running.last_success.entry(acc_key).or_insert(now);
+        // Phases 2 and 3 — the reactors lock is NOT held here. Record the
+        // recovery event and sleep out the backoff unlocked (serial, matching
+        // the pre-T-0915 pacing), then re-acquire the lock per restart and
+        // re-validate before acting.
+        for plan in plans {
+            match plan {
+                PlannedRestart::Reactor {
+                    reactor_name,
+                    component_key,
+                    attempt,
+                    backoff_secs,
+                    dead,
+                } => {
+                    // Non-blocking: the handle already finished in phase 1.
+                    let reason = classify_join_result(dead.await);
+                    self.record_recovery_event(&component_key, attempt, backoff_secs)
+                        .await;
+                    tokio::time::sleep(std::time::Duration::from_secs(backoff_secs)).await;
+                    if self
+                        .restart_reactor_after_backoff(&reactor_name, reason, now)
+                        .await
+                    {
+                        restarted += 1;
+                    }
+                }
+                PlannedRestart::Accumulator {
+                    reactor_name,
+                    acc_name,
+                    component_key,
+                    attempt,
+                    backoff_secs,
+                    dead,
+                } => {
+                    let reason = classify_join_result(dead.await);
+                    self.record_recovery_event(&component_key, attempt, backoff_secs)
+                        .await;
+                    tokio::time::sleep(std::time::Duration::from_secs(backoff_secs)).await;
+                    if self
+                        .restart_accumulator_after_backoff(&reactor_name, &acc_name, reason, now)
+                        .await
+                    {
+                        restarted += 1;
                     }
                 }
             }
         }
 
         restarted
+    }
+
+    /// Phase 3 of [`check_and_restart_failed`]: after the unlocked backoff,
+    /// re-acquire the write lock and perform the full-graph restart.
+    ///
+    /// Re-validates before acting — while the lock was released the reactor
+    /// may have been unloaded, or replaced with a live task by another path
+    /// (e.g. unload + reload). Returns whether a restart actually happened.
+    async fn restart_reactor_after_backoff(
+        &self,
+        reactor_name: &str,
+        reason: &'static str,
+        now: std::time::Instant,
+    ) -> bool {
+        let mut graphs = self.reactors.write().await;
+        let Some(running) = graphs.get_mut(reactor_name) else {
+            info!(
+                graph = %reactor_name,
+                "reactor unloaded during restart backoff — skipping restart"
+            );
+            return false;
+        };
+        // Phase 1 swapped a finished dummy into `reactor_handle`. A live
+        // (unfinished) handle means another path already brought a reactor
+        // up under this name — don't stomp it.
+        if !running.reactor_handle.is_finished() {
+            info!(
+                graph = %reactor_name,
+                "reactor already replaced during restart backoff — skipping restart"
+            );
+            return false;
+        }
+
+        // Full graph restart: new channels, re-spawn everything
+        let (shutdown_tx, shutdown_rx) = shutdown_signal();
+        let stored_shutdown_rx = shutdown_rx.clone();
+        let (boundary_tx, boundary_rx) = mpsc::channel(256);
+        let stored_boundary_tx = boundary_tx.clone();
+
+        let expected_sources: Vec<SourceName> = running
+            .declaration
+            .accumulators
+            .iter()
+            .map(|a| SourceName::new(&a.name))
+            .collect();
+
+        let mut new_acc_handles = Vec::new();
+        let mut restart_acc_health_rxs: Vec<(
+            String,
+            watch::Receiver<super::accumulator::AccumulatorHealth>,
+        )> = Vec::new();
+        for acc_decl in &running.declaration.accumulators {
+            let (health_tx, health_rx) = health_channel();
+            restart_acc_health_rxs.push((acc_decl.name.clone(), health_rx.clone()));
+            let freshness = super::accumulator::FreshnessHandle::new();
+            let spawn_config = AccumulatorSpawnConfig {
+                dal: self.dal.clone(),
+                health_tx: Some(health_tx),
+                graph_name: reactor_name.to_string(),
+                freshness: freshness.clone(),
+            };
+            let (socket_tx, handle) = acc_decl.factory.spawn(
+                acc_decl.name.clone(),
+                boundary_tx.clone(),
+                shutdown_rx.clone(),
+                spawn_config,
+            );
+            self.registry
+                .register_accumulator(acc_decl.name.clone(), socket_tx)
+                .await;
+            self.registry
+                .register_accumulator_health(acc_decl.name.clone(), health_rx)
+                .await;
+            self.registry
+                .register_accumulator_freshness(acc_decl.name.clone(), freshness)
+                .await;
+            // CLOACI-I-0128 follow-up: re-register discoverability meta
+            // on the restart path too (graph + tenant).
+            self.registry
+                .register_accumulator_meta(
+                    acc_decl.name.clone(),
+                    super::registry::AccumulatorDescriptor {
+                        reactor: reactor_name.to_string(),
+                        tenant_id: running.declaration.tenant_id.clone(),
+                    },
+                )
+                .await;
+            new_acc_handles.push((acc_decl.name.clone(), handle));
+        }
+
+        let (manual_tx, manual_rx) = mpsc::channel(64);
+        let (reactor_health_tx, reactor_health_rx) = reactor_health_channel();
+        // Reuse the same subscriber map across restart so subscribers
+        // bound mid-life don't get dropped when the reactor restarts.
+        let restart_dispatcher =
+            make_subscriber_dispatcher(reactor_name.to_string(), running.subscribers.clone());
+        let mut reactor = Reactor::new(
+            restart_dispatcher,
+            running.declaration.reactor.criteria.clone(),
+            running.declaration.reactor.strategy.clone(),
+            boundary_rx,
+            manual_rx,
+            shutdown_rx,
+        )
+        .with_graph_name(reactor_name.to_string())
+        .with_health(reactor_health_tx)
+        .with_expected_sources(expected_sources)
+        .with_accumulator_health(restart_acc_health_rxs)
+        .with_tenant_id(running.declaration.tenant_id.clone())
+        .with_graph_executor(self.graph_executor.read().await.clone());
+        // CLOACI-T-0830: re-install the reactor-constructor decider on
+        // restart. The decider was resolved once at load and is shared
+        // (`Arc<dyn ReactorFireDecider>`, `Send + Sync`), so the restart
+        // reuses it rather than re-loading the WASM component.
+        if let Some(ref ev) = running.evaluator {
+            reactor = reactor.with_evaluator(ev.clone());
+        }
+        if let Some(ref dal) = self.dal {
+            reactor = reactor.with_dal(dal.clone());
+        }
+        let reactor_shared = reactor.handle();
+        let reactor_handle = tokio::spawn(reactor.run());
+
+        // Re-register every endpoint-registry key the reactor was
+        // originally registered under (its own name + any back-compat
+        // aliases for bundled-form callers; T-0545 M1 stores these
+        // explicitly on RunningGraph instead of recovering from
+        // declaration.name).
+        for key in &running.endpoint_registry_keys {
+            self.registry
+                .register_reactor(key.clone(), manual_tx.clone(), reactor_shared.clone())
+                .await;
+        }
+
+        // Re-set auth policies after restart
+        let restart_acc_policy = match &running.declaration.tenant_id {
+            Some(tid) => AccumulatorAuthPolicy::for_tenant(tid),
+            None => AccumulatorAuthPolicy::allow_all(),
+        };
+        let restart_reactor_policy = match &running.declaration.tenant_id {
+            Some(tid) => ReactorAuthPolicy::for_tenant(tid),
+            None => ReactorAuthPolicy::allow_all(),
+        };
+        for acc_decl in &running.declaration.accumulators {
+            self.registry
+                .set_accumulator_policy(acc_decl.name.clone(), restart_acc_policy.clone())
+                .await;
+        }
+        for key in &running.endpoint_registry_keys {
+            self.registry
+                .set_reactor_policy(key.clone(), restart_reactor_policy.clone())
+                .await;
+        }
+
+        running.shutdown_tx = shutdown_tx;
+        running.shutdown_rx = stored_shutdown_rx;
+        running.boundary_tx = stored_boundary_tx;
+        running.accumulator_handles = new_acc_handles;
+        running.reactor_handle = reactor_handle;
+        running.reactor_shared = reactor_shared;
+        running.reactor_health_rx = Some(reactor_health_rx);
+        running
+            .last_success
+            .insert(format!("{}::reactor", reactor_name), now);
+
+        metrics::counter!(
+            "cloacina_supervisor_restarts_total",
+            "graph" => reactor_name.to_string(),
+            "component" => "reactor",
+            "reason" => reason,
+        )
+        .increment(1);
+        emit_component_health(reactor_name, "reactor", "starting");
+        info!(graph = %reactor_name, "reactor restarted successfully");
+        true
+    }
+
+    /// Phase 3 of [`check_and_restart_failed`]: after the unlocked backoff,
+    /// re-acquire the write lock and respawn a single accumulator in place.
+    ///
+    /// Re-validates before acting — while the lock was released the graph
+    /// may have been unloaded, or the slot replaced by a full-graph restart.
+    /// Returns whether a restart actually happened.
+    async fn restart_accumulator_after_backoff(
+        &self,
+        reactor_name: &str,
+        acc_name: &str,
+        reason: &'static str,
+        now: std::time::Instant,
+    ) -> bool {
+        let mut graphs = self.reactors.write().await;
+        let Some(running) = graphs.get_mut(reactor_name) else {
+            info!(
+                graph = %reactor_name,
+                accumulator = %acc_name,
+                "graph unloaded during restart backoff — skipping accumulator restart"
+            );
+            return false;
+        };
+        // Phase 1 left a finished dummy in this slot. A missing slot or a
+        // live handle means another path (unload, full-graph restart)
+        // already handled it — don't stomp.
+        let Some(slot) = running
+            .accumulator_handles
+            .iter()
+            .position(|(n, h)| n.as_str() == acc_name && h.is_finished())
+        else {
+            info!(
+                graph = %reactor_name,
+                accumulator = %acc_name,
+                "accumulator replaced or removed during restart backoff — skipping restart"
+            );
+            return false;
+        };
+
+        // Find the declaration for this accumulator
+        let Some(factory) = running
+            .declaration
+            .accumulators
+            .iter()
+            .find(|d| d.name == acc_name)
+            .map(|d| d.factory.clone())
+        else {
+            error!(
+                graph = %reactor_name,
+                accumulator = %acc_name,
+                "cannot restart: declaration not found"
+            );
+            running.accumulator_handles.remove(slot);
+            return false;
+        };
+
+        // Re-spawn with the CURRENT boundary_tx and shutdown_rx — the
+        // re-validation above guarantees the slot is still the dead one,
+        // and reading the live fields keeps the respawn wired to whatever
+        // channels the graph has now.
+        let (health_tx, health_rx) = health_channel();
+        let freshness = super::accumulator::FreshnessHandle::new();
+        let spawn_config = AccumulatorSpawnConfig {
+            dal: self.dal.clone(),
+            health_tx: Some(health_tx),
+            graph_name: reactor_name.to_string(),
+            freshness: freshness.clone(),
+        };
+        let (socket_tx, new_handle) = factory.spawn(
+            acc_name.to_string(),
+            running.boundary_tx.clone(),
+            running.shutdown_rx.clone(),
+            spawn_config,
+        );
+
+        // Re-register socket, health, and auth policy in endpoint registry
+        self.registry
+            .register_accumulator(acc_name.to_string(), socket_tx)
+            .await;
+        self.registry
+            .register_accumulator_health(acc_name.to_string(), health_rx)
+            .await;
+        self.registry
+            .register_accumulator_freshness(acc_name.to_string(), freshness)
+            .await;
+        let ind_acc_policy = match &running.declaration.tenant_id {
+            Some(tid) => AccumulatorAuthPolicy::for_tenant(tid),
+            None => AccumulatorAuthPolicy::allow_all(),
+        };
+        self.registry
+            .set_accumulator_policy(acc_name.to_string(), ind_acc_policy)
+            .await;
+
+        running
+            .last_success
+            .insert(format!("{}::{}", reactor_name, acc_name), now);
+        running.accumulator_handles[slot].1 = new_handle;
+        metrics::counter!(
+            "cloacina_supervisor_restarts_total",
+            "graph" => reactor_name.to_string(),
+            "component" => acc_name.to_string(),
+            "reason" => reason,
+        )
+        .increment(1);
+        emit_component_health(reactor_name, acc_name, "starting");
+
+        info!(
+            graph = %reactor_name,
+            accumulator = %acc_name,
+            "accumulator restarted individually"
+        );
+
+        // Mark accumulators that are still running as successful
+        for (name, _) in &running.accumulator_handles {
+            let key = format!("{}::{}", reactor_name, name);
+            running.last_success.entry(key).or_insert(now);
+        }
+        true
     }
 
     /// Start a background supervision loop that checks for crashed tasks.

--- a/crates/cloacina/src/cron_trigger_scheduler.rs
+++ b/crates/cloacina/src/cron_trigger_scheduler.rs
@@ -1165,7 +1165,7 @@ impl Scheduler {
             // logged warn and treated as skip — fail-closed semantics
             // mirror the spec: a broken filter shouldn't fire workflows.
             if let Some(expr) = predicate_expr {
-                match self.evaluate_predicate(sub.id, expr, &context) {
+                match self.evaluate_predicate(sub.id, expr, &sub.tenant_id, &context) {
                     Ok(true) => {} // proceed to dispatch
                     Ok(false) => {
                         debug!(
@@ -1290,6 +1290,7 @@ impl Scheduler {
         &self,
         sub_id: UniversalUuid,
         expr: &str,
+        tenant: &str,
         context: &Context<serde_json::Value>,
     ) -> Result<bool, String> {
         // Cache lookup. Re-compile only when the stored expression
@@ -1309,7 +1310,7 @@ impl Scheduler {
                 }
             }
         };
-        eval_cel_predicate_program(&program, context)
+        eval_cel_predicate_program(&program, tenant, context)
     }
 
     /// TTL prune of `reactor_firings` (CLOACI-I-0100 / T-0601).
@@ -1407,6 +1408,7 @@ impl Scheduler {
 /// evaluation logic can be tested independently.
 fn eval_cel_predicate_program(
     program: &cel_interpreter::Program,
+    tenant: &str,
     context: &Context<serde_json::Value>,
 ) -> Result<bool, String> {
     use cel_interpreter::{Context as CelContext, Value as CelValue};
@@ -1428,8 +1430,11 @@ fn eval_cel_predicate_program(
             context.get("reactor_name").cloned().unwrap_or_default(),
         )
         .map_err(|e| format!("cel add_variable(reactor): {}", e))?;
+    // CLOACI-T-0915: bind the real tenant id — this was a `""` stub while
+    // the docs advertised the tenant, so any predicate referencing `tenant`
+    // silently never matched (and, fail-closed, silently never fired).
     cel_ctx
-        .add_variable("tenant", serde_json::Value::String(String::new()))
+        .add_variable("tenant", serde_json::Value::String(tenant.to_string()))
         .map_err(|e| format!("cel add_variable(tenant): {}", e))?;
 
     match program.execute(&cel_ctx) {
@@ -1783,14 +1788,14 @@ mod tests {
             "quote",
             serde_json::json!({"price": 150, "region": "us-east"}),
         )]);
-        assert!(eval_cel_predicate_program(&prog, &ctx).unwrap());
+        assert!(eval_cel_predicate_program(&prog, "public", &ctx).unwrap());
     }
 
     #[test]
     fn cel_predicate_false_when_payload_does_not_match() {
         let prog = cel_interpreter::Program::compile("payload.quote.price > 100").unwrap();
         let ctx = ctx_with_payload(&[("quote", serde_json::json!({"price": 50}))]);
-        assert!(!eval_cel_predicate_program(&prog, &ctx).unwrap());
+        assert!(!eval_cel_predicate_program(&prog, "public", &ctx).unwrap());
     }
 
     #[test]
@@ -1805,14 +1810,28 @@ mod tests {
             .unwrap();
         // With the bookkeeping keys stripped, payload.reactor_name
         // doesn't exist → has() returns false.
-        assert!(!eval_cel_predicate_program(&prog, &ctx).unwrap());
+        assert!(!eval_cel_predicate_program(&prog, "public", &ctx).unwrap());
+    }
+
+    #[test]
+    fn cel_predicate_tenant_binds_real_tenant_id() {
+        // CLOACI-T-0915: `tenant` was a stub bound to "" — any predicate
+        // referencing it silently never matched. It must carry the
+        // subscription's tenant id.
+        let prog = cel_interpreter::Program::compile("tenant == 'acme'").unwrap();
+        let ctx = ctx_with_payload(&[("quote", serde_json::json!({"price": 50}))]);
+        assert!(eval_cel_predicate_program(&prog, "acme", &ctx).unwrap());
+        assert!(!eval_cel_predicate_program(&prog, "public", &ctx).unwrap());
+        // The historical stub value must no longer match a real predicate.
+        let prog_empty = cel_interpreter::Program::compile("tenant == ''").unwrap();
+        assert!(!eval_cel_predicate_program(&prog_empty, "acme", &ctx).unwrap());
     }
 
     #[test]
     fn cel_predicate_non_bool_result_is_error() {
         let prog = cel_interpreter::Program::compile("payload.quote.price").unwrap();
         let ctx = ctx_with_payload(&[("quote", serde_json::json!({"price": 50}))]);
-        let err = eval_cel_predicate_program(&prog, &ctx).unwrap_err();
+        let err = eval_cel_predicate_program(&prog, "public", &ctx).unwrap_err();
         assert!(
             err.contains("must evaluate to bool"),
             "expected bool-type error, got: {}",

--- a/crates/cloacina/tests/integration/computation_graph.rs
+++ b/crates/cloacina/tests/integration/computation_graph.rs
@@ -2014,6 +2014,348 @@ mod resilience_tests {
 
         scheduler.shutdown_all().await;
     }
+
+    /// CLOACI-T-0915 finding 3: the supervisor must NOT hold the reactors
+    /// write lock across its restart-backoff sleeps — list/health reads have
+    /// to stay responsive while a restart is pending.
+    ///
+    /// Loads a graph whose graph_fn panics on every fire (killing the reactor
+    /// task), drives one supervised restart (1s backoff), crashes it again so
+    /// the next backoff is 2s, then — while `check_and_restart_failed` is
+    /// mid-backoff — asserts `list_graphs()` completes well under the backoff
+    /// duration. Before the fix, the read blocked behind the sleeping write
+    /// lock and this timeout fired.
+    #[tokio::test]
+    async fn test_health_reads_responsive_during_restart_backoff() {
+        use std::sync::atomic::{AtomicU32, Ordering};
+
+        let registry = EndpointRegistry::new();
+        let scheduler = Arc::new(ComputationGraphScheduler::new(registry.clone()));
+
+        /// Plain passthrough factory — the crash lives in the graph_fn, not
+        /// the accumulator.
+        struct PassthroughFactory;
+
+        impl AccumulatorFactory for PassthroughFactory {
+            fn spawn(
+                &self,
+                name: String,
+                boundary_tx: tokio_mpsc::Sender<(SourceName, Vec<u8>)>,
+                shutdown_rx: tokio::sync::watch::Receiver<bool>,
+                config: AccumulatorSpawnConfig,
+            ) -> (tokio_mpsc::Sender<Vec<u8>>, JoinHandle<()>) {
+                let (socket_tx, socket_rx) = tokio_mpsc::channel(64);
+                let sender = BoundarySender::new(boundary_tx, SourceName::new(&name));
+                let ctx = AccumulatorContext {
+                    output: sender,
+                    name: name.clone(),
+                    shutdown: shutdown_rx,
+                    checkpoint: None,
+                    health: config.health_tx,
+                };
+                let handle = tokio::spawn(accumulator_runtime(
+                    TestPassthroughAccumulator,
+                    ctx,
+                    socket_rx,
+                    AccumulatorRuntimeConfig::default(),
+                ));
+                (socket_tx, handle)
+            }
+        }
+
+        // A graph_fn that panics on every fire. The panic unwinds through the
+        // in-process executor and the reactor's executor loop, killing the
+        // reactor task — is_finished() goes true and the supervisor sees a
+        // reactor crash.
+        let fires = Arc::new(AtomicU32::new(0));
+        let f = fires.clone();
+        let graph_fn: CompiledGraphFn = Arc::new(move |_cache: InputCache| {
+            let f = f.clone();
+            Box::pin(async move {
+                let n = f.fetch_add(1, Ordering::SeqCst);
+                if n < u32::MAX {
+                    panic!("intentional reactor-killing panic (T-0915 backoff test)");
+                }
+                GraphResult::completed(vec![])
+            })
+        });
+
+        let decl = ComputationGraphDeclaration {
+            name: "t0915_backoff_graph".to_string(),
+            accumulators: vec![AccumulatorDeclaration {
+                name: "t0915_alpha".to_string(),
+                factory: Arc::new(PassthroughFactory),
+            }],
+            reactor: ReactorDeclaration {
+                criteria: ReactionCriteria::WhenAny,
+                strategy: InputStrategy::Latest,
+                graph_fn,
+                constructor: None,
+            },
+            tenant_id: None,
+            reactor_name: None,
+            topology: None,
+        };
+        scheduler.load_graph(decl).await.unwrap();
+
+        async fn crash_reactor(registry: &EndpointRegistry, scheduler: &ComputationGraphScheduler) {
+            registry
+                .send_to_accumulator(
+                    "t0915_alpha",
+                    serde_json::to_vec(&AlphaData { value: 1.0 }).unwrap(),
+                )
+                .await
+                .unwrap();
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+            loop {
+                let down = scheduler
+                    .list_graphs()
+                    .await
+                    .iter()
+                    .any(|g| g.name == "t0915_backoff_graph" && !g.running);
+                if down {
+                    return;
+                }
+                if std::time::Instant::now() > deadline {
+                    panic!("timed out waiting for the reactor task to crash");
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            }
+        }
+
+        // Crash 1 → supervised restart (failure count 1, 1s backoff runs
+        // inside this call).
+        crash_reactor(&registry, &scheduler).await;
+        let mut restarted = 0;
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        while std::time::Instant::now() < deadline {
+            restarted = scheduler.check_and_restart_failed().await;
+            if restarted >= 1 {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        assert_eq!(restarted, 1, "first supervised reactor restart");
+
+        // Crash 2 → next restart backs off for 2s (failure count 2).
+        crash_reactor(&registry, &scheduler).await;
+        let sup_sched = scheduler.clone();
+        let supervisor = tokio::spawn(async move { sup_sched.check_and_restart_failed().await });
+
+        // Let the supervisor take the lock, plan the restart, release the
+        // lock, and enter its 2s backoff sleep.
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+
+        // The health surface must answer while the backoff is pending.
+        let statuses = tokio::time::timeout(
+            std::time::Duration::from_millis(500),
+            scheduler.list_graphs(),
+        )
+        .await
+        .expect("list_graphs must not block behind the supervisor's restart backoff (T-0915)");
+        assert!(
+            statuses.iter().any(|g| g.name == "t0915_backoff_graph"),
+            "graph should still be listed while its restart is pending"
+        );
+
+        // The pass itself still completes and restarts the reactor.
+        let restarted = tokio::time::timeout(std::time::Duration::from_secs(10), supervisor)
+            .await
+            .expect("supervisor pass should finish after the backoff")
+            .unwrap();
+        assert_eq!(
+            restarted, 1,
+            "supervisor should restart the crashed reactor after the unlocked backoff"
+        );
+
+        scheduler.shutdown_all().await;
+    }
+
+    /// CLOACI-T-0915 finding 2: a sequential queue persisted before a crash
+    /// mid-drain must come back on a fresh `Reactor::run` and drain ahead of
+    /// new boundaries, in order.
+    #[tokio::test]
+    async fn test_reactor_restart_restores_sequential_queue() {
+        let dal = test_dal().await;
+        let graph = "t0915_seq_restore";
+
+        // Persist reactor state the way a crash mid-drain leaves it: two
+        // queued boundaries that were never applied to the cache.
+        let cache_entries: std::collections::HashMap<SourceName, Vec<u8>> = Default::default();
+        let dirty: std::collections::HashMap<SourceName, bool> = Default::default();
+        let queued: std::collections::VecDeque<(SourceName, Vec<u8>)> = vec![
+            (
+                SourceName::new("alpha"),
+                serialize(&AlphaData { value: 1.0 }).unwrap(),
+            ),
+            (
+                SourceName::new("alpha"),
+                serialize(&AlphaData { value: 2.0 }).unwrap(),
+            ),
+        ]
+        .into();
+        dal.checkpoint()
+            .save_reactor_state(
+                graph,
+                serde_json::to_vec(&cache_entries).unwrap(),
+                serde_json::to_vec(&dirty).unwrap(),
+                Some(serde_json::to_vec(&queued).unwrap()),
+            )
+            .await
+            .unwrap();
+
+        // Fresh reactor over the same DAL: the restored queue must seed the
+        // sequential executor.
+        let (boundary_tx, boundary_rx) = tokio::sync::mpsc::channel(10);
+        let (_manual_tx, manual_rx) = tokio::sync::mpsc::channel(10);
+        let (shutdown_tx, shutdown_rx) = shutdown_signal();
+
+        let seen: Arc<tokio::sync::Mutex<Vec<f64>>> = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let seen_inner = seen.clone();
+        let graph_fn: CompiledGraphFn = Arc::new(move |cache: InputCache| {
+            let seen = seen_inner.clone();
+            Box::pin(async move {
+                if let Some(Ok(alpha)) = cache.get::<AlphaData>("alpha") {
+                    seen.lock().await.push(alpha.value);
+                }
+                GraphResult::completed(vec![])
+            })
+        });
+
+        let reactor = Reactor::new(
+            graph_fn,
+            ReactionCriteria::WhenAny,
+            InputStrategy::Sequential,
+            boundary_rx,
+            manual_rx,
+            shutdown_rx,
+        )
+        .with_graph_name(graph.to_string())
+        .with_dal(dal.clone());
+        let reactor_handle = tokio::spawn(reactor.run());
+
+        // A sequential drain runs on the next strategy signal; send one live
+        // boundary so the restored items (1.0, 2.0) drain ahead of it.
+        boundary_tx
+            .send((
+                SourceName::new("alpha"),
+                serialize(&AlphaData { value: 3.0 }).unwrap(),
+            ))
+            .await
+            .unwrap();
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while seen.lock().await.len() < 3 && std::time::Instant::now() < deadline {
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        assert_eq!(
+            *seen.lock().await,
+            vec![1.0, 2.0, 3.0],
+            "restored queue items must drain first, in order, before the live boundary"
+        );
+
+        shutdown_tx.send(true).unwrap();
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(2), reactor_handle).await;
+    }
+
+    /// CLOACI-T-0915 finding 2 (dirty flags): persisted dirty flags must
+    /// overlay the expected-source seed on a fresh `Reactor::run`, so a
+    /// WhenAll graph that had seen `alpha` before the crash fires when only
+    /// `beta` arrives in the new life. A stale flag for a source that is no
+    /// longer expected must be dropped (it would otherwise wedge `all_set()`
+    /// forever).
+    #[tokio::test]
+    async fn test_reactor_restart_restores_dirty_flags() {
+        let dal = test_dal().await;
+        let graph = "t0915_dirty_restore";
+
+        // Persisted state from the previous life: alpha had arrived (cache
+        // entry + dirty flag) while WhenAll still waited on beta. The unset
+        // "gone" flag simulates a de-scoped source and must NOT be overlaid.
+        let mut cache_entries: std::collections::HashMap<SourceName, Vec<u8>> = Default::default();
+        cache_entries.insert(
+            SourceName::new("alpha"),
+            serialize(&AlphaData { value: 4.0 }).unwrap(),
+        );
+        let mut dirty: std::collections::HashMap<SourceName, bool> = Default::default();
+        dirty.insert(SourceName::new("alpha"), true);
+        dirty.insert(SourceName::new("gone"), false);
+        dal.checkpoint()
+            .save_reactor_state(
+                graph,
+                serde_json::to_vec(&cache_entries).unwrap(),
+                serde_json::to_vec(&dirty).unwrap(),
+                None,
+            )
+            .await
+            .unwrap();
+
+        let (boundary_tx, boundary_rx) = tokio::sync::mpsc::channel(10);
+        let (_manual_tx, manual_rx) = tokio::sync::mpsc::channel(10);
+        let (shutdown_tx, shutdown_rx) = shutdown_signal();
+
+        let fires = Arc::new(std::sync::atomic::AtomicU32::new(0));
+        let fires_inner = fires.clone();
+        let captured: Arc<tokio::sync::Mutex<Option<InputCache>>> =
+            Arc::new(tokio::sync::Mutex::new(None));
+        let captured_inner = captured.clone();
+        let graph_fn: CompiledGraphFn = Arc::new(move |cache: InputCache| {
+            let fires = fires_inner.clone();
+            let captured = captured_inner.clone();
+            Box::pin(async move {
+                fires.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                *captured.lock().await = Some(cache.clone());
+                GraphResult::completed(vec![])
+            })
+        });
+
+        let reactor = Reactor::new(
+            graph_fn,
+            ReactionCriteria::WhenAll,
+            InputStrategy::Latest,
+            boundary_rx,
+            manual_rx,
+            shutdown_rx,
+        )
+        .with_graph_name(graph.to_string())
+        .with_expected_sources(vec![SourceName::new("alpha"), SourceName::new("beta")])
+        .with_dal(dal.clone());
+        let reactor_handle = tokio::spawn(reactor.run());
+
+        // Only beta arrives in this life. WhenAll can fire ONLY because
+        // alpha's dirty flag was restored from the checkpoint.
+        boundary_tx
+            .send((
+                SourceName::new("beta"),
+                serialize(&AlphaData { value: 5.0 }).unwrap(),
+            ))
+            .await
+            .unwrap();
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while fires.load(std::sync::atomic::Ordering::SeqCst) < 1
+            && std::time::Instant::now() < deadline
+        {
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        assert_eq!(
+            fires.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "WhenAll should fire on beta alone because alpha's dirty flag was restored"
+        );
+
+        let snapshot = captured.lock().await;
+        let cache = snapshot.as_ref().expect("fire should capture the cache");
+        assert_eq!(
+            cache.get::<AlphaData>("alpha").unwrap().unwrap().value,
+            4.0,
+            "restored cache should carry alpha from the previous life"
+        );
+        assert!(cache.has("beta"), "live beta boundary should be cached");
+
+        shutdown_tx.send(true).unwrap();
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(2), reactor_handle).await;
+    }
 } // mod resilience_tests
 
 // =============================================================================


### PR DESCRIPTION
## Summary

The three computation-graph runtime defects from the architecture deep dive (CLOACI-T-0915), each verified in source before fixing.

**1. CEL `tenant` variable was a stub bound to `""`.** The docs (and `evaluate_predicate`'s own doc comment) advertised the tenant id, but evaluation bound the empty string — any reactor→workflow subscription predicate referencing `tenant` silently never matched and, per fail-closed semantics, silently never fired, with the watermark advancing past each firing forever. The real `sub.tenant_id` is now threaded from the subscription row into the CEL context. Unit test pins real-tenant matching and that the historical stub value no longer matches anything.

**2. Reactor state restore was write-only.** `Reactor::run` persisted the sequential queue and dirty flags before every drain ("so a crash mid-drain doesn't lose items") — then discarded both on restore, making Sequential's no-loss/ordering promise and WhenAll's accumulated dirty state per-process-lifetime only. Both now restore: the seq queue seeds the executor's VecDeque (restored items drain first, in order), and dirty flags overlay the expected-source seed — guarded so a stale flag for a de-scoped source can't wedge `all_set()`. Integration tests cover ordered drain-after-restart and WhenAll firing from restored flags.

**3. Supervisor slept its backoff holding the reactors write lock.** `check_and_restart_failed` held `self.reactors.write()` across recovery-event writes and backoff sleeps (up to 60s) on both crash paths — during a restart storm, `/v1/health/graphs`, `load_reactor`, and package loads all blocked behind the sleeps: the health surface went dark exactly when operators needed it. Restructured into plan-under-lock → classify/record/sleep unlocked → re-acquire-per-restart with re-validation guards (entry unloaded or live handle installed while unlocked → skip). Restart bodies moved verbatim; a test asserts health reads complete in <500ms mid-backoff (previously blocked ~1.5s in the same scenario).

Intended behavioral nuance from 3: a component crashing during another's backoff is picked up at the next supervision tick rather than mid-pass.

## Test plan
- New unit test: CEL tenant binding (match/non-match/stub-no-longer-matches)
- New integration tests: sequential-queue restore ordering, dirty-flag restore + stale-flag guard, health-responsiveness mid-backoff
- `cargo check -p cloacina` clean both backends; pre-commit dual-backend check passed on all commits
- Full lanes on this PR