### PR TITLE
chore(T-0917): close the CI verification-lattice holes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
       charts: ${{ steps.filter.outputs.charts }}
       api: ${{ steps.filter.outputs.api }}
       ui: ${{ steps.filter.outputs.ui }}
+      scripts: ${{ steps.filter.outputs.scripts }}
     steps:
       - uses: actions/checkout@v4
 
@@ -60,6 +61,20 @@ jobs:
               - 'crates/cloacina-testing/**'
               - 'crates/cloacina-workflow/**'
               - 'crates/cloacina-workflow-plugin/**'
+              # CLOACI-T-0917: these crates + the python surfaces were absent —
+              # a PR touching only them ran ZERO test lanes. Server lib/auth
+              # tests run in the integration lane (cloacina.yml), and the
+              # python bindings/scenarios/client are exercised by
+              # `angreal test integration`, so all of these must reach the
+              # reusable test matrix.
+              - 'crates/cloacina-agent/**'
+              - 'crates/cloacina-client/**'
+              - 'crates/cloacina-compiler/**'
+              - 'crates/cloacina-constructor-contract/**'
+              - 'crates/cloacina-python/**'
+              - 'crates/cloacina-server/**'
+              - 'tests/python/**'
+              - 'clients/python/**'
               - 'Cargo.*'
               - 'rust-toolchain.toml'
             workflows:
@@ -89,15 +104,21 @@ jobs:
               - 'ui/**'
               - 'clients/typescript/**'
               - 'docs/static/openapi.json'
+            # CLOACI-T-0917: CI guard scripts (credential-logging, version
+            # lockstep, publish tiers) must at minimum re-run quick-checks
+            # when they change.
+            scripts:
+              - 'scripts/**'
 
-  # Quick gate - only runs if code, harness, or workflows changed
+  # Quick gate - only runs if code, harness, scripts, or workflows changed
   quick-checks:
     name: Quick Checks
     needs: changes
     if: |
       needs.changes.outputs.rust == 'true' ||
       needs.changes.outputs.workflows == 'true' ||
-      needs.changes.outputs.harness == 'true'
+      needs.changes.outputs.harness == 'true' ||
+      needs.changes.outputs.scripts == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -120,6 +141,17 @@ jobs:
 
       - name: Credential-logging guard (OPS-03 / T-0443)
         run: python3 scripts/check_credential_logging.py
+
+      # CLOACI-T-0917: version lockstep was pre-commit-only (one --no-verify
+      # from drift reaching main). Stdlib-only script, no build needed.
+      - name: Version lockstep (single source of truth)
+        run: python3 .angreal/version_lockstep.py check
+
+      # CLOACI-T-0917: the hand-maintained crates.io publish tiers in
+      # unified_release.yml must cover every publishable workspace crate
+      # exactly once (0.10.0 postmortem 8961abb5 — two crates missing).
+      - name: Publish-tier completeness (unified_release.yml)
+        run: python3 scripts/check_publish_tiers.py
 
       - name: Check formatting
         run: cargo fmt --all -- --check

--- a/.github/workflows/examples-docs.yml
+++ b/.github/workflows/examples-docs.yml
@@ -129,6 +129,10 @@ jobs:
         with:
           compose-file: ".angreal/docker-compose.yaml"
 
+      # CLOACI-T-0917: retries kept deliberately — this leg runs a real docker
+      # stack + crates.io fetches, so INFRA flake tolerance is still warranted.
+      # Remove the retry wrapper if/when a run history shows attempts>1 is
+      # never what saves the leg (retries can mask real product flakes).
       - name: Run tutorial ${{ matrix.tutorial }}
         uses: nick-fields/retry@v3
         with:
@@ -238,6 +242,10 @@ jobs:
         with:
           compose-file: ".angreal/docker-compose.yaml"
 
+      # CLOACI-T-0917: retries kept deliberately — every example leg boots a
+      # real docker stack, so INFRA flake tolerance is still warranted. Remove
+      # the retry wrapper if/when a run history shows attempts>1 is never what
+      # saves the leg (retries can mask real product flakes).
       - name: Run ${{ matrix.example }} example
         uses: nick-fields/retry@v3
         with:
@@ -253,7 +261,9 @@ jobs:
     name: Python Tutorial Tests
     needs: [build-cache]
     timeout-minutes: 30
-    continue-on-error: true
+    # CLOACI-T-0917: continue-on-error: true removed — it dated from the
+    # PyO3/tokio GIL flake era; post-I-0140 that flake class is closed, so
+    # python tutorial failures must fail CI like every other lane.
     strategy:
       fail-fast: false
       matrix:
@@ -363,6 +373,11 @@ jobs:
         with:
           compose-file: ".angreal/docker-compose.yaml"
 
+      # CLOACI-T-0917: retries kept deliberately — the postgres legs run a
+      # real docker stack and every leg fetches deps, so INFRA flake tolerance
+      # is still warranted. Now that continue-on-error is gone this retry is
+      # the ONLY tolerance channel on this lane; remove it if/when run history
+      # shows attempts>1 is never what saves the leg.
       - name: Run Python tutorial ${{ matrix.tutorial }} (${{ matrix.backend }})
         uses: nick-fields/retry@v3
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -42,6 +42,52 @@ jobs:
     uses: ./.github/workflows/examples-docs.yml
 
   # -----------------------------------------------------------------------
+  # Constructor provider suite (CLOACI-T-0917)
+  #
+  # The 14 feature-gated test targets (constructors-wasm implies
+  # constructor-packaging) previously ran in NO lane — only wave-day certify
+  # exercised the path. Nightly (not per-PR): the tail targets compile
+  # fixture crates inside the tests (wasm components + native cdylibs),
+  # which blew the per-PR time budget in local measurement. This workflow is
+  # also the release gate (unified_release.yml calls it), so the suite is
+  # release-blocking.
+  #
+  # The packaging path shells out to `cargo build --target wasm32-wasip2`
+  # on the fixture crates under examples/constructor-contract (and builds
+  # host cdylibs for the native provider fixtures under providers/), so the
+  # wasm target must be installed. Targets are scoped ('*constructor*' +
+  # provider_bundle) because an unscoped `cargo test -p cloacina` would also
+  # run the postgres-backed `fixtures` target, which needs a live DB this
+  # job doesn't have.
+  # -----------------------------------------------------------------------
+
+  constructor-suite:
+    name: Constructor Suite (wasm + packaging)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Rust (with wasm32-wasip2)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-wasip2
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "cloacina-constructor-suite"
+
+      - name: Install PostgreSQL dev libraries
+        # cloacina's default features include postgres → links libpq.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libpq-dev
+
+      - name: Run constructor suite
+        run: cargo test -p cloacina --features constructors-wasm --test '*constructor*' --test provider_bundle
+
+  # -----------------------------------------------------------------------
   # Code coverage — cargo-tarpaulin on cloacina core
   # -----------------------------------------------------------------------
 
@@ -321,7 +367,7 @@ jobs:
 
   notify-failure:
     name: Notify on Failure
-    needs: [cloacina-tests, examples-docs, coverage, macos-integration, sdk-contract, ui-e2e, nightly-docker]
+    needs: [cloacina-tests, examples-docs, constructor-suite, coverage, macos-integration, sdk-contract, ui-e2e, nightly-docker]
     if: failure()
     runs-on: ubuntu-latest
     permissions:
@@ -385,7 +431,7 @@ jobs:
 
   close-resolved:
     name: Close Resolved Issues
-    needs: [cloacina-tests, examples-docs, coverage, macos-integration, sdk-contract, ui-e2e, nightly-docker]
+    needs: [cloacina-tests, examples-docs, constructor-suite, coverage, macos-integration, sdk-contract, ui-e2e, nightly-docker]
     if: success()
     runs-on: ubuntu-latest
     permissions:
@@ -433,7 +479,7 @@ jobs:
 
   prune-caches:
     name: Prune Stale Caches
-    needs: [cloacina-tests, examples-docs, coverage, macos-integration, sdk-contract, ui-e2e, nightly-docker]
+    needs: [cloacina-tests, examples-docs, constructor-suite, coverage, macos-integration, sdk-contract, ui-e2e, nightly-docker]
     if: always()
     runs-on: ubuntu-latest
     permissions:

--- a/.metis/backlog/bugs/CLOACI-T-0915.md
+++ b/.metis/backlog/bugs/CLOACI-T-0915.md
@@ -4,7 +4,7 @@ level: task
 title: "CG runtime defects — CEL tenant stub, sequential-queue restore, lock-held supervisor backoff"
 short_code: "CLOACI-T-0915"
 created_at: 2026-08-02T16:33:18.144884+00:00
-updated_at: 2026-08-02T22:23:04.124639+00:00
+updated_at: 2026-08-03T01:32:47.536198+00:00
 parent:
 blocked_by: []
 archived: false
@@ -12,7 +12,7 @@ archived: false
 tags:
   - "#task"
   - "#bug"
-  - "#phase/active"
+  - "#phase/completed"
 
 
 exit_criteria_met: false
@@ -45,12 +45,11 @@ Related but tracked elsewhere: cross-replica reactive state is T-0851; the crash
 
 ## Acceptance Criteria
 
-## Acceptance Criteria
-
-- [ ] Predicate referencing `tenant` matches the firing tenant (test with two tenants: one matches, one skips)
-- [ ] Reactor restart after crash restores seq queue + dirty flags (or persistence removed + docs state ephemerality)
-- [ ] Health endpoints respond during a forced restart-backoff storm (test holds a failing reactor and asserts /v1/health/graphs latency)
+- [x] Predicate referencing `tenant` matches the firing tenant (cel_predicate_tenant_binds_real_tenant_id: match, non-match, and stub-value-no-longer-matches)
+- [x] Reactor restart restores seq queue + dirty flags (test_reactor_restart_restores_sequential_queue: restored items drain first in order; test_reactor_restart_restores_dirty_flags: WhenAll fires from restored flag, stale de-scoped flag not overlaid)
+- [x] Health reads responsive during restart backoff (test_health_reads_responsive_during_restart_backoff: <500ms mid-backoff vs ~1.5s blocked before)
 
 ## Status Updates
 
 - 2026-08-02: Filed from the architecture deep dive (cg-runtime report; DEEPDIVE.md risk register). Findings verified against main @ 5216e632.
+- 2026-08-02: DONE — merged to main in PR #230 (squash). (1) tenant threaded from the subscription row through evaluate_predicate into the CEL context. (2) Both persisted states now restore: seq queue seeds the executor VecDeque; dirty flags overlay the expected-source seed, only for sources still expected (stale flag cannot wedge all_set). (3) check_and_restart_failed restructured to plan-under-lock -> classify/record/sleep unlocked -> re-acquire per restart with re-validation (entry unloaded or live handle installed while unlocked -> skip); restart bodies verbatim. Intended nuance: crashes during another component's backoff wait for the next supervision tick. NOT done here (deliberate): the load-time lint for unbound predicate variables (finding 1 'consider') and the CEL-error watermark/dead-letter behavior — that is DEEPDIVE register #5, still unticketed as its own item.

--- a/.metis/backlog/bugs/CLOACI-T-0916.md
+++ b/.metis/backlog/bugs/CLOACI-T-0916.md
@@ -4,7 +4,7 @@ level: task
 title: "Server HA truthfulness — in-memory agent roster and WS tickets contradict the chart HA claim"
 short_code: "CLOACI-T-0916"
 created_at: 2026-08-02T16:33:28.701827+00:00
-updated_at: 2026-08-02T23:13:55.174712+00:00
+updated_at: 2026-08-04T01:22:06.237472+00:00
 parent:
 blocked_by: []
 archived: false
@@ -12,7 +12,7 @@ archived: false
 tags:
   - "#task"
   - "#bug"
-  - "#phase/active"
+  - "#phase/completed"
 
 
 exit_criteria_met: false
@@ -46,13 +46,12 @@ Fix options (choose per component): move roster + tickets to DB rows (both are t
 
 ## Acceptance Criteria
 
-## Acceptance Criteria
-
-- [ ] Agent heartbeats + selection correct behind a round-robin LB with 2 replicas (or chart hard-documents affinity and refuses/warns on replicas>1 without it)
-- [ ] WS tickets redeemable on any replica (or same affinity gate)
-- [ ] A crashed CG no longer fails /ready platform-wide; its state is visible via health routes
-- [ ] docs service/explanation/horizontal-scaling.md updated to the resulting truth
+- [x] Agent roster DB-backed (045_create_fleet_agents: upsert-register, CAS heartbeat, recency-filtered list_live, exactly-once CAS-delete sweep); all cross-replica reads converted; two-DAL-handle tests prove selection/reclaim see other replicas' agents
+- [x] WS tickets DB-backed (044_create_ws_tickets, LoginFlowStore pattern; atomic CAS redeem); cross-replica redeem + 8-concurrent-redeemers-exactly-one-wins tests
+- [x] /ready platform-scoped; crashed CG stays visible via /v1/health/graphs (test: /ready 200 with crashed graph listed)
+- [x] horizontal-scaling.md (+ api-server, kubernetes how-tos) updated; residual affinity STATED (key-pool self-heal for secret dispatch; reactive placement = T-0851)
 
 ## Status Updates
 
 - 2026-08-02: Filed from the architecture deep dive (control-plane report; DEEPDIVE.md risk register). Verified against main @ 5216e632.
+- 2026-08-03: DONE — merged to main in PR #231 (squash). Key verification that shaped the design: work packets already ride the delivery outbox and NoRoute leaves rows pending for the socket-holding replica (A-0006) — dispatch never needed affinity; the fix was reads-only. Deliberately replica-local: capacity snapshot for sync TaskExecutor trait methods; D-5 one-time key pools (now self-establishing on every replica via full-deficit reporting). Landing frictions worth remembering: the /ready reword changed the OpenAPI spec (spec-check gate) AND the generated TS client types (check:generated gate) — both regen steps are mandatory for any route-annotation change; and an unverified emit redirect truncated openapi.json to zero bytes once (always verify emitted artifacts before committing).

--- a/.metis/backlog/bugs/CLOACI-T-0918.md
+++ b/.metis/backlog/bugs/CLOACI-T-0918.md
@@ -4,15 +4,15 @@ level: task
 title: "Installer and packaging leftovers — root install.sh 404s Intel macs, stale sandbox comments, dead code"
 short_code: "CLOACI-T-0918"
 created_at: 2026-08-02T16:33:41.487632+00:00
-updated_at: 2026-08-02T16:33:41.487632+00:00
+updated_at: 2026-08-04T01:08:07.306953+00:00
 parent:
 blocked_by: []
 archived: false
 
 tags:
   - "#task"
-  - "#phase/backlog"
   - "#bug"
+  - "#phase/active"
 
 
 exit_criteria_met: false
@@ -42,6 +42,10 @@ Sweep the small concrete leftovers the deep dive found in installers and the pac
 5. Unload rejection (bound-subscriber guard) drops the scheduler tracking state for the rejected package, and a partial load can orphan cron schedules — both leave operator-visible ghosts. Add cleanup on the rejection path and a partial-load rollback for schedules.
 6. COMPILER AMBIENT ENV LEAK (DEEPDIVE register #11): post-sandbox-excision, compile-phase build.rs/proc-macros inherit the compiler's FULL environment including DATABASE_URL — the cargo spawn does no env_clear. Fix: env_clear + an explicit allowlist (PATH, CARGO_HOME, RUSTUP_HOME, TMPDIR, the injected build wiring vars) on the cargo Command. Cheap, and removes the sharpest edge of the accepted no-sandbox posture.
 7. --cargo-flag REPLACES the entire default flag list including --frozen --offline (a single override silently re-enables network during the compile phase). Fix: make --cargo-flag additive; keep a separate explicit --cargo-flags-replace escape hatch for the rare full-override case.
+
+## Acceptance Criteria
+
+## Acceptance Criteria
 
 ## Acceptance Criteria
 

--- a/.metis/backlog/tech-debt/CLOACI-T-0872.md
+++ b/.metis/backlog/tech-debt/CLOACI-T-0872.md
@@ -4,15 +4,15 @@ level: task
 title: "Independent provider release path — publish/tag first-party providers on their own cadence (not core's v* tag)"
 short_code: "CLOACI-T-0872"
 created_at: 2026-07-08T11:43:21.080493+00:00
-updated_at: 2026-07-31T05:39:49.412122+00:00
-parent:
+updated_at: 2026-08-01T17:55:04.851680+00:00
+parent: 
 blocked_by: []
 archived: false
 
 tags:
   - "#task"
   - "#tech-debt"
-  - "#phase/active"
+  - "#phase/completed"
 
 
 exit_criteria_met: false
@@ -66,6 +66,8 @@ Design + build a release path for first-party providers that lets them publish/t
 - **Current Problems**: {What's difficult/slow/buggy now}
 - **Benefits of Fixing**: {What improves after refactoring}
 - **Risk Assessment**: {Risks of not addressing this}
+
+## Acceptance Criteria
 
 ## Acceptance Criteria
 
@@ -165,6 +167,16 @@ Design + build a release path for first-party providers that lets them publish/t
 - First wave is the plumbing shakedown: expect crates.io first-publish quirks (mirror the core train's soft-fail handling).
 
 ## Status Updates **[REQUIRED]**
+
+### 2026-08-01 — WAVE 2 SUCCESS: both providers LIVE on crates.io. Task complete.
+
+`providers-v2026.08.2` (after the #223 shakedown fixes): **full green** — kafka certified (signed native package, 3/3 real broker messages, published core) and PUBLISHED; fs certified (3/3 grant cases) and PUBLISHED. Verified live on crates.io: `cloacina-provider-kafka 0.1.0` + `cloacina-provider-fs 0.1.0`. Wave release notes truthful; compat table (wave 2026.08.2) merged via #224.
+
+Inaugural-wave (providers-v2026.08) postmortem — all fixed in #223: missing crates.io metadata (description/license) on both manifests (kafka rejected 400); the publish step's tee-masked exit code let that 400 go GREEN and record a false published claim (release deleted; now PIPESTATUS like the core train, whose comments document this exact trap); fs certify carried pre-#220 drift from a stale-origin/main branch cut (memory rule banked). Per-provider atomicity + certification worked perfectly on both waves.
+
+**Ops note:** the wave's `gh pr create` under GITHUB_TOKEN is blocked until "Allow GitHub Actions to create pull requests" is enabled in repo settings — the compat branch pushes fine; the PR needed manual opening. Flip the setting or keep the manual step.
+
+All six acceptance criteria met. Server-compiled workflows can now depend on both first-party providers.
 
 ### 2026-07-31 — BUILD-OUT COMPLETE (branch feat/t0872-provider-waves); BOTH providers certified locally
 

--- a/.metis/backlog/tech-debt/CLOACI-T-0917.md
+++ b/.metis/backlog/tech-debt/CLOACI-T-0917.md
@@ -4,15 +4,15 @@ level: task
 title: "CI verification-lattice holes — path filters, constructor suite, server-side lockstep, publish tiers"
 short_code: "CLOACI-T-0917"
 created_at: 2026-08-02T16:33:33.333322+00:00
-updated_at: 2026-08-02T16:33:33.333322+00:00
+updated_at: 2026-08-04T01:06:09.137022+00:00
 parent:
 blocked_by: []
 archived: false
 
 tags:
   - "#task"
-  - "#phase/backlog"
   - "#tech-debt"
+  - "#phase/active"
 
 
 exit_criteria_met: false
@@ -40,6 +40,10 @@ Close the verification-lattice blind spots found by the 2026-08-02 deep dive. Pa
 3. LOCKSTEP IS CLIENT-SIDE ONLY: scripts/version_lockstep.py (cargo pins, 3 npm, python client, scaffold, 3 helm appVersions) runs only in pre-commit; no workflow runs pre-commit, and check_sdk_versions.py (what CI/release actually run) omits helm/scaffold/cargo pins. The pre-commit comment claiming "CI runs pre-commit, so drift cannot reach main" is false — the exact incident the check commemorates (charts drifted four minors) can recur through one --no-verify. Fix: run version_lockstep.py in ci.yml quick-checks.
 4. HAND-MAINTAINED PUBLISH TIERS: the 0.10.0 postmortem (8961abb5) was two crates missing from hand-maintained tier lists + a zombie job; no check verifies tier completeness against the workspace. Fix: generate tiers from cargo metadata (publish=true set) or add a tier-completeness assertion to CI.
 5. Quieter tolerance channels to revisit deliberately: 3x retry wrappers on every examples-matrix leg and `continue-on-error: true` on the python-tutorials job — decide which are still warranted post-I-0140 and document the ones that stay.
+
+## Acceptance Criteria
+
+## Acceptance Criteria
 
 ## Acceptance Criteria
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,8 +40,10 @@ repos:
         pass_filenames: false
       # CLOACI-I-0134: single source of version truth. Fails if any core
       # version touchpoint (Rust workspace, npm, python, scaffold pin) has
-      # drifted from [workspace.package] version. CI runs pre-commit, so drift
-      # cannot reach main. `language: python` uses a pre-commit-managed
+      # drifted from [workspace.package] version. CI does NOT run pre-commit;
+      # the server-side enforcement is the same script run directly in ci.yml
+      # quick-checks (CLOACI-T-0917) — this hook is the fast local feedback.
+      # `language: python` uses a pre-commit-managed
       # interpreter (stdlib-only script) so it never depends on the ambient
       # python. Providers under examples/ are independently versioned (A-0010)
       # and deliberately excluded.

--- a/scripts/check_publish_tiers.py
+++ b/scripts/check_publish_tiers.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""
+Publish-tier completeness guard (CLOACI-T-0917).
+
+The crates.io publish tiers in .github/workflows/unified_release.yml are a
+hand-maintained, dependency-ordered list of `publish <crate>` shell calls.
+The 0.10.0 postmortem (8961abb5) was exactly this list drifting from the
+workspace: two crates (cloacina-constructor-contract, cloacina-agent) were
+born during the cycle but never added, so the whole release train failed at
+tag time. This check makes that drift a PR-time failure instead.
+
+Assertions:
+  1. Every workspace crate with `publish != false` appears in the tier list
+     exactly once (missing => a future release will fail to resolve deps;
+     duplicated => ambiguous ordering / copy-paste error).
+  2. Every crate named in the tier list is a publishable workspace member
+     (a stale entry => the release train publishes a ghost or fails).
+
+Scope: only the root workspace (crates/*). Provider crates (providers/*) are
+NOT workspace members and release through the provider wave workflow
+(provider_release.yml), not unified_release.yml — they are out of scope here.
+
+Stdlib-only; needs `cargo` on PATH. Run: python3 scripts/check_publish_tiers.py
+"""
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+WORKFLOW = PROJECT_ROOT / ".github" / "workflows" / "unified_release.yml"
+
+# A bare `publish <crate>` call inside the publish-cargo job's run script.
+# Deliberately does NOT match the `publish() {` function definition (parens)
+# or `cargo publish -p "$crate"` (extra tokens).
+_PUBLISH_CALL = re.compile(r"^\s*publish\s+([A-Za-z0-9_-]+)\s*$", re.MULTILINE)
+
+
+def tier_crates() -> list[str]:
+    text = WORKFLOW.read_text()
+    crates = _PUBLISH_CALL.findall(text)
+    if not crates:
+        raise SystemExit(
+            f"check_publish_tiers: found no `publish <crate>` calls in {WORKFLOW} — "
+            "the publish-cargo job's shape changed; update this parser."
+        )
+    return crates
+
+
+def workspace_publishable() -> set[str]:
+    out = subprocess.run(
+        ["cargo", "metadata", "--no-deps", "--format-version", "1"],
+        cwd=PROJECT_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    meta = json.loads(out)
+    # `publish` is null when unrestricted, [] when `publish = false`,
+    # or a registry list when restricted.
+    return {p["name"] for p in meta["packages"] if p["publish"] != []}
+
+
+def main() -> int:
+    tiers = tier_crates()
+    workspace = workspace_publishable()
+
+    errors = []
+    seen: dict[str, int] = {}
+    for c in tiers:
+        seen[c] = seen.get(c, 0) + 1
+    for c, n in seen.items():
+        if n > 1:
+            errors.append(f"'{c}' appears {n} times in the publish tiers (must be exactly once)")
+    for c in sorted(workspace - set(tiers)):
+        errors.append(
+            f"workspace crate '{c}' has publish != false but is MISSING from the "
+            f"publish tiers in {WORKFLOW.name} — the release train will fail (0.10.0 postmortem class)"
+        )
+    for c in sorted(set(tiers) - workspace):
+        errors.append(
+            f"publish tier entry '{c}' is not a publishable workspace crate — "
+            "stale tier entry (crate removed/renamed or publish = false)"
+        )
+
+    if errors:
+        print("publish-tier completeness FAILED:", file=sys.stderr)
+        for e in errors:
+            print(f"  ✗ {e}", file=sys.stderr)
+        print(
+            "\nFix the tier list in .github/workflows/unified_release.yml "
+            "(keep dependency order) or the crate's `publish` field.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"publish-tiers OK — {len(tiers)} tier entries cover all "
+        f"{len(workspace)} publishable workspace crates exactly once"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

The deep dive's process diagnosis was that the CI system "hardens only where it has bled" — every past incident has a guard at its exact failing line, while symmetric never-failed paths had none. This closes the five cheapest, highest-leverage holes (CLOACI-T-0917).

- **Path filters**: `cloacina-python`, `-server`, `-compiler`, `-agent`, `-client`, `-constructor-contract`, `tests/python/**`, and `clients/python/**` now route into the test matrix — a bindings-only or server-only PR previously triggered **zero** test lanes. `scripts/**` triggers quick-checks.
- **Constructor suite CI home**: the 14 `constructors-wasm`/`constructor-packaging` test targets (previously run by no lane anywhere) get a nightly `constructor-suite` job — ubuntu, wasm32-wasip2 toolchain, 60-min cap, **target-scoped** invocation (an unscoped `cargo test -p cloacina` drags in the postgres-dependent fixtures target). Nightly rather than per-PR because the suite compiles fixture crates inside tests and blew the 10-minute budget in local measurement (11/14 green before cutoff; zero constructor-target failures). Since `unified_release` calls nightly, the suite is now release-blocking.
- **Server-side lockstep**: `.angreal/version_lockstep.py` (19 touchpoints, verified at 0.10.0) now runs in quick-checks; the pre-commit comment falsely claiming "CI runs pre-commit" is corrected.
- **Publish-tier completeness**: new `scripts/check_publish_tiers.py` parses `unified_release.yml`'s publish calls and asserts exactly-once coverage against `cargo metadata` both directions — the 0.10.0-postmortem class, now mechanical. Passes today (15 entries / 15 publishable crates). Wired into quick-checks.
- **Tolerance channels**: `python-tutorials` loses `continue-on-error` (post-I-0140 the flake class is closed — this PR's own CI proves the lane); the three ×3 retry sites stay with justification comments and removal criteria. Repo-wide grep confirms no other allow-failure sites.

## Test plan
- `yamllint --strict` clean on all touched workflows
- Both scripts run green locally
- This PR's own run exercises the new filters, quick-checks additions, and the un-tolerated python-tutorials lane