### PR TITLE
fix(T-0921): key process-global registries by tenant, not bare name

### DIFF
--- a/.metis/backlog/bugs/CLOACI-T-0921.md
+++ b/.metis/backlog/bugs/CLOACI-T-0921.md
@@ -4,15 +4,15 @@ level: task
 title: "Flat name-global registries cross tenant lines in-process — audit and key by tenant/package"
 short_code: "CLOACI-T-0921"
 created_at: 2026-08-02T17:44:00.940671+00:00
-updated_at: 2026-08-04T05:05:01.821436+00:00
-parent: 
+updated_at: 2026-08-02T17:44:00.940671+00:00
+parent:
 blocked_by: []
 archived: false
 
 tags:
   - "#task"
+  - "#phase/backlog"
   - "#bug"
-  - "#phase/active"
 
 
 exit_criteria_met: false
@@ -43,10 +43,6 @@ Context: workflow task namespaces already carry tenant::package:: prefixes (Task
 
 ## Acceptance Criteria
 
-## Acceptance Criteria
-
-## Acceptance Criteria
-
 - [ ] Registry audit table (registry -> keying -> verdict) recorded in this task
 - [ ] EndpointRegistry keyed by (tenant, package, name); cross-package same-name test proves isolation (inject into A, B receives nothing; unload A, B survives)
 - [ ] Python graph/accumulator registries scoped the same way with an equivalent test
@@ -55,3 +51,187 @@ Context: workflow task namespaces already carry tenant::package:: prefixes (Task
 ## Status Updates
 
 - 2026-08-02: Filed from the architecture deep dive (DEEPDIVE.md risk register #23; cg-runtime report §7.6 + python-integration report §7.4). Verified against main @ 5216e632.
+
+- 2026-08-04 (PHASE 1 COMPLETE — audit table): Systematic sweep of every process-global
+  name-keyed map across `crates/`. Verdicts below. Work happening on branch
+  `fix/t-0921-registry-tenant-keying` (worktree `.claude/worktrees/t-0921`).
+
+### Audit table — process-global name-keyed registries
+
+| # | Registry | file:line | Key shape | Writers | Readers | Verdict |
+|---|---|---|---|---|---|---|
+| 1 | `EndpointRegistry.accumulators` | `crates/cloacina/src/computation_graph/registry.rs:212` | `String` (bare acc name) | `scheduler.rs:628`, restart `scheduler.rs:1448` | `routes/ws.rs:277`, `routes/health_graphs.rs:732`, `embedded.rs:73` | **VIOLATOR** — `.entry(name).or_insert_with(Vec::new).push()` *appends*, so tenant A's WS push is broadcast into tenant B's boundary channel |
+| 2 | `EndpointRegistry.reactors` / `.reactor_handles` | `registry.rs:214,216` | `String` (bare reactor name) | `scheduler.rs:695,704`, restart `:1510` | `ws.rs:334`, `health_graphs.rs:588,632` | **VIOLATOR** — last-writer-wins; `deregister_reactor(name)` removes the other tenant's entry |
+| 3 | `EndpointRegistry.accumulator_policies` / `.reactor_policies` | `registry.rs:218,220` | `String` | `scheduler.rs:721,726`, restart `:1525,1530` | `check_accumulator_auth` `registry.rs:358`, `check_reactor_auth` `:377`, `check_reactor_op_auth` `:397` | **VIOLATOR** — *overwrite* (unlike #1 which appends). Second tenant's policy governs both, which is what today keeps the breach from being trivially exploitable AND what makes it silent |
+| 4 | `EndpointRegistry.accumulator_health` / `_freshness` / `_meta` / `_injects` | `registry.rs:222,224,226,231` | `String` | `scheduler.rs:631,634,640`; `registry.rs:255` | `health_graphs.rs:108,127`; `registry.rs:518,528,556` | **VIOLATOR** — cross-tenant health/freshness/inject-count bleed. `AccumulatorDescriptor` (`registry.rs:194`) already *carries* `tenant_id`, but as payload, not key |
+| 5 | `RuntimeInner.workflows` | `crates/cloacina/src/runtime.rs:78` | `String` | `runtime.rs:140,207`; `reconciler/loading.rs:1173`; `cloacina-python/src/workflow.rs:211,420`, `loader.rs:389` | `execution_planner/mod.rs:348`, `state_manager.rs:110`, `context_manager.rs:57` | **VIOLATOR (deferred)** — one `Arc<Runtime>` is shared by every tenant's runner (`cloacina-server/src/tenant_runner_cache.rs:93,116`). Two tenants shipping `daily_etl` → last load wins for both |
+| 6 | `RuntimeInner.triggers` | `runtime.rs:79` | `String` | `runtime.rs:144,242`; `loading.rs:1808`; `constructor_loader.rs:937` | `cron_trigger_scheduler.rs:801`; `loading.rs:1323,1479,1774,1797` | **VIOLATOR (deferred)** — same shared-`Runtime` mechanism |
+| 7 | `RuntimeInner.computation_graphs` / `.triggerless_graphs` / `.reactors` | `runtime.rs:80,81,82` | `String` | `runtime.rs:148,152,156`; `loading.rs:1953,2076` | `loading.rs:1427,1501,1913,1933`; `packaging_bridge.rs:951` | **VIOLATOR (deferred)** — same |
+| 8 | `RuntimeInner.stream_backends` | `runtime.rs:83` | `String` (backend *type* name, e.g. `"kafka"`) | `runtime.rs:161,385` | `stream_backend.rs:95` | **SAFE BY CONSTRUCTION** — key is a backend kind, not a tenant-authored entity name; collisions are intentional dedup |
+| 9 | `RuntimeInner.tasks` | `runtime.rs:77` | `TaskNamespace{tenant,package,workflow,task}` | `runtime.rs:139` | task lookups | **OK** — already tenant-scoped (`cloacina-workflow/src/namespace.rs:62`). This is the pattern the others should copy |
+| 10 | `ComputationGraphScheduler.reactors` | `crates/cloacina/src/computation_graph/scheduler.rs:475` | `String` (reactor name) | `scheduler.rs:772,1026,1211,1394,1570` | `:558` (idempotency probe), `:789,844,872,1010,1076,1094,1149` | **VIOLATOR (deferred)** — cross-tenant same-name reactor with an identical contract *silently shares one running reactor* (`load_reactor` `:557-580` returns `Ok(())`); with a differing contract it leaks the other tenant's reactor name into the error. Partially mitigated: `check_reactor_contract_matches` `:211` compares `tenant_id`, so an identical-contract cross-tenant share is only possible when `tenant_id` also matches |
+| 11 | `ComputationGraphScheduler.graph_to_reactor` / `.graph_topologies` | `scheduler.rs:479,484` | `String` (graph name) | `:969,974` | `:1108-1110` | **VIOLATOR (deferred)** — `bind_graph_to_reactor` `:790` rejects a same-named graph from another tenant with "graph 'x' already loaded" |
+| 12 | Python `GRAPH_EXECUTORS` | `crates/cloacina-python/src/computation_graph.rs:661` | `String` (graph name) | `register_graph_executor` `:664` ← `:618` | `get_graph_executor` `:674`, `get_graph_executors_for_reactor` `:683`, `:898`; `task.rs:302,632`; `loader.rs:485`; `cloacina-agent/src/main.rs:807,811` | **VIOLATOR** — last-load-wins; two tenants' same-named graphs share one executor slot |
+| 13 | Python `ACCUMULATOR_REGISTRY` | `computation_graph.rs:130` | `String` (`func.__name__`) | `:133` ← decorators `:229,276,314,360,410` | `:142,151` (`drain_accumulators`), `:167`; drained `:1548,1575` | **VIOLATOR** — same-named accumulator decorators from two packages overwrite each other |
+| 14 | Python `NODE_REGISTRY` | `computation_graph.rs:87` | `String` (node fn name) | `register_node` `:106` | `drain_nodes()` `:109` ← `:537` | **VIOLATOR (deferred)** — drain-on-build scratch buffer; only unsafe under *interleaved* imports. Import is GIL-serialized and `@graph` drains at the end of its own decorator body, so it is collision-safe in the current single-threaded import path. Ticket separately |
+| 15 | Python `ACTIVE_GRAPH_CONTEXT` | `computation_graph.rs:89` | single `Option<String>` | `push/pop_graph_context` `:91,96` | `:101` | **VIOLATOR (deferred)** — same reasoning as #14 (GIL-serialized push/pop within one decorator body) |
+| 16 | Python `PYTHON_TRIGGER_REGISTRY` | `crates/cloacina-python/src/trigger.rs:39` | `Vec` drain buffer (entries carry bare `name`/`workflow_name`) | decorator | `drain_python_triggers()` `:61` | **VIOLATOR (deferred)** — drain buffer, same import-serialization argument as #14 |
+| 17 | Python `WORKFLOW_CONTEXT_STACK` | `crates/cloacina-python/src/task.rs:87` | `Vec` stack | `:90,96` | `:101` | **SAFE BY CONSTRUCTION (fragile)** — a *stack*, so nesting is correct; process-global rather than thread-local is the latent risk, not name collision |
+| 18 | `Scheduler.last_poll_times` | `crates/cloacina/src/cron_trigger_scheduler.rs:149` | `String` (bare trigger name) | poll loop | `:801` | **VIOLATOR (deferred)** — per-runner, but with the shared `Runtime` (#6) two tenants' same-named triggers share one poll-rate slot. Blocked on #6 |
+| 19 | `PROVIDER_SEARCH_PATH` | `crates/cloacina/src/registry/loader/constructor_loader.rs:1649` | `Option<PathBuf>` (not a map) | `:1663,1668` | `:1674` | **VIOLATOR (deferred, different class)** — process-wide provider dir makes constructor resolution tenant-blind. Not name-keying; ticket separately |
+| 20 | `LOADED_RUNTIMES`, `imported_py_graph_digests`, `loaded_graphs` | `crates/cloacina-agent/src/main.rs:1139,718,878` | artifact **digest** | — | `:807,811` | **SAFE BY CONSTRUCTION for the cache itself** (content-addressed), but the dispatch at `:807/:811` looks the graph up by bare `packet.graph_name` in #12, so the digest keying buys nothing downstream |
+| 21 | `TenantDatabaseCache.databases` | `crates/cloacina-server/src/lib.rs:136` | `String` = **tenant_id** | `:180` | `:164,177` | **OK** |
+| 22 | `TenantRunnerCache.cache` | `crates/cloacina-server/src/tenant_runner_cache.rs:90` | `String` = **tenant_id** | — | — | **OK** |
+| 23 | `DeliverySink.by_key` | `crates/cloacina-server/src/delivery_sink.rs:55` | `(String, Option<String>)` = `(recipient, tenant_id)` | — | — | **OK — reference implementation.** This is the composite-key shape the fixes below copy |
+| 24 | `KeyCache`, `WsTicketStore`, `LoginFlowStore`, `fleet_coordinator.pending`, `reconciler.loaded_packages`, `cron_recovery.recovery_attempts` | `routes/auth.rs:58,321`; `oidc.rs:383`; `fleet_coordinator.rs:45`; `reconciler/mod.rs:261`; `cron_recovery.rs:99` | key-hash / nonce / UUID | — | — | **SAFE BY CONSTRUCTION** — keys are secrets or UUIDs, not tenant-authored names |
+| 25 | `COMPILE_TIME_TASK_REGISTRY` | `crates/cloacina-macros/src/registry.rs:36` | `String` | — | — | **SAFE BY CONSTRUCTION** — lives in the proc-macro compiler process, one crate at a time; never sees two tenants |
+| 26 | `StreamBackendRegistry` (`stream_backend.rs:80`), `DefaultDispatcher.executors` (`dispatcher/default.rs:55`), `TaskRegistrar` maps (`task_registrar/mod.rs:51`), `DependencyLoader.loaded_contexts` (`executor/types.rs:60`), `WorkflowGraph.task_index` (`graph.rs:78`) | — | `String` but **per-instance, not global** | — | — | **SAFE BY CONSTRUCTION** — not process-global. (`stream_backend.rs:135` notes the global version was removed in CLOACI-T-0509; the collision moved into #8, which is safe) |
+| 27 | `PYTHON_RUNTIME` (`crates/cloacina/src/python_runtime.rs:96`), cdylib `OnceLock` runtimes (`cloacina-workflow-plugin/src/lib.rs:230,384,548,645`) | — | singleton value, not a map | — | — | **SAFE BY CONSTRUCTION** |
+
+**Scope decision for this task.** Fixing #1–#4 (EndpointRegistry) and #12–#13 (Python) — these are
+the ticket's named acceptance criteria and the two that are reachable from an *unauthenticated-name*
+surface (`/v1/ws/accumulator/{name}`, `/v1/ws/reactor/{name}`). #5–#7, #10–#11, #14–#16, #18, #19
+are recorded as violators and deferred to follow-up tickets: re-keying `Runtime` and the CG
+scheduler touches ~12 public call sites plus the reconciler's unload bookkeeping and is a
+materially larger change than this ticket's stated scope.
+
+- 2026-08-04 (PHASE 2a COMPLETE — EndpointRegistry re-keyed; audit rows #1–#4).
+  `cargo check -p cloacina --no-default-features --features postgres,sqlite` and
+  `cargo check -p cloacina-server` both clean.
+
+  **New types** (`crates/cloacina/src/computation_graph/registry.rs`):
+  - `EndpointKey { tenant_id: Option<String>, name: String }` — the map key for all 8 inner maps.
+  - `EndpointOwner { tenant_id, package: Option<String>, reactor }` — provenance stamped on each entry.
+  - `EndpointScope { tenant_id: Option<&str>, is_admin }` — the *caller's* scope; built from
+    `KeyContext` via `EndpointScope::from_key_context`.
+  - `resolve_key()` — scoped lookup: (1) caller's own tenant, (2) the untenanted entry
+    (embedded/pre-tenancy, allow-all), (3) admins only: a **unique** cross-tenant match;
+    two tenants owning the name ⇒ `RegistryError::AmbiguousEndpoint`, never a guess.
+    A non-admin can no longer resolve another tenant's endpoint at all.
+  - `RegistryError::EndpointOwnershipConflict` — the loud same-tenant collision.
+
+  **Collision policy.** `register_accumulator` / `register_reactor` now return
+  `Result`. Same owner re-registering ⇒ append/replace (the restart path relies on
+  this). *Different* owner claiming a live `(tenant, name)` ⇒ hard error naming both
+  owners and the tenant. `scheduler.rs::load_reactor` unwinds the whole load on such a
+  rejection (shutdown signal + deregister everything already claimed) so a rejected
+  package leaves nothing half-wired.
+
+  **Deregistration is owner-scoped.** `deregister_accumulator/reactor` take the owner and
+  no-op (with a warn) when the live entry belongs to someone else — unloading tenant A
+  can no longer tear down tenant B's same-named endpoint. Deregistration now also clears
+  the health/freshness/policy/inject side tables, which previously leaked past unload.
+
+  **`list_accumulators_with_health_for_key`** gained a key-tenant gate *ahead* of the
+  policy check. This was a real hole: accumulators with no policy row fell back to
+  `allow_all`, so tenant B could enumerate tenant A's accumulator names. Covered by
+  `test_cloaci_t_0921_health_listing_filters_by_key_tenant`.
+
+  **Ownership carried on `RunningGraph.owner`** (`scheduler.rs`) so the load, restart
+  (full + per-accumulator), and unload paths all use the identity claimed at load.
+
+  **Route compatibility — verified, no API change.**
+  - `/v1/ws/accumulator/{name}` (`routes/ws.rs:277`) and `/v1/ws/reactor/{name}`
+    (`ws.rs:334`, `:430`) keep their bare-`{name}` paths. `AuthenticatedKey` (already in
+    scope in both handlers, carrying `tenant_id` + `is_admin`) now builds an
+    `EndpointScope` that is threaded into `send_to_accumulator` / `get_reactor_handle` /
+    `send_to_reactor`. Identity was ALREADY in scope — it simply was not being used for
+    resolution, only for the policy check.
+  - REST equivalents threaded the same way: `routes/health_graphs.rs` `list_accumulators`
+    (descriptor + inject stat), `fire_reactor` (`send_to_reactor`), `inject_accumulator`
+    (`send_to_accumulator` + `note_accumulator_operator_inject`), `list_reactor_fires` and
+    `reactor_fire_timeseries` (`get_reactor_handle`).
+  - `computation_graph/embedded.rs` carries the declaration's `tenant_id` and pushes under
+    that scope (embedded registries are per-instance, so this is a no-op in practice).
+
+  **Deferred within this row.** `EndpointOwner.package` is `None` from `load_reactor`
+  today — package provenance is not a parameter there, and threading it would ripple
+  through `packaging_bridge::dispatch_{runtime,package}_reactors_into_scheduler` and ~10
+  call sites in three crates. It buys only error-message provenance: the *reactor name*
+  already discriminates two same-tenant packages claiming one accumulator name (the case
+  the AC tests). The one case package would add — two same-tenant packages declaring the
+  same **reactor** name — cannot be closed here anyway, because
+  `scheduler.rs::load_reactor`'s idempotency guard (audit row #10) returns `Ok(())`
+  before `register_reactor` is ever reached. Both belong to the same follow-up.
+
+- 2026-08-04 (PHASE 2b COMPLETE — Python registries scoped; audit rows #12–#13).
+  `cargo check -p cloacina-python --tests` clean.
+
+  **New module** `crates/cloacina-python/src/registration_scope.rs` — the tenancy
+  counterpart to the existing `runtime_scope::ScopedRuntime`. `ScopedRuntime` tells
+  Python decorators *which `Runtime`* to register into; `ScopedRegistration` tells them
+  *whose* registration it is. `RegistrationScope { tenant_id, package }` lives in a
+  thread-local; unlike `ScopedRuntime` it **nests** (saves/restores the previous scope)
+  so a transitively-scoped import cannot strand the outer scope.
+
+  **`GraphKey { tenant_id, package, name }`** now keys both process-globals in
+  `crates/cloacina-python/src/computation_graph.rs`: `GRAPH_EXECUTORS` (was `:661`) and
+  `ACCUMULATOR_REGISTRY` (was `:130`). `resolve_graph_key()` mirrors the Rust-side
+  resolution order: exact `(tenant, package, name)` → same tenant/any package (unique)
+  → the unscoped entry → for unscoped callers only, a unique match anywhere. A
+  *scoped* caller never falls through to another tenant. Ambiguity logs and returns
+  `None` rather than picking a winner.
+
+  **Loader wiring** — the packaged loader knows tenant + package at import time and now
+  installs the scope around the import:
+  - `loader.rs::import_python_computation_graph` gained `tenant_id` / `package_name`
+    params (one non-test caller); `runtime_impl.rs::load_cg_package` already had
+    `tenant_id` and derives the package from the entry module's top-level name.
+  - `loader.rs::import_and_register_python_workflow_named` already had both
+    `package_name` and `tenant_id` — scope installed, no signature change.
+
+  **Reader-side scoping.** `get_registered_accumulators()` now returns only the current
+  scope's declarations plus unscoped ones, so `reactor.rs:139` (which builds a reactor's
+  accumulator specs) stops seeing other tenants' declarations.
+  `get_graph_executors_for_reactor()` filters the same way; the fleet agent dispatches
+  with no scope installed and still sees everything it hosts.
+  `resolve_poll_closure()` resolves through the scope.
+  Added `get_graph_executor_by_key`, `registered_graph_keys`,
+  `get_all_registered_accumulators` for explicit/diagnostic access.
+
+  **Python-side deferrals** (audit rows #14–#16): `NODE_REGISTRY`,
+  `ACTIVE_GRAPH_CONTEXT`, and `PYTHON_TRIGGER_REGISTRY` are drain-on-build scratch
+  buffers, not persistent lookup tables. Registration and drain both happen inside a
+  single GIL-serialized decorator body, so they are collision-safe on the current import
+  path. They remain latent risks if imports are ever parallelized — ticket separately.
+
+- 2026-08-04 (PHASE 3 COMPLETE — tests + validation). Task complete; changes left
+  uncommitted in the worktree.
+
+  **Compile checks — all clean:**
+  - `cargo check -p cloacina --no-default-features --features postgres,sqlite` ✅
+    (and `--features postgres,sqlite,macros --tests` — the integration suite needs
+    `macros`, without it `cloacina_macros` is unresolved, which is pre-existing)
+  - `cargo check -p cloacina-python --tests` ✅
+  - `cargo check -p cloacina-server --tests` ✅
+  - `cargo check -p cloacina-agent` ✅ (consumes `get_graph_executor`)
+  - `cargo fmt --all --check` ✅
+
+  **Tests run (none require a live DB):**
+  - `cargo test -p cloacina --lib computation_graph` → **54 passed**, incl. 7 new
+    `registry::tests::test_cloaci_t_0921_*`: cross-tenant accumulator isolation,
+    cross-tenant lookup is not-found, admin ambiguity refused, same-tenant second claim
+    rejected loudly (accumulator + reactor), owner-scoped deregistration, health-listing
+    tenant filter.
+  - `cargo test -p cloacina --test integration computation_graph::` → **50 passed**,
+    incl. 2 new scheduler-level tests: `test_cloaci_t_0921_cross_tenant_accumulator_isolation`
+    (inject as A fires only A, B receives nothing; unload A, B survives and still fires)
+    and `test_cloaci_t_0921_same_tenant_duplicate_accumulator_rejected` (error names the
+    endpoint, tenant, and both owners; incumbent untouched; rejected load unwinds its
+    reactor registration). The pre-existing supervisor restart/resilience tests pass,
+    which exercises the re-registration paths.
+  - `cargo test -p cloacina-python --lib` → **138 passed, 1 failed**. The failure is
+    `bindings::runner::tests::test_runner_set_cron_schedule_enabled` ("database table is
+    locked: schedules") — a pre-existing SQLite parallel-test flake, unrelated to this
+    change; it passes in isolation with `--test-threads=1`.
+  - `cargo test -p cloacina-python --test python_reactor_library --test cross_language_fan_out`
+    → **5 passed**.
+
+  **Acceptance criteria status:**
+  - [x] Registry audit table recorded in this task (26 rows, all classified).
+  - [x] `EndpointRegistry` keyed by tenant with owner metadata; cross-package/tenant
+        same-name isolation proven (inject into A → B receives nothing; unload A → B
+        survives).
+  - [x] Python graph/accumulator registries scoped, with equivalent tests.
+  - [~] Further violators: enumerated in the audit table with verdicts; the deferred set
+        needs follow-up tickets filed (rows #5–#7, #10–#11, #14–#16, #18, #19).

--- a/crates/cloacina-python/src/computation_graph.rs
+++ b/crates/cloacina-python/src/computation_graph.rs
@@ -80,6 +80,8 @@ use pyo3::types::{PyCFunction, PyDict, PyList, PyString, PyTuple};
 
 use cloacina::computation_graph::types::{GraphError, GraphResult};
 
+use crate::registration_scope::{current_registration_scope, RegistrationScope};
+
 // ---------------------------------------------------------------------------
 // Global node registry (scoped by active builder context)
 // ---------------------------------------------------------------------------
@@ -127,28 +129,151 @@ pub struct PyAccumulatorRegistration {
     pub capacity: i32,
 }
 
-static ACCUMULATOR_REGISTRY: Lazy<Mutex<HashMap<String, (PyObject, PyAccumulatorRegistration)>>> =
+/// CLOACI-T-0921: process-global Python registries are keyed by
+/// `(tenant, package, name)`, not by bare name.
+///
+/// The `@graph` / `@*_accumulator` decorators run at import time; the loader
+/// installs a [`RegistrationScope`] around each package import
+/// ([`crate::registration_scope`]) so a registration is stamped with whose it
+/// is. Two tenants shipping a graph called `pipeline` used to share one
+/// executor slot — last import wins, cross-tenant.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct GraphKey {
+    pub tenant_id: Option<String>,
+    pub package: Option<String>,
+    pub name: String,
+}
+
+impl GraphKey {
+    pub fn new(scope: &RegistrationScope, name: &str) -> Self {
+        Self {
+            tenant_id: scope.tenant_id.clone(),
+            package: scope.package.clone(),
+            name: name.to_string(),
+        }
+    }
+
+    /// The key this name would take under the thread's current scope.
+    pub fn current(name: &str) -> Self {
+        Self::new(&current_registration_scope(), name)
+    }
+
+    fn matches_scope(&self, scope: &RegistrationScope) -> bool {
+        self.tenant_id == scope.tenant_id && self.package == scope.package
+    }
+
+    fn same_tenant(&self, scope: &RegistrationScope) -> bool {
+        self.tenant_id == scope.tenant_id
+    }
+
+    pub fn describe(&self) -> String {
+        format!(
+            "{}::{}::{}",
+            self.tenant_id.as_deref().unwrap_or("<untenanted>"),
+            self.package.as_deref().unwrap_or("<unpackaged>"),
+            self.name
+        )
+    }
+}
+
+/// Resolve a bare `name` to a concrete key within the thread's current scope.
+///
+/// Order, mirroring `EndpointRegistry::resolve_key` on the Rust side:
+/// 1. exact `(tenant, package, name)` — the normal packaged path;
+/// 2. same tenant, any package — a tenant addressing its own graph from a
+///    differently-scoped thread;
+/// 3. the unscoped entry — embedded / direct-import / test registrations;
+/// 4. a unique match by name anywhere (the fleet-agent path, which dispatches
+///    by graph name with no scope installed). Ambiguity resolves to `None`
+///    rather than a coin flip.
+fn resolve_graph_key<V>(map: &HashMap<GraphKey, V>, name: &str) -> Option<GraphKey> {
+    let scope = current_registration_scope();
+
+    let exact = GraphKey::new(&scope, name);
+    if map.contains_key(&exact) {
+        return Some(exact);
+    }
+
+    if scope.tenant_id.is_some() {
+        let same_tenant: Vec<&GraphKey> = map
+            .keys()
+            .filter(|k| k.name == name && k.same_tenant(&scope))
+            .collect();
+        if same_tenant.len() == 1 {
+            return Some(same_tenant[0].clone());
+        }
+        if same_tenant.len() > 1 {
+            return None;
+        }
+    }
+
+    let unscoped = GraphKey::new(&RegistrationScope::unscoped(), name);
+    if map.contains_key(&unscoped) {
+        return Some(unscoped);
+    }
+
+    // A scoped caller must never fall through to another tenant's entry.
+    if scope.tenant_id.is_some() {
+        return None;
+    }
+
+    let any: Vec<&GraphKey> = map.keys().filter(|k| k.name == name).collect();
+    match any.len() {
+        1 => Some(any[0].clone()),
+        0 => None,
+        _ => {
+            tracing::warn!(
+                graph = %name,
+                candidates = ?any.iter().map(|k| k.describe()).collect::<Vec<_>>(),
+                "ambiguous graph name across tenants/packages — refusing to guess"
+            );
+            None
+        }
+    }
+}
+
+static ACCUMULATOR_REGISTRY: Lazy<Mutex<HashMap<GraphKey, (PyObject, PyAccumulatorRegistration)>>> =
     Lazy::new(|| Mutex::new(HashMap::new()));
 
 fn register_accumulator(name: String, func: PyObject, reg: PyAccumulatorRegistration) {
     ACCUMULATOR_REGISTRY
         .lock()
         .unwrap()
-        .insert(name, (func, reg));
+        .insert(GraphKey::current(&name), (func, reg));
 }
 
-/// Get all registered accumulators (for testing/inspection).
+/// Get the accumulators registered in the thread's current scope (plus the
+/// unscoped ones, for embedded/test use). CLOACI-T-0921: a tenant-scoped
+/// caller no longer sees another tenant's accumulator declarations.
 pub fn get_registered_accumulators() -> Vec<PyAccumulatorRegistration> {
+    let scope = current_registration_scope();
     ACCUMULATOR_REGISTRY
         .lock()
         .unwrap()
-        .values()
-        .map(|(_, reg)| reg.clone())
+        .iter()
+        .filter(|(key, _)| {
+            if scope.is_unscoped() {
+                true
+            } else {
+                key.matches_scope(&scope) || (key.tenant_id.is_none() && key.package.is_none())
+            }
+        })
+        .map(|(_, (_, reg))| reg.clone())
         .collect()
 }
 
-/// Drain all registered accumulators (used by builder on __exit__).
-pub fn drain_accumulators() -> HashMap<String, (PyObject, PyAccumulatorRegistration)> {
+/// Every registered accumulator, across all scopes — diagnostics only.
+pub fn get_all_registered_accumulators() -> Vec<(GraphKey, PyAccumulatorRegistration)> {
+    ACCUMULATOR_REGISTRY
+        .lock()
+        .unwrap()
+        .iter()
+        .map(|(key, (_, reg))| (key.clone(), reg.clone()))
+        .collect()
+}
+
+/// Drain all registered accumulators (used by builder on __exit__ / test reset).
+pub fn drain_accumulators() -> HashMap<GraphKey, (PyObject, PyAccumulatorRegistration)> {
     let mut registry = ACCUMULATOR_REGISTRY.lock().unwrap();
     std::mem::take(&mut *registry)
 }
@@ -165,7 +290,9 @@ fn resolve_poll_closure(
 ) -> Option<cloacina::computation_graph::packaging_bridge::PollClosure> {
     let function = {
         let registry = ACCUMULATOR_REGISTRY.lock().unwrap();
-        let (func, reg) = registry.get(name)?;
+        // CLOACI-T-0921: resolve within the thread's registration scope.
+        let key = resolve_graph_key(&registry, name)?;
+        let (func, reg) = registry.get(&key)?;
         if reg.accumulator_type != "polling" {
             return None;
         }
@@ -657,8 +784,10 @@ impl PyComputationGraphBuilder {
 // Graph executor
 // ---------------------------------------------------------------------------
 
-/// Global registry of graph executors.
-static GRAPH_EXECUTORS: Lazy<Mutex<HashMap<String, PythonGraphExecutor>>> =
+/// Global registry of graph executors, keyed by `(tenant, package, name)`
+/// (CLOACI-T-0921) — a bare-name key made two tenants' same-named graphs share
+/// one slot, last import wins.
+static GRAPH_EXECUTORS: Lazy<Mutex<HashMap<GraphKey, PythonGraphExecutor>>> =
     Lazy::new(|| Mutex::new(HashMap::new()));
 
 fn register_graph_executor(
@@ -666,13 +795,29 @@ fn register_graph_executor(
     executor: PythonGraphExecutor,
     _py: Python<'_>,
 ) -> PyResult<()> {
-    GRAPH_EXECUTORS.lock().unwrap().insert(name, executor);
+    let key = GraphKey::current(&name);
+    tracing::debug!(graph = %key.describe(), "registering Python graph executor");
+    GRAPH_EXECUTORS.lock().unwrap().insert(key, executor);
     Ok(())
 }
 
-/// Get a registered graph executor by name (for testing / reactor use).
+/// Get a registered graph executor by name, resolved within the thread's
+/// current [`RegistrationScope`] (for testing / reactor / fleet-agent use).
 pub fn get_graph_executor(name: &str) -> Option<PythonGraphExecutor> {
-    GRAPH_EXECUTORS.lock().unwrap().get(name).cloned()
+    let registry = GRAPH_EXECUTORS.lock().unwrap();
+    let key = resolve_graph_key(&registry, name)?;
+    registry.get(&key).cloned()
+}
+
+/// Get a registered graph executor by its full `(tenant, package, name)` key,
+/// ignoring the thread's ambient scope.
+pub fn get_graph_executor_by_key(key: &GraphKey) -> Option<PythonGraphExecutor> {
+    GRAPH_EXECUTORS.lock().unwrap().get(key).cloned()
+}
+
+/// Every registered graph executor key — diagnostics / tests.
+pub fn registered_graph_keys() -> Vec<GraphKey> {
+    GRAPH_EXECUTORS.lock().unwrap().keys().cloned().collect()
 }
 
 /// All registered graph executors subscribed to `reactor` (CLOACI-T-0841).
@@ -681,10 +826,18 @@ pub fn get_graph_executor(name: &str) -> Option<PythonGraphExecutor> {
 /// graph(s) to execute — the agent-side analog of the scheduler's
 /// subscriber dispatcher.
 pub fn get_graph_executors_for_reactor(reactor: &str) -> Vec<PythonGraphExecutor> {
+    // CLOACI-T-0921: when a scope is installed, only that tenant's subscriber
+    // graphs (plus unscoped ones) fan out. The fleet agent dispatches with no
+    // scope installed and still sees everything it hosts.
+    let scope = current_registration_scope();
     GRAPH_EXECUTORS
         .lock()
         .unwrap()
-        .values()
+        .iter()
+        .filter(|(key, _)| {
+            scope.tenant_id.is_none() || key.same_tenant(&scope) || key.tenant_id.is_none()
+        })
+        .map(|(_, ex)| ex)
         .filter(|ex| ex.has_reactor && ex.reactor_name.as_deref() == Some(reactor))
         .cloned()
         .collect()
@@ -1571,6 +1724,176 @@ mod tests {
             assert_eq!(reg.accumulator_type, "state");
             assert_eq!(reg.capacity, 5);
             assert_eq!(reg.config.get("capacity").map(String::as_str), Some("5"));
+
+            let _ = drain_accumulators();
+        });
+    }
+
+    // -----------------------------------------------------------------
+    // CLOACI-T-0921: process-global Python registries are tenant-scoped
+    // -----------------------------------------------------------------
+
+    use crate::registration_scope::ScopedRegistration;
+
+    fn stub_executor(name: &str) -> PythonGraphExecutor {
+        PythonGraphExecutor {
+            name: name.to_string(),
+            node_functions: HashMap::new(),
+            node_map: HashMap::new(),
+            execution_order: Vec::new(),
+            react_mode: String::new(),
+            accumulators: Vec::new(),
+            has_reactor: false,
+            reactor_name: None,
+        }
+    }
+
+    /// Two packages in two tenants register a graph under the SAME name. Each
+    /// must resolve to its own executor — pre-T-0921 the second import silently
+    /// replaced the first for both tenants.
+    #[test]
+    fn test_cloaci_t_0921_same_name_graphs_resolve_per_scope() {
+        pyo3::prepare_freethreaded_python();
+        Python::with_gil(|py| {
+            let name = "t0921_pipeline";
+
+            // Tenant A / package alpha registers `pipeline`.
+            {
+                let _s = ScopedRegistration::for_package(Some("acme"), Some("alpha"));
+                register_graph_executor(name.to_string(), stub_executor("acme-alpha"), py).unwrap();
+            }
+            // Tenant B / package beta registers `pipeline` too.
+            {
+                let _s = ScopedRegistration::for_package(Some("globex"), Some("beta"));
+                register_graph_executor(name.to_string(), stub_executor("globex-beta"), py)
+                    .unwrap();
+            }
+
+            // Both survive as distinct entries.
+            let keys = registered_graph_keys();
+            assert_eq!(
+                keys.iter().filter(|k| k.name == name).count(),
+                2,
+                "both tenants' graphs must coexist, got {keys:?}"
+            );
+
+            // Each scope resolves to its OWN executor.
+            {
+                let _s = ScopedRegistration::for_package(Some("acme"), Some("alpha"));
+                assert_eq!(get_graph_executor(name).unwrap().name, "acme-alpha");
+            }
+            {
+                let _s = ScopedRegistration::for_package(Some("globex"), Some("beta"));
+                assert_eq!(get_graph_executor(name).unwrap().name, "globex-beta");
+            }
+
+            // A third tenant sees nothing under that name.
+            {
+                let _s = ScopedRegistration::for_package(Some("initech"), Some("gamma"));
+                assert!(
+                    get_graph_executor(name).is_none(),
+                    "a tenant must not resolve another tenant's graph"
+                );
+            }
+
+            // An unscoped caller facing an ambiguous name refuses to guess.
+            assert!(
+                get_graph_executor(name).is_none(),
+                "ambiguous unscoped lookup must not pick a winner"
+            );
+
+            // Explicit-key lookup still works regardless of ambient scope.
+            let acme_key =
+                GraphKey::new(&RegistrationScope::new(Some("acme"), Some("alpha")), name);
+            assert_eq!(
+                get_graph_executor_by_key(&acme_key).unwrap().name,
+                "acme-alpha"
+            );
+            assert_eq!(acme_key.describe(), "acme::alpha::t0921_pipeline");
+        });
+    }
+
+    /// A tenant addressing its own graph from a thread scoped to a *different
+    /// package* of the same tenant still resolves (same-tenant fallback), and
+    /// unscoped registrations stay globally addressable.
+    #[test]
+    fn test_cloaci_t_0921_same_tenant_and_unscoped_fallbacks() {
+        pyo3::prepare_freethreaded_python();
+        Python::with_gil(|py| {
+            let scoped_name = "t0921_same_tenant_graph";
+            let bare_name = "t0921_unscoped_graph";
+
+            {
+                let _s = ScopedRegistration::for_package(Some("umbrella"), Some("pkg-one"));
+                register_graph_executor(scoped_name.to_string(), stub_executor("owned"), py)
+                    .unwrap();
+            }
+            register_graph_executor(bare_name.to_string(), stub_executor("embedded"), py).unwrap();
+
+            // Same tenant, different package → resolves to the tenant's graph.
+            {
+                let _s = ScopedRegistration::for_package(Some("umbrella"), Some("pkg-two"));
+                assert_eq!(get_graph_executor(scoped_name).unwrap().name, "owned");
+                // The unscoped/embedded entry stays reachable from any scope.
+                assert_eq!(get_graph_executor(bare_name).unwrap().name, "embedded");
+            }
+
+            // A different tenant reaches neither its neighbour's graph…
+            {
+                let _s = ScopedRegistration::for_package(Some("stranger"), Some("pkg-x"));
+                assert!(get_graph_executor(scoped_name).is_none());
+                // …but the unscoped one is still shared (pre-tenancy behaviour).
+                assert_eq!(get_graph_executor(bare_name).unwrap().name, "embedded");
+            }
+        });
+    }
+
+    /// Accumulator declarations are scoped too: a tenant's
+    /// `get_registered_accumulators()` must not include another tenant's.
+    #[test]
+    fn test_cloaci_t_0921_accumulator_registry_scoped_by_tenant() {
+        pyo3::prepare_freethreaded_python();
+        Python::with_gil(|py| {
+            let _ = drain_accumulators();
+
+            let reg = |name: &str| PyAccumulatorRegistration {
+                name: name.to_string(),
+                accumulator_type: "passthrough".to_string(),
+                config: HashMap::new(),
+                capacity: 0,
+            };
+
+            {
+                let _s = ScopedRegistration::for_package(Some("acme"), Some("alpha"));
+                register_accumulator("ticks".to_string(), py.None(), reg("ticks"));
+                register_accumulator("acme_only".to_string(), py.None(), reg("acme_only"));
+            }
+            {
+                let _s = ScopedRegistration::for_package(Some("globex"), Some("beta"));
+                register_accumulator("ticks".to_string(), py.None(), reg("ticks"));
+            }
+
+            // Both tenants' `ticks` coexist as separate entries.
+            assert_eq!(
+                get_all_registered_accumulators()
+                    .iter()
+                    .filter(|(k, _)| k.name == "ticks")
+                    .count(),
+                2
+            );
+
+            {
+                let _s = ScopedRegistration::for_package(Some("globex"), Some("beta"));
+                let names: Vec<String> = get_registered_accumulators()
+                    .into_iter()
+                    .map(|r| r.name)
+                    .collect();
+                assert!(names.contains(&"ticks".to_string()));
+                assert!(
+                    !names.contains(&"acme_only".to_string()),
+                    "tenant B must not see tenant A's accumulator declarations: {names:?}"
+                );
+            }
 
             let _ = drain_accumulators();
         });

--- a/crates/cloacina-python/src/lib.rs
+++ b/crates/cloacina-python/src/lib.rs
@@ -79,6 +79,7 @@ pub use runtime_impl::{install, CloacinaPythonRuntime};
 
 // Thread-local "current Runtime" slot used by decorator/loader paths to
 // register into a scoped Runtime rather than cloacina's process-globals.
+pub mod registration_scope;
 pub mod runtime_scope;
 pub use runtime_scope::{current_runtime, ScopedRuntime};
 

--- a/crates/cloacina-python/src/loader.rs
+++ b/crates/cloacina-python/src/loader.rs
@@ -216,6 +216,12 @@ pub fn import_and_register_python_workflow_named(
         // import below resolves it via `current_runtime()`.
         let _scope =
             ScopedRuntime::new(runtime.clone()).map_err(PythonLoaderError::RuntimeError)?;
+        // CLOACI-T-0921: stamp every registration this import triggers with the
+        // owning tenant + package.
+        let _registration = crate::registration_scope::ScopedRegistration::for_package(
+            Some(tenant_id.as_str()),
+            Some(package_name.as_str()),
+        );
         Python::with_gil(|py| {
             // 1. Ensure cloaca module is available
             ensure_cloaca_module(py)?;
@@ -438,6 +444,11 @@ pub fn import_python_computation_graph(
     vendor_dir: &Path,
     entry_module: &str,
     graph_name: &str,
+    // CLOACI-T-0921: whose import this is. Stamped onto every `@graph` /
+    // `@*_accumulator` registration the import triggers, so two tenants'
+    // same-named graphs no longer share one executor slot.
+    tenant_id: Option<&str>,
+    package_name: Option<&str>,
     runtime: Arc<Runtime>,
 ) -> Result<String, PythonLoaderError> {
     validate_no_stdlib_shadowing(workflow_dir, vendor_dir)?;
@@ -446,11 +457,14 @@ pub fn import_python_computation_graph(
     let vendor_dir = vendor_dir.to_path_buf();
     let entry_module = entry_module.to_string();
     let graph_name = graph_name.to_string();
+    let registration_scope =
+        crate::registration_scope::RegistrationScope::new(tenant_id, package_name);
     let timeout = Duration::from_secs(IMPORT_TIMEOUT_SECS);
 
     let handle = std::thread::spawn(move || -> Result<String, PythonLoaderError> {
         let _scope =
             ScopedRuntime::new(runtime.clone()).map_err(PythonLoaderError::RuntimeError)?;
+        let _registration = crate::registration_scope::ScopedRegistration::new(registration_scope);
         Python::with_gil(|py| {
             ensure_cloaca_module(py)?;
 

--- a/crates/cloacina-python/src/registration_scope.rs
+++ b/crates/cloacina-python/src/registration_scope.rs
@@ -1,0 +1,132 @@
+/*
+ *  Copyright 2026 Colliery Software
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+//! Thread-local "who is importing right now" slot (CLOACI-T-0921).
+//!
+//! [`crate::runtime_scope::ScopedRuntime`] tells Python decorators *which
+//! `Runtime`* to register into. This is its tenancy counterpart: it tells them
+//! *whose* registration this is, so the process-global Python registries
+//! (`GRAPH_EXECUTORS`, `ACCUMULATOR_REGISTRY`) can be keyed by
+//! `(tenant, package, name)` instead of a bare name.
+//!
+//! Without it, two tenants each shipping a graph called `pipeline` share one
+//! executor slot and the second import silently wins for both — the Python-side
+//! form of the same doctrine breach CLOACI-T-0921 fixes in `EndpointRegistry`.
+//!
+//! The loader installs a [`ScopedRegistration`] around each package import.
+//! Unscoped registration (embedded use, `cloaca` imported directly in a REPL,
+//! unit tests) yields the default all-`None` scope, which behaves exactly as
+//! the pre-T-0921 bare-name registry did.
+
+use std::cell::RefCell;
+
+/// Identity of the package whose import is currently running on this thread.
+///
+/// `None` fields mean "unknown / not packaged" — the embedded and test paths.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
+pub struct RegistrationScope {
+    pub tenant_id: Option<String>,
+    pub package: Option<String>,
+}
+
+impl RegistrationScope {
+    pub fn new(tenant_id: Option<&str>, package: Option<&str>) -> Self {
+        Self {
+            tenant_id: tenant_id.map(|s| s.to_string()),
+            package: package.map(|s| s.to_string()),
+        }
+    }
+
+    /// The unscoped (embedded / direct-import / test) identity.
+    pub fn unscoped() -> Self {
+        Self::default()
+    }
+
+    /// True when neither tenant nor package is known.
+    pub fn is_unscoped(&self) -> bool {
+        self.tenant_id.is_none() && self.package.is_none()
+    }
+}
+
+thread_local! {
+    static CURRENT_SCOPE: RefCell<RegistrationScope> =
+        const { RefCell::new(RegistrationScope { tenant_id: None, package: None }) };
+}
+
+/// The registration scope installed on this thread (all-`None` if unscoped).
+pub fn current_registration_scope() -> RegistrationScope {
+    CURRENT_SCOPE.with(|slot| slot.borrow().clone())
+}
+
+/// RAII guard installing a [`RegistrationScope`] for the duration of an import.
+///
+/// Unlike [`crate::runtime_scope::ScopedRuntime`] this nests: the previous
+/// scope is saved and restored on drop, so a package import that transitively
+/// triggers another scoped import cannot strand the outer scope.
+pub struct ScopedRegistration {
+    previous: RegistrationScope,
+}
+
+impl ScopedRegistration {
+    pub fn new(scope: RegistrationScope) -> Self {
+        let previous = CURRENT_SCOPE.with(|slot| slot.replace(scope));
+        Self { previous }
+    }
+
+    /// Convenience for the loader paths, which hold `&str` tenant/package.
+    pub fn for_package(tenant_id: Option<&str>, package: Option<&str>) -> Self {
+        Self::new(RegistrationScope::new(tenant_id, package))
+    }
+}
+
+impl Drop for ScopedRegistration {
+    fn drop(&mut self) {
+        let restore = std::mem::take(&mut self.previous);
+        CURRENT_SCOPE.with(|slot| {
+            *slot.borrow_mut() = restore;
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_scope_installs_and_restores() {
+        assert!(current_registration_scope().is_unscoped());
+        {
+            let _outer = ScopedRegistration::for_package(Some("acme"), Some("pkg-a"));
+            assert_eq!(
+                current_registration_scope(),
+                RegistrationScope::new(Some("acme"), Some("pkg-a"))
+            );
+            {
+                let _inner = ScopedRegistration::for_package(Some("globex"), Some("pkg-b"));
+                assert_eq!(
+                    current_registration_scope(),
+                    RegistrationScope::new(Some("globex"), Some("pkg-b"))
+                );
+            }
+            // Nested scope restored the outer one, not the empty default.
+            assert_eq!(
+                current_registration_scope(),
+                RegistrationScope::new(Some("acme"), Some("pkg-a"))
+            );
+        }
+        assert!(current_registration_scope().is_unscoped());
+    }
+}

--- a/crates/cloacina-python/src/runtime_impl.rs
+++ b/crates/cloacina-python/src/runtime_impl.rs
@@ -108,11 +108,16 @@ impl PythonRuntime for CloacinaPythonRuntime {
             .map_err(|e| format!("Failed to extract Python CG package: {}", e))?;
 
         pyo3::prepare_freethreaded_python();
+        // CLOACI-T-0921: the packaged loader knows tenant + package at import
+        // time; the Python package identity is the entry module's top-level name.
+        let package_name = entry_module.split('.').next().unwrap_or(entry_module);
         crate::loader::import_python_computation_graph(
             &extracted.workflow_dir,
             &extracted.vendor_dir,
             entry_module,
             graph_name,
+            Some(tenant_id),
+            Some(package_name),
             runtime.clone(),
         )
         .map_err(|e| format!("Python CG import failed: {}", e))?;

--- a/crates/cloacina-python/tests/cross_language_fan_out.rs
+++ b/crates/cloacina-python/tests/cross_language_fan_out.rs
@@ -39,7 +39,7 @@ use pyo3::prelude::*;
 use cloacina::computation_graph::accumulator::{
     accumulator_runtime, Accumulator, AccumulatorContext, AccumulatorRuntimeConfig, BoundarySender,
 };
-use cloacina::computation_graph::registry::EndpointRegistry;
+use cloacina::computation_graph::registry::{EndpointRegistry, EndpointScope};
 use cloacina::computation_graph::scheduler::{
     AccumulatorDeclaration, AccumulatorFactory, AccumulatorSpawnConfig, ComputationGraphScheduler,
 };
@@ -243,6 +243,7 @@ with ComputationGraphBuilder("py_g", reactor=SharedRx, graph={
     registry
         .send_to_accumulator(
             "alpha",
+            EndpointScope::untenanted(),
             serde_json::to_vec(&serde_json::json!({ "value": 42.0 })).unwrap(),
         )
         .await

--- a/crates/cloacina-python/tests/python_reactor_library.rs
+++ b/crates/cloacina-python/tests/python_reactor_library.rs
@@ -34,7 +34,7 @@ use std::sync::Arc;
 use pyo3::ffi::c_str;
 use pyo3::prelude::*;
 
-use cloacina::computation_graph::registry::EndpointRegistry;
+use cloacina::computation_graph::registry::{EndpointRegistry, EndpointScope};
 use cloacina::computation_graph::scheduler::ComputationGraphScheduler;
 
 use cloacina_python::reactor as py_reactor;
@@ -84,7 +84,10 @@ class LibRxB: pass
         vec!["lib_rx_a".to_string(), "lib_rx_b".to_string()]
     );
     assert!(scheduler.list_graphs().await.is_empty());
-    assert!(registry.get_reactor_handle("lib_rx_a").await.is_none());
+    assert!(registry
+        .get_reactor_handle("lib_rx_a", EndpointScope::untenanted())
+        .await
+        .is_none());
 
     // ---- Dispatch into the scheduler ----
     let dispatched =
@@ -101,11 +104,17 @@ class LibRxB: pass
     // Both reactors are now addressable in the endpoint registry under their
     // own names (no aliasing — `register_aliases: vec![]`).
     assert!(
-        registry.get_reactor_handle("lib_rx_a").await.is_some(),
+        registry
+            .get_reactor_handle("lib_rx_a", EndpointScope::untenanted())
+            .await
+            .is_some(),
         "lib_rx_a should be registered in the endpoint registry"
     );
     assert!(
-        registry.get_reactor_handle("lib_rx_b").await.is_some(),
+        registry
+            .get_reactor_handle("lib_rx_b", EndpointScope::untenanted())
+            .await
+            .is_some(),
         "lib_rx_b should be registered in the endpoint registry"
     );
 
@@ -183,6 +192,7 @@ class CrossPkgRx: pass
     registry
         .send_to_accumulator(
             "alpha",
+            EndpointScope::untenanted(),
             serde_json::to_vec(&serde_json::json!({ "value": 7.0 })).unwrap(),
         )
         .await

--- a/crates/cloacina-server/src/lib.rs
+++ b/crates/cloacina-server/src/lib.rs
@@ -2847,7 +2847,11 @@ mod tests {
 
         // Fire it: push one event, then wait for the reactor task to die.
         registry
-            .send_to_accumulator("t0916_alpha", b"{\"v\":1}".to_vec())
+            .send_to_accumulator(
+                "t0916_alpha",
+                cloacina::computation_graph::registry::EndpointScope::untenanted(),
+                b"{\"v\":1}".to_vec(),
+            )
             .await
             .expect("event push");
         let mut crashed = false;

--- a/crates/cloacina-server/src/routes/health_graphs.rs
+++ b/crates/cloacina-server/src/routes/health_graphs.rs
@@ -33,7 +33,7 @@ use axum::{
 use tracing::warn;
 
 use cloacina::computation_graph::reactor::ManualCommand;
-use cloacina::computation_graph::registry::{KeyContext, ReactorOp};
+use cloacina::computation_graph::registry::{EndpointScope, KeyContext, ReactorOp};
 use cloacina::computation_graph::types::{serialize as serialize_boundary, InputCache, SourceName};
 use cloacina::dal::UnifiedRegistryStorage;
 use cloacina::registry::workflow_registry::WorkflowRegistryImpl;
@@ -104,8 +104,15 @@ pub async fn list_accumulators(
     // list surfaces the relationship, not just name + health.
     let mut accumulators: Vec<AccumulatorStatus> =
         Vec::with_capacity(accumulators_with_health.len());
+    // CLOACI-T-0921: endpoint lookups are `(tenant, name)`-scoped; use the
+    // caller's own scope so a name shared with another tenant resolves to the
+    // caller's entry, never the other tenant's.
+    let scope = EndpointScope::from_key_context(&ctx);
     for (name, health, freshness) in accumulators_with_health {
-        let descriptor = state.endpoint_registry.accumulator_descriptor(&name).await;
+        let descriptor = state
+            .endpoint_registry
+            .accumulator_descriptor(&name, scope)
+            .await;
         // CLOACI-T-0765: promote freshness from the runtime probe (None until the
         // accumulator has emitted / on runtimes predating the probe).
         let last_event_at = freshness
@@ -123,15 +130,18 @@ pub async fn list_accumulators(
         let buffer_capacity = freshness.as_ref().and_then(|f| f.buffer_capacity());
         // CLOACI-T-0776: operator-inject count + last-inject time, so the UI can
         // mark accumulators that a human has manually injected into.
-        let (operator_injects, last_operator_inject_at) =
-            match state.endpoint_registry.accumulator_inject_stat(&name).await {
-                Some((count, ms)) => (
-                    count,
-                    chrono::DateTime::<chrono::Utc>::from_timestamp_millis(ms)
-                        .map(|dt| dt.to_rfc3339()),
-                ),
-                None => (0, None),
-            };
+        let (operator_injects, last_operator_inject_at) = match state
+            .endpoint_registry
+            .accumulator_inject_stat(&name, scope)
+            .await
+        {
+            Some((count, ms)) => (
+                count,
+                chrono::DateTime::<chrono::Utc>::from_timestamp_millis(ms)
+                    .map(|dt| dt.to_rfc3339()),
+            ),
+            None => (0, None),
+        };
         accumulators.push(AccumulatorStatus {
             state: Some(health.to_string()),
             status: serde_json::to_value(health).unwrap_or(serde_json::Value::Null),
@@ -505,9 +515,14 @@ pub async fn fire_reactor(
         }
     };
 
+    // CLOACI-T-0921: resolve `{name}` inside the caller's own tenant.
     match state
         .endpoint_registry
-        .send_to_reactor(&name, command)
+        .send_to_reactor(
+            &name,
+            EndpointScope::from_key_context(&key_context(&auth)),
+            command,
+        )
         .await
     {
         Ok(()) => {
@@ -585,7 +600,11 @@ pub async fn list_reactor_fires(
             .into_response();
     }
     let limit = q.limit.unwrap_or(50).min(200);
-    let fires: Vec<ReactorFire> = match state.endpoint_registry.get_reactor_handle(&name).await {
+    let fires: Vec<ReactorFire> = match state
+        .endpoint_registry
+        .get_reactor_handle(&name, EndpointScope::from_key_context(&key_context(&auth)))
+        .await
+    {
         Some(handle) => handle
             .stats
             .recent_fires(limit)
@@ -629,7 +648,11 @@ pub async fn reactor_fire_timeseries(
         return ApiError::not_found("reactor_not_found", format!("reactor '{}' not found", name))
             .into_response();
     }
-    let buckets = match state.endpoint_registry.get_reactor_handle(&name).await {
+    let buckets = match state
+        .endpoint_registry
+        .get_reactor_handle(&name, EndpointScope::from_key_context(&key_context(&auth)))
+        .await
+    {
         Some(handle) => handle.stats.fire_timeseries(),
         None => vec![0; 60],
     };
@@ -727,9 +750,11 @@ pub async fn inject_accumulator(
         }
     };
 
+    // CLOACI-T-0921: resolve `{name}` inside the caller's own tenant.
+    let inject_scope = EndpointScope::from_key_context(&key_context(&auth));
     match state
         .endpoint_registry
-        .send_to_accumulator(&name, event)
+        .send_to_accumulator(&name, inject_scope, event)
         .await
     {
         Ok(delivered) => {
@@ -737,7 +762,7 @@ pub async fn inject_accumulator(
             // is the human path; the WS push is data-source feed and is excluded).
             state
                 .endpoint_registry
-                .note_accumulator_operator_inject(&name)
+                .note_accumulator_operator_inject(&name, inject_scope)
                 .await;
             audit::log_accumulator_manual_inject(
                 &name,

--- a/crates/cloacina-server/src/routes/ws.rs
+++ b/crates/cloacina-server/src/routes/ws.rs
@@ -30,7 +30,7 @@ use serde::Deserialize;
 use tracing::{debug, info, warn};
 
 use cloacina::computation_graph::reactor::{ManualCommand, ReactorCommand, ReactorResponse};
-use cloacina::computation_graph::registry::{EndpointRegistry, KeyContext};
+use cloacina::computation_graph::registry::{EndpointRegistry, EndpointScope, KeyContext};
 use cloacina::computation_graph::types::InputCache;
 use cloacina::computation_graph::SourceName;
 
@@ -274,7 +274,14 @@ async fn handle_accumulator_socket(
                 record_ws_message("accumulator", "in");
                 // Forward raw bytes to accumulator — it deserializes JSON internally.
                 let bytes: Vec<u8> = data.into();
-                match registry.send_to_accumulator(&name, bytes).await {
+                // CLOACI-T-0921: `{name}` from the URL is resolved inside the
+                // AUTHENTICATED key's tenant, so two tenants may both own an
+                // accumulator called `ticks` without cross-wiring.
+                let scope = EndpointScope {
+                    tenant_id: auth.tenant_id.as_deref(),
+                    is_admin: auth.is_admin,
+                };
+                match registry.send_to_accumulator(&name, scope, bytes).await {
                     Ok(count) => {
                         debug!(accumulator = %name, recipients = count, "forwarded binary message");
                     }
@@ -330,8 +337,13 @@ async fn handle_reactor_socket(
     debug!(reactor = %name, key = %auth.name, "reactor WebSocket connected");
     let _conn_guard = WsConnectionGuard::new("reactor");
 
-    // Get the reactor handle for GetState/Pause/Resume
-    let handle = registry.get_reactor_handle(&name).await;
+    // Get the reactor handle for GetState/Pause/Resume. CLOACI-T-0921: resolved
+    // within the authenticated key's tenant.
+    let scope = EndpointScope {
+        tenant_id: auth.tenant_id.as_deref(),
+        is_admin: auth.is_admin,
+    };
+    let handle = registry.get_reactor_handle(&name, scope).await;
 
     while let Some(msg) = socket.recv().await {
         match msg {
@@ -421,10 +433,13 @@ async fn process_reactor_command(
         };
     }
 
+    // CLOACI-T-0921: commands resolve the reactor inside the caller's tenant.
+    let scope = EndpointScope::from_key_context(&ctx);
+
     match cmd {
         ReactorCommand::ForceFire => {
             match registry
-                .send_to_reactor(name, ManualCommand::ForceFire)
+                .send_to_reactor(name, scope, ManualCommand::ForceFire)
                 .await
             {
                 Ok(()) => ReactorResponse::Fired,
@@ -439,7 +454,7 @@ async fn process_reactor_command(
                 input_cache.update(SourceName::new(&k), v);
             }
             match registry
-                .send_to_reactor(name, ManualCommand::FireWith(input_cache))
+                .send_to_reactor(name, scope, ManualCommand::FireWith(input_cache))
                 .await
             {
                 Ok(()) => ReactorResponse::Fired,

--- a/crates/cloacina/src/computation_graph/embedded.rs
+++ b/crates/cloacina/src/computation_graph/embedded.rs
@@ -43,6 +43,11 @@ pub struct EmbeddedGraph {
     scheduler: ComputationGraphScheduler,
     registry: EndpointRegistry,
     graph_name: String,
+    /// Tenant the declaration was loaded under (`None` for the usual
+    /// untenanted embedded graph). CLOACI-T-0921: endpoint lookups are
+    /// `(tenant, name)`-scoped, so pushes must carry the same scope the
+    /// scheduler registered under.
+    tenant_id: Option<String>,
 }
 
 impl EmbeddedGraph {
@@ -52,11 +57,13 @@ impl EmbeddedGraph {
         let registry = EndpointRegistry::new();
         let scheduler = ComputationGraphScheduler::new(registry.clone());
         let graph_name = decl.name.clone();
+        let tenant_id = decl.tenant_id.clone();
         scheduler.load_graph(decl).await?;
         Ok(Self {
             scheduler,
             registry,
             graph_name,
+            tenant_id,
         })
     }
 
@@ -70,7 +77,11 @@ impl EmbeddedGraph {
     /// Push pre-encoded raw event bytes into an accumulator by name.
     pub async fn push_raw(&self, accumulator: &str, bytes: Vec<u8>) -> Result<(), String> {
         self.registry
-            .send_to_accumulator(accumulator, bytes)
+            .send_to_accumulator(
+                accumulator,
+                super::registry::EndpointScope::of(self.tenant_id.as_deref()),
+                bytes,
+            )
             .await
             .map(|_| ())
             .map_err(|e| e.to_string())

--- a/crates/cloacina/src/computation_graph/registry.rs
+++ b/crates/cloacina/src/computation_graph/registry.rs
@@ -53,6 +53,32 @@ pub enum RegistryError {
 
     #[error("operation '{op}' not permitted on reactor '{name}'")]
     OperationNotPermitted { name: String, op: String },
+
+    /// CLOACI-T-0921: two different owners (packages/reactors) inside the SAME
+    /// tenant tried to claim the same endpoint name. This is a load-time
+    /// rejection, not a silent cross-wire — the second package must rename.
+    #[error(
+        "{kind} '{name}' is already registered in tenant '{tenant}' by {existing}; \
+         {incoming} cannot claim the same name — rename the {kind} in one of the two packages"
+    )]
+    EndpointOwnershipConflict {
+        kind: &'static str,
+        name: String,
+        tenant: String,
+        existing: String,
+        incoming: String,
+    },
+
+    /// CLOACI-T-0921: an admin (tenant-less) caller named an endpoint that
+    /// exists in more than one tenant. Refuse rather than guess.
+    #[error(
+        "{kind} '{name}' is ambiguous across tenants {tenants:?}; scope the request to a tenant"
+    )]
+    AmbiguousEndpoint {
+        kind: &'static str,
+        name: String,
+        tenants: Vec<String>,
+    },
 }
 
 /// Operations that can be performed on a reactor via WebSocket.
@@ -198,37 +224,228 @@ pub struct AccumulatorDescriptor {
     pub tenant_id: Option<String>,
 }
 
-/// Registry mapping endpoint names to channel senders.
+/// Composite lookup key for every endpoint map (CLOACI-T-0921).
+///
+/// Tenant is THE isolation boundary, so it is part of the *key*, not payload
+/// hanging off the value. `tenant_id: None` is the untenanted/embedded
+/// single-tenant case (and keeps the pre-multi-tenancy allow-all behaviour).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct EndpointKey {
+    pub tenant_id: Option<String>,
+    pub name: String,
+}
+
+impl EndpointKey {
+    pub fn new(tenant_id: Option<&str>, name: &str) -> Self {
+        Self {
+            tenant_id: tenant_id.map(|t| t.to_string()),
+            name: name.to_string(),
+        }
+    }
+
+    fn tenant_label(&self) -> &str {
+        self.tenant_id.as_deref().unwrap_or("<untenanted>")
+    }
+}
+
+/// Full ownership identity recorded on each registration (CLOACI-T-0921).
+///
+/// The key is `(tenant, name)`; this is the rest of the provenance. It exists
+/// so that (a) a same-tenant same-name claim by a *different* package/reactor
+/// is rejected loudly at load time instead of silently cross-wiring, and
+/// (b) deregistration only ever removes the entry its own owner installed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EndpointOwner {
+    /// Owning tenant, or `None` for untenanted/embedded graphs.
+    pub tenant_id: Option<String>,
+    /// Owning package, when the loader knows it. `None` for hand-wired and
+    /// embedded graphs.
+    pub package: Option<String>,
+    /// Owning reactor (the graph this endpoint belongs to).
+    pub reactor: String,
+}
+
+impl EndpointOwner {
+    pub fn new(
+        tenant_id: Option<String>,
+        package: Option<String>,
+        reactor: impl Into<String>,
+    ) -> Self {
+        Self {
+            tenant_id,
+            package,
+            reactor: reactor.into(),
+        }
+    }
+
+    /// An owner with no tenant and no package — embedded/hand-wired graphs.
+    pub fn embedded(reactor: impl Into<String>) -> Self {
+        Self::new(None, None, reactor)
+    }
+
+    /// The map key this owner registers `name` under.
+    pub fn key(&self, name: &str) -> EndpointKey {
+        EndpointKey {
+            tenant_id: self.tenant_id.clone(),
+            name: name.to_string(),
+        }
+    }
+
+    /// Operator-facing provenance string for conflict errors.
+    fn describe(&self) -> String {
+        match &self.package {
+            Some(pkg) => format!("package '{}' (reactor '{}')", pkg, self.reactor),
+            None => format!("reactor '{}'", self.reactor),
+        }
+    }
+}
+
+/// Tenant scope of a *caller* performing an endpoint lookup (CLOACI-T-0921).
+///
+/// The WebSocket and REST routes build this from the authenticated key so a
+/// bare `{name}` path segment resolves inside the caller's own tenant.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct EndpointScope<'a> {
+    pub tenant_id: Option<&'a str>,
+    pub is_admin: bool,
+}
+
+impl<'a> EndpointScope<'a> {
+    /// A non-admin caller in `tenant_id` (`None` = untenanted deployment).
+    pub fn of(tenant_id: Option<&'a str>) -> Self {
+        Self {
+            tenant_id,
+            is_admin: false,
+        }
+    }
+
+    /// A non-admin caller in a specific tenant.
+    pub fn tenant(tenant_id: &'a str) -> Self {
+        Self::of(Some(tenant_id))
+    }
+
+    /// The untenanted (embedded / single-tenant) caller.
+    pub fn untenanted() -> Self {
+        Self::of(None)
+    }
+
+    /// An admin caller: may reach any tenant's endpoint, but only when the
+    /// name is unambiguous across tenants.
+    pub fn admin() -> Self {
+        Self {
+            tenant_id: None,
+            is_admin: true,
+        }
+    }
+
+    /// Derive the lookup scope from an authenticated key's context.
+    pub fn from_key_context(ctx: &KeyContext<'a>) -> Self {
+        Self {
+            tenant_id: ctx.tenant_id,
+            is_admin: ctx.is_admin,
+        }
+    }
+}
+
+/// Why a scoped lookup failed to land on exactly one key.
+enum ResolveMiss {
+    NotFound,
+    Ambiguous(Vec<String>),
+}
+
+/// Resolve a bare `name` to a concrete [`EndpointKey`] within `scope`.
+///
+/// Order:
+/// 1. the caller's own tenant — the normal multi-tenant path;
+/// 2. the untenanted entry (`tenant_id: None`) — embedded/pre-tenancy graphs,
+///    which carry an allow-all policy and were always globally addressable;
+/// 3. admins only: a unique cross-tenant match. Two tenants owning the same
+///    name is [`ResolveMiss::Ambiguous`], never a guess.
+///
+/// A non-admin caller can therefore never resolve another tenant's endpoint,
+/// which is the whole point of CLOACI-T-0921.
+fn resolve_key<V>(
+    map: &HashMap<EndpointKey, V>,
+    scope: EndpointScope<'_>,
+    name: &str,
+) -> Result<EndpointKey, ResolveMiss> {
+    if let Some(tenant) = scope.tenant_id {
+        let key = EndpointKey::new(Some(tenant), name);
+        if map.contains_key(&key) {
+            return Ok(key);
+        }
+    }
+
+    let untenanted = EndpointKey::new(None, name);
+    if map.contains_key(&untenanted) {
+        return Ok(untenanted);
+    }
+
+    if scope.is_admin {
+        let matches: Vec<&EndpointKey> = map.keys().filter(|k| k.name == name).collect();
+        match matches.len() {
+            0 => return Err(ResolveMiss::NotFound),
+            1 => return Ok(matches[0].clone()),
+            _ => {
+                return Err(ResolveMiss::Ambiguous(
+                    matches
+                        .iter()
+                        .map(|k| k.tenant_label().to_string())
+                        .collect(),
+                ))
+            }
+        }
+    }
+
+    Err(ResolveMiss::NotFound)
+}
+
+/// An accumulator registration: its owner plus the socket senders fanned out
+/// under this `(tenant, name)` key.
+struct AccumulatorEntry {
+    owner: EndpointOwner,
+    senders: Vec<mpsc::Sender<Vec<u8>>>,
+}
+
+/// A reactor registration: its owner, manual command channel, and shared handle.
+struct ReactorEntry {
+    owner: EndpointOwner,
+    sender: mpsc::Sender<ManualCommand>,
+    handle: ReactorHandle,
+}
+
+/// Registry mapping `(tenant, endpoint name)` to channel senders.
 ///
 /// Shared between the computation graph scheduler (registers on spawn) and
-/// WebSocket handlers (look up on message receipt).
+/// WebSocket handlers (look up on message receipt). One instance serves the
+/// whole server process, so every map is keyed by [`EndpointKey`] —
+/// CLOACI-T-0921: keying by bare name let same-named accumulators from two
+/// tenants broadcast into each other's boundary channels.
 #[derive(Clone)]
 pub struct EndpointRegistry {
     inner: Arc<RwLock<RegistryInner>>,
 }
 
 struct RegistryInner {
-    /// Accumulator name → list of socket senders (Vec for broadcast).
-    accumulators: HashMap<String, Vec<mpsc::Sender<Vec<u8>>>>,
-    /// Reactor name → manual command sender.
-    reactors: HashMap<String, mpsc::Sender<ManualCommand>>,
-    /// Reactor name → shared handle for GetState/Pause/Resume.
-    reactor_handles: HashMap<String, ReactorHandle>,
-    /// Accumulator name → auth policy.
-    accumulator_policies: HashMap<String, AccumulatorAuthPolicy>,
-    /// Reactor name → auth policy.
-    reactor_policies: HashMap<String, ReactorAuthPolicy>,
-    /// Accumulator name → health watch receiver.
-    accumulator_health: HashMap<String, watch::Receiver<AccumulatorHealth>>,
-    /// Accumulator name → freshness probe (events_total + last-event), CLOACI-T-0765.
-    accumulator_freshness: HashMap<String, FreshnessHandle>,
-    /// Accumulator name → discoverability descriptor (CLOACI-I-0128 follow-up).
-    accumulator_meta: HashMap<String, AccumulatorDescriptor>,
-    /// Accumulator name → `(operator-inject count, last-inject epoch ms)`
+    /// `(tenant, accumulator name)` → owner + socket senders (Vec for broadcast).
+    accumulators: HashMap<EndpointKey, AccumulatorEntry>,
+    /// `(tenant, reactor name)` → owner + manual command sender + shared handle.
+    reactors: HashMap<EndpointKey, ReactorEntry>,
+    /// `(tenant, accumulator name)` → auth policy.
+    accumulator_policies: HashMap<EndpointKey, AccumulatorAuthPolicy>,
+    /// `(tenant, reactor name)` → auth policy.
+    reactor_policies: HashMap<EndpointKey, ReactorAuthPolicy>,
+    /// `(tenant, accumulator name)` → health watch receiver.
+    accumulator_health: HashMap<EndpointKey, watch::Receiver<AccumulatorHealth>>,
+    /// `(tenant, accumulator name)` → freshness probe (events_total + last-event), CLOACI-T-0765.
+    accumulator_freshness: HashMap<EndpointKey, FreshnessHandle>,
+    /// `(tenant, accumulator name)` → discoverability descriptor (CLOACI-I-0128 follow-up).
+    accumulator_meta: HashMap<EndpointKey, AccumulatorDescriptor>,
+    /// `(tenant, accumulator name)` → `(operator-inject count, last-inject epoch ms)`
     /// (CLOACI-T-0776). Every `send_to_accumulator` is an operator inject — real
     /// source events arrive on the accumulator's own socket, not here — so this
     /// counts manual interventions for the UI to mark.
-    accumulator_injects: HashMap<String, (u64, i64)>,
+    accumulator_injects: HashMap<EndpointKey, (u64, i64)>,
 }
 
 impl EndpointRegistry {
@@ -237,7 +454,6 @@ impl EndpointRegistry {
             inner: Arc::new(RwLock::new(RegistryInner {
                 accumulators: HashMap::new(),
                 reactors: HashMap::new(),
-                reactor_handles: HashMap::new(),
                 accumulator_policies: HashMap::new(),
                 reactor_policies: HashMap::new(),
                 accumulator_health: HashMap::new(),
@@ -252,97 +468,216 @@ impl EndpointRegistry {
     /// from the REST inject endpoint — the true human-operator path. (The WS
     /// accumulator-push path also goes through `send_to_accumulator` but is the
     /// data-source feed, e.g. the demo producer, so it must NOT count here.)
-    pub async fn note_accumulator_operator_inject(&self, name: &str) {
+    pub async fn note_accumulator_operator_inject(&self, name: &str, scope: EndpointScope<'_>) {
         let now = chrono::Utc::now().timestamp_millis();
         let mut inner = self.inner.write().await;
-        let entry = inner
-            .accumulator_injects
-            .entry(name.to_string())
-            .or_insert((0, 0));
+        let Ok(key) = resolve_key(&inner.accumulators, scope, name) else {
+            return;
+        };
+        let entry = inner.accumulator_injects.entry(key).or_insert((0, 0));
         entry.0 += 1;
         entry.1 = now;
     }
 
     /// `(operator-inject count, last-inject epoch ms)` for an accumulator, or
     /// `None` if it has never been operator-injected (CLOACI-T-0776).
-    pub async fn accumulator_inject_stat(&self, name: &str) -> Option<(u64, i64)> {
-        self.inner
-            .read()
-            .await
-            .accumulator_injects
-            .get(name)
-            .copied()
+    pub async fn accumulator_inject_stat(
+        &self,
+        name: &str,
+        scope: EndpointScope<'_>,
+    ) -> Option<(u64, i64)> {
+        let inner = self.inner.read().await;
+        let key = resolve_key(&inner.accumulators, scope, name).ok()?;
+        inner.accumulator_injects.get(&key).copied()
     }
 
-    /// Register an accumulator's socket sender under a name.
+    /// Register an accumulator's socket sender under `(owner.tenant, name)`.
     ///
-    /// Multiple accumulators can share the same name — messages are broadcast
-    /// to all of them.
-    pub async fn register_accumulator(&self, name: String, sender: mpsc::Sender<Vec<u8>>) {
+    /// Several accumulator *instances* belonging to the same owner may share a
+    /// name — messages are broadcast to all of them, and the restart path
+    /// re-registers this way. A *different* owner claiming an already-taken
+    /// `(tenant, name)` is rejected with
+    /// [`RegistryError::EndpointOwnershipConflict`] (CLOACI-T-0921): silently
+    /// appending is what let two packages cross-wire each other's boundary
+    /// channels.
+    pub async fn register_accumulator(
+        &self,
+        owner: &EndpointOwner,
+        name: String,
+        sender: mpsc::Sender<Vec<u8>>,
+    ) -> Result<(), RegistryError> {
+        let key = owner.key(&name);
         let mut inner = self.inner.write().await;
-        inner
-            .accumulators
-            .entry(name)
-            .or_insert_with(Vec::new)
-            .push(sender);
+        match inner.accumulators.get_mut(&key) {
+            Some(entry) => {
+                if &entry.owner != owner {
+                    return Err(RegistryError::EndpointOwnershipConflict {
+                        kind: "accumulator",
+                        name,
+                        tenant: key.tenant_label().to_string(),
+                        existing: entry.owner.describe(),
+                        incoming: owner.describe(),
+                    });
+                }
+                entry.senders.push(sender);
+            }
+            None => {
+                inner.accumulators.insert(
+                    key,
+                    AccumulatorEntry {
+                        owner: owner.clone(),
+                        senders: vec![sender],
+                    },
+                );
+            }
+        }
+        Ok(())
     }
 
-    /// Register a reactor's manual command sender and shared handle.
+    /// Register a reactor's manual command sender and shared handle under
+    /// `(owner.tenant, name)`. Same ownership rule as
+    /// [`register_accumulator`](Self::register_accumulator): a different owner
+    /// claiming a live `(tenant, name)` is a load-time error.
     pub async fn register_reactor(
         &self,
+        owner: &EndpointOwner,
         name: String,
         sender: mpsc::Sender<ManualCommand>,
         handle: ReactorHandle,
-    ) {
+    ) -> Result<(), RegistryError> {
+        let key = owner.key(&name);
         let mut inner = self.inner.write().await;
-        inner.reactors.insert(name.clone(), sender);
-        inner.reactor_handles.insert(name, handle);
+        if let Some(existing) = inner.reactors.get(&key) {
+            if &existing.owner != owner {
+                return Err(RegistryError::EndpointOwnershipConflict {
+                    kind: "reactor",
+                    name,
+                    tenant: key.tenant_label().to_string(),
+                    existing: existing.owner.describe(),
+                    incoming: owner.describe(),
+                });
+            }
+        }
+        inner.reactors.insert(
+            key,
+            ReactorEntry {
+                owner: owner.clone(),
+                sender,
+                handle,
+            },
+        );
+        Ok(())
     }
 
     /// Register an accumulator's discoverability descriptor (its parent reactor
-    /// + tenant), self-supplied by the graph at load. Keyed by name; a re-load
-    /// overwrites. (CLOACI-I-0128 follow-up.)
-    pub async fn register_accumulator_meta(&self, name: String, descriptor: AccumulatorDescriptor) {
+    /// + tenant), self-supplied by the graph at load. Keyed by
+    /// `(tenant, name)`; a re-load by the same owner overwrites.
+    /// (CLOACI-I-0128 follow-up.)
+    pub async fn register_accumulator_meta(
+        &self,
+        owner: &EndpointOwner,
+        name: String,
+        descriptor: AccumulatorDescriptor,
+    ) {
         let mut inner = self.inner.write().await;
-        inner.accumulator_meta.insert(name, descriptor);
+        inner.accumulator_meta.insert(owner.key(&name), descriptor);
     }
 
-    /// The discoverability descriptor for an accumulator, if registered.
-    pub async fn accumulator_descriptor(&self, name: &str) -> Option<AccumulatorDescriptor> {
+    /// The discoverability descriptor for an accumulator visible to `scope`.
+    pub async fn accumulator_descriptor(
+        &self,
+        name: &str,
+        scope: EndpointScope<'_>,
+    ) -> Option<AccumulatorDescriptor> {
         let inner = self.inner.read().await;
-        inner.accumulator_meta.get(name).cloned()
+        let key = resolve_key(&inner.accumulator_meta, scope, name).ok()?;
+        inner.accumulator_meta.get(&key).cloned()
     }
 
-    /// Deregister all accumulators under a name.
-    pub async fn deregister_accumulator(&self, name: &str) {
+    /// Deregister the accumulator `owner` registered under `name`, with all of
+    /// its side tables. A no-op when the live entry belongs to somebody else —
+    /// CLOACI-T-0921: unloading tenant A's package must not tear down tenant
+    /// B's same-named accumulator.
+    pub async fn deregister_accumulator(&self, owner: &EndpointOwner, name: &str) {
+        let key = owner.key(name);
         let mut inner = self.inner.write().await;
-        inner.accumulators.remove(name);
-        inner.accumulator_meta.remove(name);
+        match inner.accumulators.get(&key) {
+            Some(entry) if &entry.owner == owner => {}
+            Some(entry) => {
+                tracing::warn!(
+                    accumulator = %name,
+                    tenant = %key.tenant_label(),
+                    owner = %entry.owner.describe(),
+                    requester = %owner.describe(),
+                    "refusing to deregister an accumulator owned by another package"
+                );
+                return;
+            }
+            None => return,
+        }
+        inner.accumulators.remove(&key);
+        inner.accumulator_meta.remove(&key);
+        inner.accumulator_health.remove(&key);
+        inner.accumulator_freshness.remove(&key);
+        inner.accumulator_policies.remove(&key);
+        inner.accumulator_injects.remove(&key);
     }
 
-    /// Deregister a reactor by name.
-    pub async fn deregister_reactor(&self, name: &str) {
+    /// Deregister the reactor `owner` registered under `name`. A no-op when the
+    /// live entry belongs to somebody else (CLOACI-T-0921).
+    pub async fn deregister_reactor(&self, owner: &EndpointOwner, name: &str) {
+        let key = owner.key(name);
         let mut inner = self.inner.write().await;
-        inner.reactors.remove(name);
-        inner.reactor_handles.remove(name);
+        match inner.reactors.get(&key) {
+            Some(entry) if &entry.owner == owner => {}
+            Some(entry) => {
+                tracing::warn!(
+                    reactor = %name,
+                    tenant = %key.tenant_label(),
+                    owner = %entry.owner.describe(),
+                    requester = %owner.describe(),
+                    "refusing to deregister a reactor owned by another package"
+                );
+                return;
+            }
+            None => return,
+        }
+        inner.reactors.remove(&key);
+        inner.reactor_policies.remove(&key);
     }
 
-    /// Get a reactor's shared handle (for GetState/Pause/Resume).
-    pub async fn get_reactor_handle(&self, name: &str) -> Option<ReactorHandle> {
+    /// Get a reactor's shared handle (for GetState/Pause/Resume), resolved
+    /// within the caller's tenant scope.
+    pub async fn get_reactor_handle(
+        &self,
+        name: &str,
+        scope: EndpointScope<'_>,
+    ) -> Option<ReactorHandle> {
         let inner = self.inner.read().await;
-        inner.reactor_handles.get(name).cloned()
+        let key = resolve_key(&inner.reactors, scope, name).ok()?;
+        inner.reactors.get(&key).map(|e| e.handle.clone())
     }
 
     /// Set the auth policy for an accumulator endpoint.
-    pub async fn set_accumulator_policy(&self, name: String, policy: AccumulatorAuthPolicy) {
+    pub async fn set_accumulator_policy(
+        &self,
+        owner: &EndpointOwner,
+        name: String,
+        policy: AccumulatorAuthPolicy,
+    ) {
         let mut inner = self.inner.write().await;
-        inner.accumulator_policies.insert(name, policy);
+        inner.accumulator_policies.insert(owner.key(&name), policy);
     }
 
     /// Set the auth policy for a reactor endpoint.
-    pub async fn set_reactor_policy(&self, name: String, policy: ReactorAuthPolicy) {
+    pub async fn set_reactor_policy(
+        &self,
+        owner: &EndpointOwner,
+        name: String,
+        policy: ReactorAuthPolicy,
+    ) {
         let mut inner = self.inner.write().await;
-        inner.reactor_policies.insert(name, policy);
+        inner.reactor_policies.insert(owner.key(&name), policy);
     }
 
     /// Check if a key is authorized for an accumulator endpoint.
@@ -355,7 +690,14 @@ impl EndpointRegistry {
         ctx: &KeyContext<'_>,
     ) -> Result<(), RegistryError> {
         let inner = self.inner.read().await;
-        match inner.accumulator_policies.get(name) {
+        let scope = EndpointScope::from_key_context(ctx);
+        // CLOACI-T-0921: an unresolvable name (including another tenant's) is
+        // indistinguishable from "no policy" — deny by default either way, and
+        // never leak that the name exists in a tenant the caller can't see.
+        let Ok(key) = resolve_key(&inner.accumulator_policies, scope, name) else {
+            return Err(RegistryError::AccumulatorUnauthorized(name.to_string()));
+        };
+        match inner.accumulator_policies.get(&key) {
             None => Err(RegistryError::AccumulatorUnauthorized(name.to_string())),
             Some(policy) => {
                 if policy.is_authorized(ctx) {
@@ -374,7 +716,11 @@ impl EndpointRegistry {
         ctx: &KeyContext<'_>,
     ) -> Result<(), RegistryError> {
         let inner = self.inner.read().await;
-        match inner.reactor_policies.get(name) {
+        let scope = EndpointScope::from_key_context(ctx);
+        let Ok(key) = resolve_key(&inner.reactor_policies, scope, name) else {
+            return Err(RegistryError::ReactorUnauthorized(name.to_string()));
+        };
+        match inner.reactor_policies.get(&key) {
             None => Err(RegistryError::ReactorUnauthorized(name.to_string())),
             Some(policy) => {
                 if policy.is_authorized(ctx) {
@@ -394,7 +740,11 @@ impl EndpointRegistry {
         op: &ReactorOp,
     ) -> Result<(), RegistryError> {
         let inner = self.inner.read().await;
-        match inner.reactor_policies.get(name) {
+        let scope = EndpointScope::from_key_context(ctx);
+        let Ok(key) = resolve_key(&inner.reactor_policies, scope, name) else {
+            return Err(RegistryError::ReactorUnauthorized(name.to_string()));
+        };
+        match inner.reactor_policies.get(&key) {
             None => Err(RegistryError::ReactorUnauthorized(name.to_string())),
             Some(policy) => {
                 if policy.is_operation_permitted(ctx, op) {
@@ -416,13 +766,28 @@ impl EndpointRegistry {
     pub async fn send_to_accumulator(
         &self,
         name: &str,
+        scope: EndpointScope<'_>,
         bytes: Vec<u8>,
     ) -> Result<usize, RegistryError> {
         let mut inner = self.inner.write().await;
-        let senders = inner
+        let key = match resolve_key(&inner.accumulators, scope, name) {
+            Ok(k) => k,
+            Err(ResolveMiss::NotFound) => {
+                return Err(RegistryError::AccumulatorNotFound(name.to_string()))
+            }
+            Err(ResolveMiss::Ambiguous(tenants)) => {
+                return Err(RegistryError::AmbiguousEndpoint {
+                    kind: "accumulator",
+                    name: name.to_string(),
+                    tenants,
+                })
+            }
+        };
+        let senders = &mut inner
             .accumulators
-            .get_mut(name)
-            .ok_or_else(|| RegistryError::AccumulatorNotFound(name.to_string()))?;
+            .get_mut(&key)
+            .ok_or_else(|| RegistryError::AccumulatorNotFound(name.to_string()))?
+            .senders;
 
         if senders.is_empty() {
             return Err(RegistryError::AccumulatorNotFound(name.to_string()));
@@ -463,13 +828,28 @@ impl EndpointRegistry {
     pub async fn send_to_reactor(
         &self,
         name: &str,
+        scope: EndpointScope<'_>,
         command: ManualCommand,
     ) -> Result<(), RegistryError> {
         let inner = self.inner.read().await;
-        let sender = inner
+        let key = match resolve_key(&inner.reactors, scope, name) {
+            Ok(k) => k,
+            Err(ResolveMiss::NotFound) => {
+                return Err(RegistryError::ReactorNotFound(name.to_string()))
+            }
+            Err(ResolveMiss::Ambiguous(tenants)) => {
+                return Err(RegistryError::AmbiguousEndpoint {
+                    kind: "reactor",
+                    name: name.to_string(),
+                    tenants,
+                })
+            }
+        };
+        let sender = &inner
             .reactors
-            .get(name)
-            .ok_or_else(|| RegistryError::ReactorNotFound(name.to_string()))?;
+            .get(&key)
+            .ok_or_else(|| RegistryError::ReactorNotFound(name.to_string()))?
+            .sender;
 
         sender
             .send(command)
@@ -479,47 +859,80 @@ impl EndpointRegistry {
             })
     }
 
-    /// List all registered accumulator names.
+    /// List all registered accumulator names, across every tenant. Operator/
+    /// diagnostic surface only — the tenant-filtered listing is
+    /// [`list_accumulators_with_health_for_key`](Self::list_accumulators_with_health_for_key).
     pub async fn list_accumulators(&self) -> Vec<String> {
+        let inner = self.inner.read().await;
+        inner.accumulators.keys().map(|k| k.name.clone()).collect()
+    }
+
+    /// List all registered reactor names, across every tenant.
+    pub async fn list_reactors(&self) -> Vec<String> {
+        let inner = self.inner.read().await;
+        inner.reactors.keys().map(|k| k.name.clone()).collect()
+    }
+
+    /// List every registered accumulator as its full `(tenant, name)` key.
+    pub async fn list_accumulator_keys(&self) -> Vec<EndpointKey> {
         let inner = self.inner.read().await;
         inner.accumulators.keys().cloned().collect()
     }
 
-    /// List all registered reactor names.
-    pub async fn list_reactors(&self) -> Vec<String> {
+    /// List every registered reactor as its full `(tenant, name)` key.
+    pub async fn list_reactor_keys(&self) -> Vec<EndpointKey> {
         let inner = self.inner.read().await;
         inner.reactors.keys().cloned().collect()
     }
 
-    /// Get the number of accumulators registered under a name.
-    pub async fn accumulator_count(&self, name: &str) -> usize {
+    /// Get the number of accumulator senders registered under a name, as
+    /// visible to `scope`.
+    pub async fn accumulator_count(&self, name: &str, scope: EndpointScope<'_>) -> usize {
         let inner = self.inner.read().await;
-        inner.accumulators.get(name).map(|v| v.len()).unwrap_or(0)
+        let Ok(key) = resolve_key(&inner.accumulators, scope, name) else {
+            return 0;
+        };
+        inner
+            .accumulators
+            .get(&key)
+            .map(|e| e.senders.len())
+            .unwrap_or(0)
     }
 
     /// Register a health watch receiver for an accumulator.
     pub async fn register_accumulator_health(
         &self,
+        owner: &EndpointOwner,
         name: String,
         health_rx: watch::Receiver<AccumulatorHealth>,
     ) {
         let mut inner = self.inner.write().await;
-        inner.accumulator_health.insert(name, health_rx);
+        inner.accumulator_health.insert(owner.key(&name), health_rx);
     }
 
     /// Register a freshness probe for an accumulator (CLOACI-T-0765): the shared
     /// events_total + last-event handle off its `BoundarySender`.
-    pub async fn register_accumulator_freshness(&self, name: String, handle: FreshnessHandle) {
+    pub async fn register_accumulator_freshness(
+        &self,
+        owner: &EndpointOwner,
+        name: String,
+        handle: FreshnessHandle,
+    ) {
         let mut inner = self.inner.write().await;
-        inner.accumulator_freshness.insert(name, handle);
+        inner.accumulator_freshness.insert(owner.key(&name), handle);
     }
 
-    /// Get the current health of an accumulator.
-    pub async fn get_accumulator_health(&self, name: &str) -> Option<AccumulatorHealth> {
+    /// Get the current health of an accumulator visible to `scope`.
+    pub async fn get_accumulator_health(
+        &self,
+        name: &str,
+        scope: EndpointScope<'_>,
+    ) -> Option<AccumulatorHealth> {
         let inner = self.inner.read().await;
+        let key = resolve_key(&inner.accumulator_health, scope, name).ok()?;
         inner
             .accumulator_health
-            .get(name)
+            .get(&key)
             .map(|rx| rx.borrow().clone())
     }
 
@@ -531,14 +944,14 @@ impl EndpointRegistry {
         inner
             .accumulators
             .keys()
-            .map(|name| {
+            .map(|key| {
                 let health = inner
                     .accumulator_health
-                    .get(name)
+                    .get(key)
                     .map(|rx| rx.borrow().clone())
                     .unwrap_or(AccumulatorHealth::Live); // default for accumulators without health tracking
-                let fresh = inner.accumulator_freshness.get(name).cloned();
-                (name.clone(), health, fresh)
+                let fresh = inner.accumulator_freshness.get(key).cloned();
+                (key.name.clone(), health, fresh)
             })
             .collect()
     }
@@ -561,25 +974,37 @@ impl EndpointRegistry {
         inner
             .accumulators
             .keys()
-            .filter(|name| {
-                // Apply the per-accumulator policy. Accumulators without a
+            .filter(|key| {
+                // CLOACI-T-0921: the key's own tenant is the first gate — an
+                // entry owned by another tenant is invisible regardless of
+                // policy. Untenanted entries stay globally visible (that is the
+                // pre-tenancy single-tenant deployment).
+                let tenant_visible = match (&key.tenant_id, ctx.tenant_id) {
+                    (None, _) => true,
+                    (Some(_), _) if ctx.is_admin => true,
+                    (Some(owner), Some(caller)) => owner == caller,
+                    (Some(_), None) => false,
+                };
+                if !tenant_visible {
+                    return false;
+                }
+                // Then apply the per-accumulator policy. Accumulators without a
                 // policy entry default to `allow_all_authenticated` so the
                 // pre-tenancy single-tenant deployments aren't suddenly
                 // empty after this change.
-                let allowed = match inner.accumulator_policies.get(*name) {
+                match inner.accumulator_policies.get(*key) {
                     Some(policy) => policy.is_authorized(ctx),
                     None => AccumulatorAuthPolicy::allow_all().is_authorized(ctx),
-                };
-                allowed
+                }
             })
-            .map(|name| {
+            .map(|key| {
                 let health = inner
                     .accumulator_health
-                    .get(name)
+                    .get(key)
                     .map(|rx| rx.borrow().clone())
                     .unwrap_or(AccumulatorHealth::Live);
-                let fresh = inner.accumulator_freshness.get(name).cloned();
-                (name.clone(), health, fresh)
+                let fresh = inner.accumulator_freshness.get(key).cloned();
+                (key.name.clone(), health, fresh)
             })
             .collect()
     }
@@ -604,15 +1029,42 @@ mod tests {
         }
     }
 
+    /// Untenanted owner — the embedded/pre-tenancy shape most of these tests use.
+    fn owner(reactor: &str) -> EndpointOwner {
+        EndpointOwner::embedded(reactor)
+    }
+
+    /// Owner in a specific tenant/package.
+    fn tenant_owner(tenant: &str, package: &str, reactor: &str) -> EndpointOwner {
+        EndpointOwner::new(Some(tenant.to_string()), Some(package.to_string()), reactor)
+    }
+
+    const GLOBAL: EndpointScope<'static> = EndpointScope {
+        tenant_id: None,
+        is_admin: false,
+    };
+
     #[tokio::test]
     async fn test_accumulator_descriptor_roundtrip_and_deregister() {
         // CLOACI-I-0128 follow-up: the self-registered discoverability descriptor
         // is readable and cleared on deregister.
         let registry = EndpointRegistry::new();
-        assert!(registry.accumulator_descriptor("alpha").await.is_none());
+        let acme = tenant_owner("acme", "mm-pkg", "market_maker");
+        let acme_scope = EndpointScope::tenant("acme");
+        assert!(registry
+            .accumulator_descriptor("alpha", acme_scope)
+            .await
+            .is_none());
 
+        // The accumulator itself must exist for deregistration to own-match.
+        let (tx, _rx) = mpsc::channel(10);
+        registry
+            .register_accumulator(&acme, "alpha".to_string(), tx)
+            .await
+            .unwrap();
         registry
             .register_accumulator_meta(
+                &acme,
                 "alpha".to_string(),
                 AccumulatorDescriptor {
                     reactor: "market_maker".to_string(),
@@ -622,15 +1074,18 @@ mod tests {
             .await;
 
         let d = registry
-            .accumulator_descriptor("alpha")
+            .accumulator_descriptor("alpha", acme_scope)
             .await
             .expect("descriptor present");
         assert_eq!(d.reactor, "market_maker");
         assert_eq!(d.tenant_id.as_deref(), Some("acme"));
 
-        registry.deregister_accumulator("alpha").await;
+        registry.deregister_accumulator(&acme, "alpha").await;
         assert!(
-            registry.accumulator_descriptor("alpha").await.is_none(),
+            registry
+                .accumulator_descriptor("alpha", acme_scope)
+                .await
+                .is_none(),
             "deregister should clear the descriptor"
         );
     }
@@ -639,12 +1094,16 @@ mod tests {
     async fn test_register_send_deregister_accumulator() {
         let registry = EndpointRegistry::new();
         let (tx, mut rx) = mpsc::channel(10);
+        let o = owner("g");
 
-        registry.register_accumulator("alpha".to_string(), tx).await;
+        registry
+            .register_accumulator(&o, "alpha".to_string(), tx)
+            .await
+            .unwrap();
 
         let data = vec![1, 2, 3];
         let sent = registry
-            .send_to_accumulator("alpha", data.clone())
+            .send_to_accumulator("alpha", GLOBAL, data.clone())
             .await
             .unwrap();
         assert_eq!(sent, 1);
@@ -652,10 +1111,10 @@ mod tests {
         let received = rx.recv().await.unwrap();
         assert_eq!(received, data);
 
-        registry.deregister_accumulator("alpha").await;
+        registry.deregister_accumulator(&o, "alpha").await;
 
         let err = registry
-            .send_to_accumulator("alpha", vec![4, 5])
+            .send_to_accumulator("alpha", GLOBAL, vec![4, 5])
             .await
             .unwrap_err();
         assert!(matches!(err, RegistryError::AccumulatorNotFound(_)));
@@ -666,19 +1125,22 @@ mod tests {
         let registry = EndpointRegistry::new();
         let (tx1, mut rx1) = mpsc::channel(10);
         let (tx2, mut rx2) = mpsc::channel(10);
+        let o = owner("g");
 
         registry
-            .register_accumulator("alpha".to_string(), tx1)
-            .await;
+            .register_accumulator(&o, "alpha".to_string(), tx1)
+            .await
+            .unwrap();
         registry
-            .register_accumulator("alpha".to_string(), tx2)
-            .await;
+            .register_accumulator(&o, "alpha".to_string(), tx2)
+            .await
+            .unwrap();
 
-        assert_eq!(registry.accumulator_count("alpha").await, 2);
+        assert_eq!(registry.accumulator_count("alpha", GLOBAL).await, 2);
 
         let data = vec![10, 20, 30];
         let sent = registry
-            .send_to_accumulator("alpha", data.clone())
+            .send_to_accumulator("alpha", GLOBAL, data.clone())
             .await
             .unwrap();
         assert_eq!(sent, 2);
@@ -691,7 +1153,7 @@ mod tests {
     async fn test_send_to_unregistered_accumulator() {
         let registry = EndpointRegistry::new();
         let err = registry
-            .send_to_accumulator("nonexistent", vec![1])
+            .send_to_accumulator("nonexistent", GLOBAL, vec![1])
             .await
             .unwrap_err();
         assert!(matches!(err, RegistryError::AccumulatorNotFound(_)));
@@ -701,23 +1163,25 @@ mod tests {
     async fn test_register_send_deregister_reactor() {
         let registry = EndpointRegistry::new();
         let (tx, mut rx) = mpsc::channel(10);
+        let o = owner("market_maker");
 
         registry
-            .register_reactor("market_maker".to_string(), tx, dummy_handle())
-            .await;
+            .register_reactor(&o, "market_maker".to_string(), tx, dummy_handle())
+            .await
+            .unwrap();
 
         registry
-            .send_to_reactor("market_maker", ManualCommand::ForceFire)
+            .send_to_reactor("market_maker", GLOBAL, ManualCommand::ForceFire)
             .await
             .unwrap();
 
         let cmd = rx.recv().await.unwrap();
         assert!(matches!(cmd, ManualCommand::ForceFire));
 
-        registry.deregister_reactor("market_maker").await;
+        registry.deregister_reactor(&o, "market_maker").await;
 
         let err = registry
-            .send_to_reactor("market_maker", ManualCommand::ForceFire)
+            .send_to_reactor("market_maker", GLOBAL, ManualCommand::ForceFire)
             .await
             .unwrap_err();
         assert!(matches!(err, RegistryError::ReactorNotFound(_)));
@@ -727,7 +1191,7 @@ mod tests {
     async fn test_send_to_unregistered_reactor() {
         let registry = EndpointRegistry::new();
         let err = registry
-            .send_to_reactor("nonexistent", ManualCommand::ForceFire)
+            .send_to_reactor("nonexistent", GLOBAL, ManualCommand::ForceFire)
             .await
             .unwrap_err();
         assert!(matches!(err, RegistryError::ReactorNotFound(_)));
@@ -738,20 +1202,23 @@ mod tests {
         let registry = EndpointRegistry::new();
         let (tx1, rx1) = mpsc::channel(10);
         let (tx2, mut rx2) = mpsc::channel(10);
+        let o = owner("g");
 
         registry
-            .register_accumulator("alpha".to_string(), tx1)
-            .await;
+            .register_accumulator(&o, "alpha".to_string(), tx1)
+            .await
+            .unwrap();
         registry
-            .register_accumulator("alpha".to_string(), tx2)
-            .await;
+            .register_accumulator(&o, "alpha".to_string(), tx2)
+            .await
+            .unwrap();
 
         // Drop rx1 — its channel is now closed
         drop(rx1);
 
         let data = vec![42];
         let sent = registry
-            .send_to_accumulator("alpha", data.clone())
+            .send_to_accumulator("alpha", GLOBAL, data.clone())
             .await
             .unwrap();
         assert_eq!(sent, 1); // only tx2 succeeded
@@ -759,7 +1226,7 @@ mod tests {
         assert_eq!(rx2.recv().await.unwrap(), data);
 
         // Closed channel should have been pruned
-        assert_eq!(registry.accumulator_count("alpha").await, 1);
+        assert_eq!(registry.accumulator_count("alpha", GLOBAL).await, 1);
     }
 
     #[tokio::test]
@@ -769,11 +1236,18 @@ mod tests {
         let (tx2, _rx2) = mpsc::channel::<ManualCommand>(10);
 
         registry
-            .register_accumulator("alpha".to_string(), tx1)
-            .await;
+            .register_accumulator(&owner("g"), "alpha".to_string(), tx1)
+            .await
+            .unwrap();
         registry
-            .register_reactor("market_maker".to_string(), tx2, dummy_handle())
-            .await;
+            .register_reactor(
+                &owner("market_maker"),
+                "market_maker".to_string(),
+                tx2,
+                dummy_handle(),
+            )
+            .await
+            .unwrap();
 
         let accumulators = registry.list_accumulators().await;
         assert_eq!(accumulators, vec!["alpha"]);
@@ -806,6 +1280,7 @@ mod tests {
 
         registry
             .set_accumulator_policy(
+                &owner("g"),
                 "alpha".to_string(),
                 AccumulatorAuthPolicy {
                     allow_all_authenticated: false,
@@ -847,6 +1322,7 @@ mod tests {
 
         registry
             .set_accumulator_policy(
+                &owner("g"),
                 "alpha".to_string(),
                 AccumulatorAuthPolicy::for_tenant("acme"),
             )
@@ -907,6 +1383,7 @@ mod tests {
 
         registry
             .set_reactor_policy(
+                &owner("mm"),
                 "mm".to_string(),
                 ReactorAuthPolicy {
                     allow_all_authenticated: false,
@@ -939,5 +1416,244 @@ mod tests {
             .await
             .unwrap_err();
         assert!(matches!(err, RegistryError::OperationNotPermitted { .. }));
+    }
+
+    // -----------------------------------------------------------------
+    // CLOACI-T-0921: tenant is THE isolation boundary
+    // -----------------------------------------------------------------
+
+    /// Two tenants each register an accumulator named `ticks`. An inject into
+    /// tenant A's must NOT reach tenant B, and unloading A must leave B alive.
+    #[tokio::test]
+    async fn test_cloaci_t_0921_same_name_accumulators_isolated_across_tenants() {
+        let registry = EndpointRegistry::new();
+        let acme = tenant_owner("acme", "acme-feed", "market_maker");
+        let globex = tenant_owner("globex", "globex-feed", "risk_engine");
+
+        let (tx_a, mut rx_a) = mpsc::channel(10);
+        let (tx_b, mut rx_b) = mpsc::channel(10);
+        registry
+            .register_accumulator(&acme, "ticks".to_string(), tx_a)
+            .await
+            .expect("tenant A registers");
+        registry
+            .register_accumulator(&globex, "ticks".to_string(), tx_b)
+            .await
+            .expect("tenant B registers the same name in its own tenant");
+
+        // Inject as tenant A.
+        let payload = vec![7, 7, 7];
+        let sent = registry
+            .send_to_accumulator("ticks", EndpointScope::tenant("acme"), payload.clone())
+            .await
+            .expect("A's inject lands");
+        assert_eq!(sent, 1, "exactly one recipient — A's own accumulator");
+        assert_eq!(rx_a.try_recv().unwrap(), payload);
+        assert!(
+            rx_b.try_recv().is_err(),
+            "tenant B must receive nothing from tenant A's inject"
+        );
+
+        // Unloading A leaves B intact and reachable.
+        registry.deregister_accumulator(&acme, "ticks").await;
+        assert!(
+            registry
+                .send_to_accumulator("ticks", EndpointScope::tenant("acme"), vec![1])
+                .await
+                .is_err(),
+            "A's accumulator is gone"
+        );
+        let sent_b = registry
+            .send_to_accumulator("ticks", EndpointScope::tenant("globex"), vec![9])
+            .await
+            .expect("B survives A's unload");
+        assert_eq!(sent_b, 1);
+        assert_eq!(rx_b.try_recv().unwrap(), vec![9]);
+    }
+
+    /// A tenant may not reach another tenant's endpoint by naming it, and a
+    /// tenant-less non-admin caller may not either.
+    #[tokio::test]
+    async fn test_cloaci_t_0921_cross_tenant_lookup_is_not_found() {
+        let registry = EndpointRegistry::new();
+        let acme = tenant_owner("acme", "acme-feed", "market_maker");
+        let (tx, _rx) = mpsc::channel(10);
+        registry
+            .register_accumulator(&acme, "ticks".to_string(), tx)
+            .await
+            .unwrap();
+
+        for scope in [EndpointScope::tenant("globex"), EndpointScope::untenanted()] {
+            let err = registry
+                .send_to_accumulator("ticks", scope, vec![1])
+                .await
+                .unwrap_err();
+            assert!(
+                matches!(err, RegistryError::AccumulatorNotFound(_)),
+                "cross-tenant/global lookup must not resolve, got {err:?}"
+            );
+        }
+
+        // An admin reaches it, because the name is unambiguous.
+        registry
+            .send_to_accumulator("ticks", EndpointScope::admin(), vec![1])
+            .await
+            .expect("admin resolves the unique cross-tenant match");
+    }
+
+    /// An admin naming an endpoint that exists in two tenants gets a refusal,
+    /// not a coin flip.
+    #[tokio::test]
+    async fn test_cloaci_t_0921_admin_ambiguous_name_refused() {
+        let registry = EndpointRegistry::new();
+        let (tx_a, _ra) = mpsc::channel(10);
+        let (tx_b, _rb) = mpsc::channel(10);
+        registry
+            .register_accumulator(&tenant_owner("acme", "p", "r"), "ticks".to_string(), tx_a)
+            .await
+            .unwrap();
+        registry
+            .register_accumulator(&tenant_owner("globex", "p", "r"), "ticks".to_string(), tx_b)
+            .await
+            .unwrap();
+
+        let err = registry
+            .send_to_accumulator("ticks", EndpointScope::admin(), vec![1])
+            .await
+            .unwrap_err();
+        match err {
+            RegistryError::AmbiguousEndpoint {
+                name, mut tenants, ..
+            } => {
+                assert_eq!(name, "ticks");
+                tenants.sort();
+                assert_eq!(tenants, vec!["acme".to_string(), "globex".to_string()]);
+            }
+            other => panic!("expected AmbiguousEndpoint, got {other:?}"),
+        }
+    }
+
+    /// Two packages in the SAME tenant claiming one accumulator name is a loud
+    /// load-time rejection, not a silent cross-wire.
+    #[tokio::test]
+    async fn test_cloaci_t_0921_same_tenant_second_claim_rejects_loudly() {
+        let registry = EndpointRegistry::new();
+        let first = tenant_owner("acme", "pkg-one", "reactor_one");
+        let second = tenant_owner("acme", "pkg-two", "reactor_two");
+
+        let (tx1, mut rx1) = mpsc::channel(10);
+        let (tx2, mut rx2) = mpsc::channel(10);
+        registry
+            .register_accumulator(&first, "ticks".to_string(), tx1)
+            .await
+            .expect("first claim wins");
+
+        let err = registry
+            .register_accumulator(&second, "ticks".to_string(), tx2)
+            .await
+            .expect_err("second package must be rejected");
+        let msg = err.to_string();
+        assert!(matches!(
+            err,
+            RegistryError::EndpointOwnershipConflict { .. }
+        ));
+        assert!(
+            msg.contains("pkg-one") && msg.contains("pkg-two") && msg.contains("acme"),
+            "error must name both packages and the tenant: {msg}"
+        );
+
+        // The incumbent is untouched: it still receives, the rejected one never does.
+        registry
+            .send_to_accumulator("ticks", EndpointScope::tenant("acme"), vec![5])
+            .await
+            .unwrap();
+        assert_eq!(rx1.try_recv().unwrap(), vec![5]);
+        assert!(rx2.try_recv().is_err());
+    }
+
+    /// Same rule for reactors.
+    #[tokio::test]
+    async fn test_cloaci_t_0921_reactor_same_tenant_second_claim_rejects() {
+        let registry = EndpointRegistry::new();
+        let first = tenant_owner("acme", "pkg-one", "rx");
+        let second = tenant_owner("acme", "pkg-two", "rx");
+        let (tx1, _r1) = mpsc::channel(10);
+        let (tx2, _r2) = mpsc::channel(10);
+
+        registry
+            .register_reactor(&first, "rx".to_string(), tx1, dummy_handle())
+            .await
+            .unwrap();
+        let err = registry
+            .register_reactor(&second, "rx".to_string(), tx2, dummy_handle())
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            RegistryError::EndpointOwnershipConflict { .. }
+        ));
+    }
+
+    /// Deregistration is owner-scoped: another package's unload is a no-op.
+    #[tokio::test]
+    async fn test_cloaci_t_0921_deregister_is_owner_scoped() {
+        let registry = EndpointRegistry::new();
+        let mine = tenant_owner("acme", "pkg-one", "rx-one");
+        let theirs = tenant_owner("acme", "pkg-two", "rx-two");
+        let (tx, _rx) = mpsc::channel(10);
+        registry
+            .register_accumulator(&mine, "ticks".to_string(), tx)
+            .await
+            .unwrap();
+
+        // A different package in the same tenant cannot tear it down.
+        registry.deregister_accumulator(&theirs, "ticks").await;
+        assert_eq!(
+            registry
+                .accumulator_count("ticks", EndpointScope::tenant("acme"))
+                .await,
+            1,
+            "another package's deregister must be a no-op"
+        );
+
+        registry.deregister_accumulator(&mine, "ticks").await;
+        assert_eq!(
+            registry
+                .accumulator_count("ticks", EndpointScope::tenant("acme"))
+                .await,
+            0
+        );
+    }
+
+    /// The health listing filters on the key's tenant, not just the policy.
+    #[tokio::test]
+    async fn test_cloaci_t_0921_health_listing_filters_by_key_tenant() {
+        let registry = EndpointRegistry::new();
+        let (tx_a, _ra) = mpsc::channel(10);
+        let (tx_b, _rb) = mpsc::channel(10);
+        registry
+            .register_accumulator(&tenant_owner("acme", "p", "r"), "a_acc".to_string(), tx_a)
+            .await
+            .unwrap();
+        registry
+            .register_accumulator(&tenant_owner("globex", "p", "r"), "b_acc".to_string(), tx_b)
+            .await
+            .unwrap();
+        // Deliberately leave both policies unset — the pre-T-0921 code would
+        // then fall back to allow_all and expose BOTH names to either tenant.
+
+        let key_id = uuid::Uuid::new_v4();
+        let acme_ctx = KeyContext {
+            key_id: &key_id,
+            tenant_id: Some("acme"),
+            is_admin: false,
+        };
+        let visible: Vec<String> = registry
+            .list_accumulators_with_health_for_key(&acme_ctx)
+            .await
+            .into_iter()
+            .map(|(n, _, _)| n)
+            .collect();
+        assert_eq!(visible, vec!["a_acc".to_string()]);
     }
 }

--- a/crates/cloacina/src/computation_graph/scheduler.rs
+++ b/crates/cloacina/src/computation_graph/scheduler.rs
@@ -357,6 +357,11 @@ struct RunningGraph {
     reactor_health_rx: Option<watch::Receiver<super::reactor::ReactorHealth>>,
     /// Declaration (for restarts).
     declaration: ComputationGraphDeclaration,
+    /// CLOACI-T-0921: the endpoint-registry ownership identity every
+    /// accumulator/reactor of this graph is registered under. Carried on the
+    /// running graph so the restart and unload paths re-register / deregister
+    /// under exactly the same `(tenant, name)` keys they claimed at load.
+    owner: super::registry::EndpointOwner,
     /// Subscribers bound to this reactor. May contain one or many graphs
     /// after T-0544 fan-out.
     subscribers: ReactorSubscribers,
@@ -586,6 +591,18 @@ impl ComputationGraphScheduler {
         // The resolved decider is reused on restart (stored on `RunningGraph`).
         let evaluator = resolve_reactor_evaluator(&constructor).await?;
 
+        // CLOACI-T-0921: every endpoint this reactor registers is keyed by
+        // `(tenant, name)` and stamped with this owner, so a same-named
+        // endpoint in another tenant is a separate entry and a same-named
+        // endpoint owned by another reactor in the SAME tenant is rejected.
+        let owner = super::registry::EndpointOwner::new(
+            tenant_id.clone(),
+            // Package provenance is not threaded into `load_reactor` today; the
+            // reactor name is the discriminator. See CLOACI-T-0921 deferrals.
+            None,
+            reactor_name.clone(),
+        );
+
         let (shutdown_tx, shutdown_rx) = shutdown_signal();
         let stored_shutdown_rx = shutdown_rx.clone();
 
@@ -600,7 +617,7 @@ impl ComputationGraphScheduler {
             .collect();
 
         // Spawn accumulators with health and DAL wiring
-        let mut accumulator_handles = Vec::new();
+        let mut accumulator_handles: Vec<(String, JoinHandle<()>)> = Vec::new();
         let mut acc_health_rxs: Vec<(
             String,
             watch::Receiver<super::accumulator::AccumulatorHealth>,
@@ -624,20 +641,35 @@ impl ComputationGraphScheduler {
                 spawn_config,
             );
 
+            // CLOACI-T-0921: a name already claimed by a DIFFERENT owner in
+            // this tenant is a load-time rejection. Tear down what we already
+            // spawned so a rejected load leaves nothing half-wired behind.
+            if let Err(e) = self
+                .registry
+                .register_accumulator(&owner, acc_decl.name.clone(), socket_tx)
+                .await
+            {
+                let _ = shutdown_tx.send(true);
+                for (spawned, _) in &accumulator_handles {
+                    self.registry.deregister_accumulator(&owner, spawned).await;
+                }
+                return Err(format!(
+                    "reactor '{}' cannot be loaded: {}",
+                    reactor_name, e
+                ));
+            }
             self.registry
-                .register_accumulator(acc_decl.name.clone(), socket_tx)
+                .register_accumulator_health(&owner, acc_decl.name.clone(), health_rx)
                 .await;
             self.registry
-                .register_accumulator_health(acc_decl.name.clone(), health_rx)
-                .await;
-            self.registry
-                .register_accumulator_freshness(acc_decl.name.clone(), freshness)
+                .register_accumulator_freshness(&owner, acc_decl.name.clone(), freshness)
                 .await;
             // CLOACI-I-0128 follow-up: self-register discoverability metadata
             // (the reactor this accumulator feeds + owning tenant) so the
             // discovery API can surface the relationship, not just the name.
             self.registry
                 .register_accumulator_meta(
+                    &owner,
                     acc_decl.name.clone(),
                     super::registry::AccumulatorDescriptor {
                         reactor: reactor_name.clone(),
@@ -691,20 +723,53 @@ impl ComputationGraphScheduler {
         // Register reactor under its name + any aliases. Both keys point at
         // the same manual channel + handle.
         let mut endpoint_registry_keys = vec![reactor_name.clone()];
-        self.registry
+        let mut registration_failure: Option<String> = None;
+        if let Err(e) = self
+            .registry
             .register_reactor(
+                &owner,
                 reactor_name.clone(),
                 manual_tx.clone(),
                 reactor_shared.clone(),
             )
-            .await;
-        for alias in &register_aliases {
-            if alias != &reactor_name {
-                self.registry
-                    .register_reactor(alias.clone(), manual_tx.clone(), reactor_shared.clone())
-                    .await;
-                endpoint_registry_keys.push(alias.clone());
+            .await
+        {
+            registration_failure = Some(e.to_string());
+        }
+        if registration_failure.is_none() {
+            for alias in &register_aliases {
+                if alias != &reactor_name {
+                    if let Err(e) = self
+                        .registry
+                        .register_reactor(
+                            &owner,
+                            alias.clone(),
+                            manual_tx.clone(),
+                            reactor_shared.clone(),
+                        )
+                        .await
+                    {
+                        registration_failure = Some(e.to_string());
+                        break;
+                    }
+                    endpoint_registry_keys.push(alias.clone());
+                }
             }
+        }
+        // CLOACI-T-0921: unwind the whole load if any endpoint name was
+        // already claimed by another owner in this tenant.
+        if let Some(e) = registration_failure {
+            let _ = shutdown_tx.send(true);
+            for key in &endpoint_registry_keys {
+                self.registry.deregister_reactor(&owner, key).await;
+            }
+            for (spawned, _) in &accumulator_handles {
+                self.registry.deregister_accumulator(&owner, spawned).await;
+            }
+            return Err(format!(
+                "reactor '{}' cannot be loaded: {}",
+                reactor_name, e
+            ));
         }
 
         // Set auth policies based on package tenant ownership.
@@ -718,12 +783,12 @@ impl ComputationGraphScheduler {
         };
         for acc_decl in &accumulators {
             self.registry
-                .set_accumulator_policy(acc_decl.name.clone(), acc_policy.clone())
+                .set_accumulator_policy(&owner, acc_decl.name.clone(), acc_policy.clone())
                 .await;
         }
         for key in &endpoint_registry_keys {
             self.registry
-                .set_reactor_policy(key.clone(), reactor_policy.clone())
+                .set_reactor_policy(&owner, key.clone(), reactor_policy.clone())
                 .await;
         }
 
@@ -762,6 +827,7 @@ impl ComputationGraphScheduler {
             reactor_shared,
             reactor_health_rx: Some(reactor_health_rx),
             declaration: anchor,
+            owner,
             subscribers,
             endpoint_registry_keys,
             failure_counts: HashMap::new(),
@@ -1047,14 +1113,17 @@ impl ComputationGraphScheduler {
             for label in &graph_labels {
                 emit_component_health(label, &acc_name, "stopped");
             }
-            self.registry.deregister_accumulator(&acc_name).await;
+            self.registry
+                .deregister_accumulator(&running.owner, &acc_name)
+                .await;
         }
 
         // Deregister every endpoint-registry key the reactor was registered
         // under (its own name + any back-compat aliases for bundled-form
-        // callers).
+        // callers). CLOACI-T-0921: owner-scoped, so unloading this package
+        // never tears down another tenant's/package's same-named endpoint.
         for key in &running.endpoint_registry_keys {
-            self.registry.deregister_reactor(key).await;
+            self.registry.deregister_reactor(&running.owner, key).await;
         }
 
         info!(reactor = %reactor_name, "reactor unloaded");
@@ -1423,6 +1492,9 @@ impl ComputationGraphScheduler {
             .map(|a| SourceName::new(&a.name))
             .collect();
 
+        // CLOACI-T-0921: re-register under the identity claimed at load.
+        let owner = running.owner.clone();
+
         let mut new_acc_handles = Vec::new();
         let mut restart_acc_health_rxs: Vec<(
             String,
@@ -1444,19 +1516,31 @@ impl ComputationGraphScheduler {
                 shutdown_rx.clone(),
                 spawn_config,
             );
+            // CLOACI-T-0921: the restart re-registers under the SAME owner it
+            // claimed at load, so this always matches and never conflicts.
+            if let Err(e) = self
+                .registry
+                .register_accumulator(&owner, acc_decl.name.clone(), socket_tx)
+                .await
+            {
+                warn!(
+                    graph = %reactor_name,
+                    accumulator = %acc_decl.name,
+                    error = %e,
+                    "accumulator re-registration rejected on restart"
+                );
+            }
             self.registry
-                .register_accumulator(acc_decl.name.clone(), socket_tx)
+                .register_accumulator_health(&owner, acc_decl.name.clone(), health_rx)
                 .await;
             self.registry
-                .register_accumulator_health(acc_decl.name.clone(), health_rx)
-                .await;
-            self.registry
-                .register_accumulator_freshness(acc_decl.name.clone(), freshness)
+                .register_accumulator_freshness(&owner, acc_decl.name.clone(), freshness)
                 .await;
             // CLOACI-I-0128 follow-up: re-register discoverability meta
             // on the restart path too (graph + tenant).
             self.registry
                 .register_accumulator_meta(
+                    &owner,
                     acc_decl.name.clone(),
                     super::registry::AccumulatorDescriptor {
                         reactor: reactor_name.to_string(),
@@ -1506,9 +1590,23 @@ impl ComputationGraphScheduler {
         // explicitly on RunningGraph instead of recovering from
         // declaration.name).
         for key in &running.endpoint_registry_keys {
-            self.registry
-                .register_reactor(key.clone(), manual_tx.clone(), reactor_shared.clone())
-                .await;
+            if let Err(e) = self
+                .registry
+                .register_reactor(
+                    &owner,
+                    key.clone(),
+                    manual_tx.clone(),
+                    reactor_shared.clone(),
+                )
+                .await
+            {
+                warn!(
+                    graph = %reactor_name,
+                    key = %key,
+                    error = %e,
+                    "reactor re-registration rejected on restart"
+                );
+            }
         }
 
         // Re-set auth policies after restart
@@ -1522,12 +1620,12 @@ impl ComputationGraphScheduler {
         };
         for acc_decl in &running.declaration.accumulators {
             self.registry
-                .set_accumulator_policy(acc_decl.name.clone(), restart_acc_policy.clone())
+                .set_accumulator_policy(&owner, acc_decl.name.clone(), restart_acc_policy.clone())
                 .await;
         }
         for key in &running.endpoint_registry_keys {
             self.registry
-                .set_reactor_policy(key.clone(), restart_reactor_policy.clone())
+                .set_reactor_policy(&owner, key.clone(), restart_reactor_policy.clone())
                 .await;
         }
 
@@ -1629,21 +1727,32 @@ impl ComputationGraphScheduler {
         );
 
         // Re-register socket, health, and auth policy in endpoint registry
+        // under the identity claimed at load (CLOACI-T-0921).
+        let owner = running.owner.clone();
+        if let Err(e) = self
+            .registry
+            .register_accumulator(&owner, acc_name.to_string(), socket_tx)
+            .await
+        {
+            warn!(
+                graph = %reactor_name,
+                accumulator = %acc_name,
+                error = %e,
+                "accumulator re-registration rejected on individual restart"
+            );
+        }
         self.registry
-            .register_accumulator(acc_name.to_string(), socket_tx)
+            .register_accumulator_health(&owner, acc_name.to_string(), health_rx)
             .await;
         self.registry
-            .register_accumulator_health(acc_name.to_string(), health_rx)
-            .await;
-        self.registry
-            .register_accumulator_freshness(acc_name.to_string(), freshness)
+            .register_accumulator_freshness(&owner, acc_name.to_string(), freshness)
             .await;
         let ind_acc_policy = match &running.declaration.tenant_id {
             Some(tid) => AccumulatorAuthPolicy::for_tenant(tid),
             None => AccumulatorAuthPolicy::allow_all(),
         };
         self.registry
-            .set_accumulator_policy(acc_name.to_string(), ind_acc_policy)
+            .set_accumulator_policy(&owner, acc_name.to_string(), ind_acc_policy)
             .await;
 
         running
@@ -1734,7 +1843,10 @@ impl ComputationGraphScheduler {
             for (acc_name, _) in &running.accumulator_handles {
                 let acc_state = self
                     .registry
-                    .get_accumulator_health(acc_name)
+                    .get_accumulator_health(
+                        acc_name,
+                        super::registry::EndpointScope::of(running.owner.tenant_id.as_deref()),
+                    )
                     .await
                     .map(|h| h.as_state_label())
                     .unwrap_or("healthy");
@@ -1895,7 +2007,14 @@ mod tests {
         // Push event via registry (simulating WebSocket push)
         let event = TestEvent { value: 42.0 };
         let bytes = serde_json::to_vec(&event).unwrap();
-        registry.send_to_accumulator("alpha", bytes).await.unwrap();
+        registry
+            .send_to_accumulator(
+                "alpha",
+                crate::computation_graph::registry::EndpointScope::untenanted(),
+                bytes,
+            )
+            .await
+            .unwrap();
 
         tokio::time::sleep(std::time::Duration::from_millis(200)).await;
 
@@ -1938,7 +2057,15 @@ mod tests {
         scheduler.load_graph(decl).await.unwrap();
 
         // Verify registered
-        assert_eq!(registry.accumulator_count("alpha").await, 1);
+        assert_eq!(
+            registry
+                .accumulator_count(
+                    "alpha",
+                    crate::computation_graph::registry::EndpointScope::untenanted()
+                )
+                .await,
+            1
+        );
         assert!(registry
             .list_reactors()
             .await
@@ -1948,7 +2075,15 @@ mod tests {
         scheduler.unload_graph("test_graph").await.unwrap();
 
         // Verify deregistered
-        assert_eq!(registry.accumulator_count("alpha").await, 0);
+        assert_eq!(
+            registry
+                .accumulator_count(
+                    "alpha",
+                    crate::computation_graph::registry::EndpointScope::untenanted()
+                )
+                .await,
+            0
+        );
         assert!(registry.list_reactors().await.is_empty());
     }
 

--- a/crates/cloacina/tests/constructor_reactor_scheduler_wasm.rs
+++ b/crates/cloacina/tests/constructor_reactor_scheduler_wasm.rs
@@ -227,6 +227,7 @@ async fn reactor_constructor_fires_via_scheduler() {
     registry
         .send_to_accumulator(
             "x",
+            cloacina::computation_graph::registry::EndpointScope::untenanted(),
             serde_json::to_vec(&serde_json::json!({ "value": 1.0 })).unwrap(),
         )
         .await
@@ -242,6 +243,7 @@ async fn reactor_constructor_fires_via_scheduler() {
     registry
         .send_to_accumulator(
             "x",
+            cloacina::computation_graph::registry::EndpointScope::untenanted(),
             serde_json::to_vec(&serde_json::json!({ "value": 9.0 })).unwrap(),
         )
         .await

--- a/crates/cloacina/tests/integration/computation_graph.rs
+++ b/crates/cloacina/tests/integration/computation_graph.rs
@@ -342,7 +342,7 @@ async fn test_end_to_end_accumulator_reactor_graph() {
 // Test 5: ComputationGraphScheduler — load graph, push via registry, verify fire
 // =============================================================================
 
-use cloacina::computation_graph::registry::EndpointRegistry;
+use cloacina::computation_graph::registry::{EndpointRegistry, EndpointScope};
 use cloacina::computation_graph::scheduler::{
     AccumulatorDeclaration, AccumulatorFactory, AccumulatorSpawnConfig,
     ComputationGraphDeclaration, ComputationGraphScheduler, ReactorDeclaration,
@@ -430,7 +430,11 @@ async fn test_computation_graph_scheduler_end_to_end() {
     // Push event via registry (simulates WebSocket push)
     let event = AlphaData { value: 5.0 };
     registry
-        .send_to_accumulator("alpha", serde_json::to_vec(&event).unwrap())
+        .send_to_accumulator(
+            "alpha",
+            EndpointScope::untenanted(),
+            serde_json::to_vec(&event).unwrap(),
+        )
         .await
         .unwrap();
 
@@ -449,7 +453,10 @@ async fn test_computation_graph_scheduler_end_to_end() {
     assert!(!graphs[0].paused);
 
     // Pause the reactor via handle
-    let handle = registry.get_reactor_handle("scheduler_test").await.unwrap();
+    let handle = registry
+        .get_reactor_handle("scheduler_test", EndpointScope::untenanted())
+        .await
+        .unwrap();
     handle.pause();
     assert!(handle.is_paused());
 
@@ -457,6 +464,7 @@ async fn test_computation_graph_scheduler_end_to_end() {
     registry
         .send_to_accumulator(
             "alpha",
+            EndpointScope::untenanted(),
             serde_json::to_vec(&AlphaData { value: 10.0 }).unwrap(),
         )
         .await
@@ -474,7 +482,11 @@ async fn test_computation_graph_scheduler_end_to_end() {
     handle.resume();
     use cloacina::computation_graph::reactor::ManualCommand;
     registry
-        .send_to_reactor("scheduler_test", ManualCommand::ForceFire)
+        .send_to_reactor(
+            "scheduler_test",
+            EndpointScope::untenanted(),
+            ManualCommand::ForceFire,
+        )
         .await
         .unwrap();
 
@@ -491,7 +503,12 @@ async fn test_computation_graph_scheduler_end_to_end() {
 
     // Registry should be empty
     assert!(registry.list_reactors().await.is_empty());
-    assert_eq!(registry.accumulator_count("alpha").await, 0);
+    assert_eq!(
+        registry
+            .accumulator_count("alpha", EndpointScope::untenanted())
+            .await,
+        0
+    );
 }
 
 // =============================================================================
@@ -1957,7 +1974,11 @@ mod resilience_tests {
         // so poll instead of using a fixed sleep.
         let event = AlphaData { value: 1.0 };
         registry
-            .send_to_accumulator("alpha", serde_json::to_vec(&event).unwrap())
+            .send_to_accumulator(
+                "alpha",
+                EndpointScope::untenanted(),
+                serde_json::to_vec(&event).unwrap(),
+            )
             .await
             .unwrap();
 
@@ -1973,6 +1994,7 @@ mod resilience_tests {
         registry
             .send_to_accumulator(
                 "alpha",
+                EndpointScope::untenanted(),
                 serde_json::to_vec(&AlphaData { value: 2.0 }).unwrap(),
             )
             .await
@@ -2000,6 +2022,7 @@ mod resilience_tests {
         registry
             .send_to_accumulator(
                 "alpha",
+                EndpointScope::untenanted(),
                 serde_json::to_vec(&AlphaData { value: 3.0 }).unwrap(),
             )
             .await
@@ -2102,6 +2125,7 @@ mod resilience_tests {
             registry
                 .send_to_accumulator(
                     "t0915_alpha",
+                    EndpointScope::untenanted(),
                     serde_json::to_vec(&AlphaData { value: 1.0 }).unwrap(),
                 )
                 .await
@@ -2538,7 +2562,7 @@ async fn test_cloaci_t_0538_split_form_scheduler_end_to_end() {
     // compiled function (what the split-form `#[computation_graph]` emits).
     // Push an event through the accumulator registry and assert the graph
     // fires.
-    use cloacina::computation_graph::registry::EndpointRegistry;
+    use cloacina::computation_graph::registry::{EndpointRegistry, EndpointScope};
     use cloacina::computation_graph::scheduler::{
         AccumulatorDeclaration, ComputationGraphScheduler,
     };
@@ -2584,6 +2608,7 @@ async fn test_cloaci_t_0538_split_form_scheduler_end_to_end() {
     registry
         .send_to_accumulator(
             "alpha",
+            EndpointScope::untenanted(),
             serde_json::to_vec(&AlphaData { value: 7.0 }).unwrap(),
         )
         .await
@@ -2686,7 +2711,7 @@ async fn test_cloaci_t_0538_split_missing_accumulator_fails() {
 /// receive the same firing.
 #[tokio::test]
 async fn test_cloaci_t_0544_two_graphs_share_one_reactor_via_split_form() {
-    use cloacina::computation_graph::registry::EndpointRegistry;
+    use cloacina::computation_graph::registry::{EndpointRegistry, EndpointScope};
     use cloacina::computation_graph::scheduler::{
         AccumulatorDeclaration, ComputationGraphScheduler,
     };
@@ -2746,6 +2771,7 @@ async fn test_cloaci_t_0544_two_graphs_share_one_reactor_via_split_form() {
     registry
         .send_to_accumulator(
             "alpha",
+            EndpointScope::untenanted(),
             serde_json::to_vec(&AlphaData { value: 4.0 }).unwrap(),
         )
         .await
@@ -2776,6 +2802,7 @@ async fn test_cloaci_t_0544_two_graphs_share_one_reactor_via_split_form() {
     registry
         .send_to_accumulator(
             "alpha",
+            EndpointScope::untenanted(),
             serde_json::to_vec(&AlphaData { value: 5.0 }).unwrap(),
         )
         .await
@@ -2876,7 +2903,7 @@ async fn test_cloaci_t_0544_contract_mismatch_rejected() {
 /// before the slow one.
 #[tokio::test]
 async fn test_cloaci_t_0544_dispatch_is_concurrent() {
-    use cloacina::computation_graph::registry::EndpointRegistry;
+    use cloacina::computation_graph::registry::{EndpointRegistry, EndpointScope};
     use cloacina::computation_graph::scheduler::{
         AccumulatorDeclaration, ComputationGraphScheduler,
     };
@@ -2958,6 +2985,7 @@ async fn test_cloaci_t_0544_dispatch_is_concurrent() {
     registry
         .send_to_accumulator(
             "alpha",
+            EndpointScope::untenanted(),
             serde_json::to_vec(&AlphaData { value: 1.0 }).unwrap(),
         )
         .await
@@ -2995,7 +3023,7 @@ async fn test_cloaci_t_0544_dispatch_is_concurrent() {
 /// independently of `load_graph`.
 #[tokio::test]
 async fn test_cloaci_t_0545_load_reactor_then_bind_graph() {
-    use cloacina::computation_graph::registry::EndpointRegistry;
+    use cloacina::computation_graph::registry::{EndpointRegistry, EndpointScope};
     use cloacina::computation_graph::scheduler::{
         AccumulatorDeclaration, ComputationGraphScheduler,
     };
@@ -3026,7 +3054,10 @@ async fn test_cloaci_t_0545_load_reactor_then_bind_graph() {
     // aliasing because we passed `register_aliases: vec![]`).
     assert!(
         registry
-            .get_reactor_handle("cloaci_t_0545_standalone_reactor")
+            .get_reactor_handle(
+                "cloaci_t_0545_standalone_reactor",
+                EndpointScope::untenanted()
+            )
             .await
             .is_some(),
         "reactor should be in the endpoint registry under its name"
@@ -3096,6 +3127,7 @@ async fn test_cloaci_t_0545_load_reactor_then_bind_graph() {
     registry
         .send_to_accumulator(
             "alpha",
+            EndpointScope::untenanted(),
             serde_json::to_vec(&AlphaData { value: 1.0 }).unwrap(),
         )
         .await
@@ -3129,7 +3161,7 @@ async fn test_cloaci_t_0545_load_reactor_then_bind_graph() {
 /// firings from the same reactor instance.
 #[tokio::test]
 async fn test_cloaci_t_0544_unbind_keeps_reactor_running() {
-    use cloacina::computation_graph::registry::EndpointRegistry;
+    use cloacina::computation_graph::registry::{EndpointRegistry, EndpointScope};
     use cloacina::computation_graph::scheduler::{
         AccumulatorDeclaration, ComputationGraphScheduler,
     };
@@ -3193,6 +3225,7 @@ async fn test_cloaci_t_0544_unbind_keeps_reactor_running() {
     registry
         .send_to_accumulator(
             "alpha",
+            EndpointScope::untenanted(),
             serde_json::to_vec(&AlphaData { value: 9.0 }).unwrap(),
         )
         .await
@@ -3474,4 +3507,216 @@ async fn test_cloaci_t_0540_task_invokes_trigger_less_graph() {
         .expect("terminal node 'output' should be inserted into context");
     assert_eq!(terminal["published"], true);
     assert_eq!(terminal["value"], 6.0);
+}
+
+// ---------------------------------------------------------------------------
+// CLOACI-T-0921 — tenant is THE isolation boundary
+// ---------------------------------------------------------------------------
+
+/// Two tenants each load a reactor that declares an accumulator named
+/// `t0921_shared`. Injecting as tenant A must fire ONLY A's graph, and
+/// unloading A's reactor must leave B's alive and still firing.
+///
+/// Before CLOACI-T-0921 `EndpointRegistry` keyed accumulators by bare name and
+/// `register_accumulator` *appended* senders, so A's inject was broadcast into
+/// B's boundary channel and `deregister_accumulator(name)` tore down both.
+#[tokio::test]
+async fn test_cloaci_t_0921_cross_tenant_accumulator_isolation() {
+    use cloacina::computation_graph::registry::{EndpointRegistry, EndpointScope};
+    use cloacina::computation_graph::scheduler::{
+        AccumulatorDeclaration, ComputationGraphScheduler,
+    };
+    use cloacina_computation_graph::CompiledGraphFn;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    let registry = EndpointRegistry::new();
+    let scheduler = ComputationGraphScheduler::new(registry.clone());
+
+    let a_fires = Arc::new(AtomicU32::new(0));
+    let b_fires = Arc::new(AtomicU32::new(0));
+
+    let mk_fn = |counter: Arc<AtomicU32>| -> CompiledGraphFn {
+        Arc::new(move |_cache: InputCache| {
+            let c = counter.clone();
+            Box::pin(async move {
+                c.fetch_add(1, Ordering::SeqCst);
+                GraphResult::completed(vec![])
+            })
+        })
+    };
+
+    // Same accumulator name in both tenants; different reactor names.
+    for (reactor, tenant) in [("t0921_rx_a", "acme"), ("t0921_rx_b", "globex")] {
+        scheduler
+            .load_reactor(
+                reactor.to_string(),
+                vec![AccumulatorDeclaration {
+                    name: "t0921_shared".to_string(),
+                    factory: Arc::new(TestAccumulatorFactory),
+                }],
+                cloacina::computation_graph::reactor::ReactionCriteria::WhenAny,
+                cloacina::computation_graph::reactor::InputStrategy::Latest,
+                Some(tenant.to_string()),
+                vec![],
+                None,
+            )
+            .await
+            .unwrap_or_else(|e| panic!("tenant {tenant} should load its own reactor: {e}"));
+    }
+
+    scheduler
+        .bind_graph_to_reactor(
+            "t0921_g_a".to_string(),
+            "t0921_rx_a".to_string(),
+            mk_fn(a_fires.clone()),
+        )
+        .await
+        .unwrap();
+    scheduler
+        .bind_graph_to_reactor(
+            "t0921_g_b".to_string(),
+            "t0921_rx_b".to_string(),
+            mk_fn(b_fires.clone()),
+        )
+        .await
+        .unwrap();
+
+    // ---- Inject as tenant A ----
+    let delivered = registry
+        .send_to_accumulator(
+            "t0921_shared",
+            EndpointScope::tenant("acme"),
+            serde_json::to_vec(&AlphaData { value: 1.0 }).unwrap(),
+        )
+        .await
+        .expect("tenant A's inject should resolve to its own accumulator");
+    assert_eq!(
+        delivered, 1,
+        "exactly one recipient — tenant A's accumulator"
+    );
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+    while std::time::Instant::now() < deadline && a_fires.load(Ordering::SeqCst) == 0 {
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+    assert_eq!(a_fires.load(Ordering::SeqCst), 1, "tenant A's graph fired");
+    assert_eq!(
+        b_fires.load(Ordering::SeqCst),
+        0,
+        "tenant B must receive NOTHING from tenant A's inject"
+    );
+
+    // A tenant cannot reach the other tenant's accumulator by naming it.
+    let mut initech = registry
+        .send_to_accumulator(
+            "t0921_shared",
+            EndpointScope::tenant("initech"),
+            serde_json::to_vec(&AlphaData { value: 2.0 }).unwrap(),
+        )
+        .await;
+    assert!(
+        initech.is_err(),
+        "a third tenant must not resolve either tenant's accumulator"
+    );
+
+    // ---- Unload tenant A; tenant B survives ----
+    scheduler.unload_graph("t0921_g_a").await.unwrap();
+
+    initech = registry
+        .send_to_accumulator(
+            "t0921_shared",
+            EndpointScope::tenant("acme"),
+            serde_json::to_vec(&AlphaData { value: 3.0 }).unwrap(),
+        )
+        .await;
+    assert!(initech.is_err(), "tenant A's accumulator is gone");
+
+    let delivered_b = registry
+        .send_to_accumulator(
+            "t0921_shared",
+            EndpointScope::tenant("globex"),
+            serde_json::to_vec(&AlphaData { value: 4.0 }).unwrap(),
+        )
+        .await
+        .expect("tenant B's accumulator must survive tenant A's unload");
+    assert_eq!(delivered_b, 1);
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+    while std::time::Instant::now() < deadline && b_fires.load(Ordering::SeqCst) == 0 {
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+    assert_eq!(
+        b_fires.load(Ordering::SeqCst),
+        1,
+        "tenant B's graph still fires after tenant A unloaded"
+    );
+
+    scheduler.unload_graph("t0921_g_b").await.unwrap();
+}
+
+/// Two packages in the SAME tenant claiming one accumulator name is a LOUD
+/// load-time rejection, not a silent cross-wire — and the rejected load leaves
+/// nothing half-wired behind.
+#[tokio::test]
+async fn test_cloaci_t_0921_same_tenant_duplicate_accumulator_rejected() {
+    use cloacina::computation_graph::registry::{EndpointRegistry, EndpointScope};
+    use cloacina::computation_graph::scheduler::{
+        AccumulatorDeclaration, ComputationGraphScheduler,
+    };
+
+    let registry = EndpointRegistry::new();
+    let scheduler = ComputationGraphScheduler::new(registry.clone());
+
+    let load = |reactor: &'static str| {
+        let scheduler = &scheduler;
+        async move {
+            scheduler
+                .load_reactor(
+                    reactor.to_string(),
+                    vec![AccumulatorDeclaration {
+                        name: "t0921_contended".to_string(),
+                        factory: Arc::new(TestAccumulatorFactory),
+                    }],
+                    cloacina::computation_graph::reactor::ReactionCriteria::WhenAny,
+                    cloacina::computation_graph::reactor::InputStrategy::Latest,
+                    Some("acme".to_string()),
+                    vec![],
+                    None,
+                )
+                .await
+        }
+    };
+
+    load("t0921_first_rx").await.expect("first load wins");
+
+    let err = load("t0921_second_rx")
+        .await
+        .expect_err("a second package in the same tenant must be rejected");
+    assert!(
+        err.contains("t0921_contended") && err.contains("acme"),
+        "rejection must name the contended endpoint and the tenant: {err}"
+    );
+    assert!(
+        err.contains("t0921_first_rx") && err.contains("t0921_second_rx"),
+        "rejection must name both owners: {err}"
+    );
+
+    // The incumbent is untouched and still the only registration.
+    assert_eq!(
+        registry
+            .accumulator_count("t0921_contended", EndpointScope::tenant("acme"))
+            .await,
+        1,
+        "the rejected load must not have appended a second sender"
+    );
+    // And the rejected reactor left no endpoint behind.
+    assert!(
+        registry
+            .get_reactor_handle("t0921_second_rx", EndpointScope::tenant("acme"))
+            .await
+            .is_none(),
+        "the rejected load must unwind its reactor registration"
+    );
+
+    scheduler.unload_reactor("t0921_first_rx").await.unwrap();
 }

--- a/crates/cloacina/tests/integration/dal/reconciler_e2e_load.rs
+++ b/crates/cloacina/tests/integration/dal/reconciler_e2e_load.rs
@@ -50,7 +50,7 @@
 //! separately so this e2e suite can ship.
 
 use crate::fixtures::get_or_init_fixture;
-use cloacina::computation_graph::registry::EndpointRegistry;
+use cloacina::computation_graph::registry::{EndpointRegistry, EndpointScope};
 use cloacina::computation_graph::scheduler::ComputationGraphScheduler;
 use cloacina::registry::reconciler::{ReconcilerConfig, RegistryReconciler};
 use cloacina::registry::traits::WorkflowRegistry;
@@ -228,7 +228,7 @@ async fn reconciler_loads_cross_package_publisher_subscriber_end_to_end() {
     let event_bytes =
         serde_json::to_vec(&serde_json::json!({"value": 42.0})).expect("serialize event");
     endpoint_registry
-        .send_to_accumulator("alpha", event_bytes)
+        .send_to_accumulator("alpha", EndpointScope::untenanted(), event_bytes)
         .await
         .expect("event send to accumulator should succeed");
     tokio::time::sleep(std::time::Duration::from_millis(200)).await;

--- a/crates/cloacina/tests/integration/dal/reconciler_e2e_load.rs
+++ b/crates/cloacina/tests/integration/dal/reconciler_e2e_load.rs
@@ -228,7 +228,11 @@ async fn reconciler_loads_cross_package_publisher_subscriber_end_to_end() {
     let event_bytes =
         serde_json::to_vec(&serde_json::json!({"value": 42.0})).expect("serialize event");
     endpoint_registry
-        .send_to_accumulator("alpha", EndpointScope::untenanted(), event_bytes)
+        // The reconciler registered this endpoint under its
+        // `default_tenant_id` ("public"), so the send must resolve in that
+        // tenant's scope — the same way the WS bridge scopes by the
+        // authenticated key's tenant (CLOACI-T-0921).
+        .send_to_accumulator("alpha", EndpointScope::tenant("public"), event_bytes)
         .await
         .expect("event send to accumulator should succeed");
     tokio::time::sleep(std::time::Duration::from_millis(200)).await;


### PR DESCRIPTION
## Summary

Tenant is THE isolation boundary — the entire authz design rests on it being structural — but eight `EndpointRegistry` maps and both Python CG registries were keyed by **bare entity name**, so same-named accumulators/graphs from different tenants collided inside one server process: cross-wiring on inject, teardown removing the other tenant's entry, last-load-wins on Python executors (CLOACI-T-0921).

**Audit first**: all 26 process-global name-keyed maps enumerated and classified (table lives in the ticket). Verified-safe ones include `RuntimeInner.tasks` (already `TaskNamespace`-keyed — the pattern the others should copy) and `DeliverySink.by_key` (already `(recipient, tenant)` — used as the reference shape). Safety was verified, never assumed.

**EndpointRegistry**: all 8 maps key on `EndpointKey { tenant_id, name }` with `EndpointOwner` stamped per entry. Resolution goes own-tenant → untenanted (embedded/pre-tenancy) → admin-only *unique* cross-tenant match; two tenants owning a name yields `AmbiguousEndpoint` rather than a guess, and non-admins can't reach another tenant's endpoint at all. A different owner claiming a live `(tenant, name)` is a loud `EndpointOwnershipConflict`; `load_reactor` unwinds so nothing is left half-wired. Deregistration is owner-scoped and now also clears the health/freshness/policy/inject side tables that previously leaked past unload.

**Bonus hole closed during the audit**: `list_accumulators_with_health_for_key` fell back to `allow_all` for accumulators with no policy row — letting tenant B enumerate tenant A's accumulator names. Now gated on tenant before the policy check.

**No API change**: `/v1/ws/{accumulator,reactor}/{name}` keep bare-name paths. `AuthenticatedKey` (tenant + is_admin) was already in scope in both handlers for the policy check — it's now threaded into resolution too, plus the `health_graphs` REST equivalents.

**Python**: new `registration_scope.rs` (tenancy counterpart to `ScopedRuntime`, nesting-safe); `GRAPH_EXECUTORS`/`ACCUMULATOR_REGISTRY` key on `GraphKey { tenant_id, package, name }` with mirrored resolution; reader-side scoping fixed too.

## Test plan
- 7 registry unit tests, 2 CG integration tests, 4 Python-side: cross-tenant isolation (inject A → B silent; deregister A → B survives), same-tenant collision rejection, per-scope Python executors
- Suites run: 54 + 50 + 5 + 138 pass (one pre-existing SQLite parallel-test flake, passes in isolation)
- `cargo check` clean across cloacina/-python/-server/-agent; `fmt --check` clean

## Deferred (recorded in the ticket)
`Runtime`/`ComputationGraphScheduler` re-keying (~12 public call sites + an unload API change), `EndpointOwner.package` provenance, Python drain buffers (GIL-serialized on today's import path), `PROVIDER_SEARCH_PATH` (a different tenant-blindness class). No follow-up tickets filed yet.