### PR TITLE
fix(T-0919): interrupt hung Python imports; surface a wedged runtime on /ready; thread-local the context stack

### DIFF
--- a/.metis/backlog/bugs/CLOACI-T-0919.md
+++ b/.metis/backlog/bugs/CLOACI-T-0919.md
@@ -4,15 +4,15 @@ level: task
 title: "Python runtime edges — unkillable import hang bricks the subsystem, global workflow-context stack race"
 short_code: "CLOACI-T-0919"
 created_at: 2026-08-02T16:33:45.835985+00:00
-updated_at: 2026-08-04T04:59:55.885467+00:00
-parent: 
+updated_at: 2026-08-02T16:33:45.835985+00:00
+parent:
 blocked_by: []
 archived: false
 
 tags:
   - "#task"
+  - "#phase/backlog"
   - "#bug"
-  - "#phase/active"
 
 
 exit_criteria_met: false
@@ -40,13 +40,35 @@ Fix the two residual structural edges in the Python integration found by the dee
 
 ## Acceptance Criteria
 
-## Acceptance Criteria
-
-## Acceptance Criteria
-
-- [ ] A module-scope infinite loop in a packaged upload results in a visible degraded state (health surface + log) and, if interruption is implemented, a recovered runtime — test with a hostile fixture
-- [ ] Concurrent loads of two packages from two threads namespace their tasks correctly (test), or cross-thread use hard-errors
+- [x] A module-scope infinite loop in a packaged upload results in a visible degraded state (health surface + log) and, if interruption is implemented, a recovered runtime — test with a hostile fixture
+- [x] Concurrent loads of two packages from two threads namespace their tasks correctly (test), or cross-thread use hard-errors
 
 ## Status Updates
 
 - 2026-08-02: Filed from the architecture deep dive (python-integration report; DEEPDIVE.md register high tier for #1). Verified against main @ 5216e632.
+- 2026-08-05 (agent, worktree .claude/worktrees/t-0919 @ 35a1769c): CODE SHAPE VERIFIED before touching anything.
+  - Import hang: `crates/cloacina-python/src/loader.rs:38` `const IMPORT_TIMEOUT_SECS: u64 = 60` (hardcoded, no knob); import runs on `std::thread::spawn` at `loader.rs:206` inside `Python::with_gil`; poll-join watchdog at `loader.rs:411-427` (`handle.is_finished()` / 100ms sleep / return Err on elapsed>timeout) — it abandons the thread, no kill, no health surface. Same pattern repeats for CGs in `import_python_computation_graph` (`loader.rs:443+`, timeout at `loader.rs:452`).
+  - `PythonRuntime` trait (`crates/cloacina/src/python_runtime.rs:67`) is a 2-method seam + `OnceLock` registry (`:96-110`). No health/state surface today → wedged flag will be added as free functions in this module (cloacina has the `metrics` dep at `crates/cloacina/Cargo.toml:98`; cloacina-python does NOT, so metric emission helpers live here and cloacina-python calls them).
+  - `/ready` is `crates/cloacina-server/src/lib.rs:2075` (`async fn ready`), post-#231 predicate is DB-only; utoipa annotation `:2067-2074`; route wired `:1986`. Regression guard test `ready_stays_200_with_crashed_graph_visible_in_health_routes` at `:2747`.
+  - Item 2: `static WORKFLOW_CONTEXT_STACK: Mutex<Vec<WorkflowBuilderRef>>` at `crates/cloacina-python/src/task.rs:87`; push/pop/current at `:90/:97/:102`. Consumers audited — ALL are import-time/same-thread: `task.rs:577` (TaskDecorator::__call__), `constructor.rs:71`, `workflow.rs:161/173` (`__enter__`/`__exit__`), `loader.rs:303/308/316`, plus tests. Nothing pushes on one thread and pops on another → thread-local move is safe.
+  - Thread-local runtime seam already exists: `crates/cloacina-python/src/runtime_scope.rs` (`CURRENT_RUNTIME` thread_local + `ScopedRuntime` RAII, errors on nesting). Item 2 will mirror it.
+  - Test patterns: `crates/cloacina-python/tests/python_package.rs` (`#[serial_test::serial(python_import)]`, `pyo3::prepare_freethreaded_python()`, temp-dir fixture packages) — new hostile-fixture test follows this.
+- 2026-08-05 (agent): ITEM 1a/1b LANDED (compiles, `cargo check -p cloacina-python --all-targets` clean).
+  - NEW `crates/cloacina-python/src/import_guard.rs` (registered `pub mod import_guard` in lib.rs): `import_timeout()` (env knob `CLOACINA_PYTHON_IMPORT_TIMEOUT_SECS`, default 60s), `ImportThreadIdent` (Arc<AtomicI64>, `.record(py)` via `threading.get_ident()` — pyo3-ffi 0.25 has NO `PyThread_get_thread_ident`), and `supervise_import()` = the ladder. Custom exception `ImportTimeout` via `create_exception!(cloaca, ImportTimeout, PyBaseException, ...)` — BaseException on purpose so a module-scope `except Exception` cannot swallow the deadline.
+  - `PyThreadState_SetAsyncExc` signature in pyo3-ffi 0.25.1 is `(c_long, *mut PyObject) -> c_int` (`pystate.rs:64`). Revert protocol IS handled: `if modified > 1 { call again with null_mut() }`.
+  - Injection runs on a scratch `std::thread` doing `Python::with_gil` and is poll-joined for 5s (`GIL_ACQUIRE_TIMEOUT`) — not tokio spawn_blocking, because the loader entrypoints are sync fns with no runtime handle; same "can't get the GIL fast ⇒ C-level hold" evidence, no tokio coupling. Grace join 5s, 2 injection attempts.
+  - Wedged surface: free functions in `crates/cloacina/src/python_runtime.rs` (NOT a trait method — the trait is per-impl, the wedge is per-process, and cloacina-server must read it without linking pyo3): `mark_python_runtime_wedged(reason)` (latching, keeps FIRST reason, gauge `cloacina_python_runtime_wedged`=1 + `error!`), `is_python_runtime_wedged()`, `python_runtime_wedged_reason()`, `record_python_import_interrupted()` (counter `cloacina_python_import_interrupted_total`), `init_python_runtime_health_metrics()` (publishes gauge 0 baseline, called from `register_python_runtime`). Metrics live here because cloacina has the `metrics` dep and cloacina-python does not.
+  - Both loader entrypoints now use the ladder: `import_and_register_python_workflow_named` and `import_python_computation_graph` (their hand-rolled poll-join loops deleted).
+  - NEXT: /ready wiring, item 2, tests.
+- 2026-08-05 (agent): /READY + ITEM 2 LANDED; new tests GREEN.
+  - `/ready` (`crates/cloacina-server/src/lib.rs`) now returns 503 with `reason` = the wedged reason when `cloacina::python_runtime::python_runtime_wedged_reason()` is Some. #231 semantics preserved: the wedge is set by THIS process's own import thread (replica-local), tenant workloads still cannot fail readiness; `ready_stays_200_with_crashed_graph_visible_in_health_routes` untouched. New test `ready_reports_503_when_python_runtime_is_wedged` (asserts 200 first, then 503 + reason names the package, resets the flag before asserting so a failure can't poison the binary). Added `#[doc(hidden)] reset_python_runtime_wedged_for_tests()` because the production flag is latching and process-global.
+  - Utoipa annotation on `/ready` WAS edited (200/503 descriptions) + the doc comment → openapi.json + TS client regen REQUIRED. Not yet done at this checkpoint.
+  - Item 2: `WORKFLOW_CONTEXT_STACK` is now `thread_local! { ContextStack(RefCell<Vec<WorkflowBuilderRef>>) }` in `crates/cloacina-python/src/task.rs`, plus a process-global `ACTIVE_CONTEXT_PUSHES: AtomicUsize` used ONLY to diagnose cross-thread misuse. `ContextStack` has a `Drop` that decrements the counter by whatever is left, so an interrupted import thread cannot leave it inflated. Cross-thread decorator evaluation = a hard `PyValueError` in EVERY build (a `debug_assert!` panic across the pyo3 boundary would be worse, and it is user-reachable); the `debug_assert!` sits on the `pop_workflow_context()` path, which only internal code can reach.
+  - NEW `crates/cloacina-python/tests/python_import_edges.rs` — 3 tests, ALL PASS (`cargo test -p cloacina-python --test python_import_edges`, 2.20s): hostile `while True: pass` at module scope fails via the interrupt path (asserts the error says "interrupted", asserts NOT wedged, asserts the env knob shortened the deadline) and a SUBSEQUENT good package still loads; two threads loading two packages concurrently keep their own tenant/package/workflow; a foreign thread calling the decorator seam gets the deterministic cross-thread error.
+  - Documented in the test-file header: a true C-level hang is NOT portably testable (needs a per-platform hostile native module, and a failure would wedge the test binary itself) — the wedged path is covered by the flag unit test + the /ready test instead.
+- 2026-08-05 (agent): COMPLETE in the worktree (uncommitted, per instruction). Final state:
+  - Added `ensure_python_runtime_usable()` fail-fast at BOTH loader entrypoints — once wedged, a further load would otherwise park a fresh thread on a GIL nobody releases (a thread leak per attempt, and a hang instead of an error).
+  - OPENAPI + TS REGEN DONE (the utoipa annotation and its doc comment were both edited, so both gates applied): `cargo run -p cloacina-server --bin cloacina-server -- emit-openapi` → `docs/static/openapi.json` (204941 bytes, parses as JSON; diff vs HEAD is 13 lines, ALL under `paths./ready`). `cd clients/typescript && npm ci && npm run generate` then `npm run check:generated` → exit 0 (clean diff).
+  - VALIDATION: `cargo check -p cloacina-python --all-targets`, `-p cloacina --no-default-features --features postgres,sqlite`, `-p cloacina-server --all-targets` — all clean. `cargo fmt --all` run (only the two new files needed formatting).
+  - TESTS GREEN: `python_import_edges` 3/3; `cloacina-python --lib` 137/137; `python_package` 13/13, `python_reactor_library` 1/1, `trigger_packaging` 4/4, `cross_language_fan_out` 10/10; `cloacina --lib python_runtime` 2/2; `cloacina-server --lib ready` 3/3 (incl. the #231 guard `ready_stays_200_with_crashed_graph_visible_in_health_routes`). The postgres-backed tests need the dev stack — started `docker compose up -d postgres` from `.angreal/` (port 15432); before that, 3 python_package tests failed on connection-refused only.
+  - RESIDUALS: (1) a true C-level hang stays untestable and unrecoverable by design — the wedged flag is the deliverable there; (2) module-scope code that catches `BaseException` in its own loop can swallow the injected `ImportTimeout` and is then indistinguishable from a C hang (it wedges); (3) the wedged flag is latching and never self-clears — `reset_python_runtime_wedged_for_tests()` is `#[doc(hidden)]` test support only; (4) a thread that stays wedged keeps its `ACTIVE_CONTEXT_PUSHES` increment (the `ContextStack::drop` refund only runs if the thread exits) — harmless, the process is already 503; (5) the new env knob `CLOACINA_PYTHON_IMPORT_TIMEOUT_SECS` is documented only in rustdoc — no env-var reference page exists in `docs/` to add it to.

--- a/clients/typescript/generated/types.ts
+++ b/clients/typescript/generated/types.ts
@@ -30,11 +30,19 @@ export interface paths {
         };
         /**
          * GET /ready — readiness check, scoped to PLATFORM health only (DB
-         *     reachable). CLOACI-T-0916: tenant-workload health is deliberately NOT part
-         *     of readiness — one crashed computation graph used to flip `/ready` false on
-         *     EVERY replica simultaneously, letting a single bad package eject the whole
-         *     server fleet from the load-balancer pool. Crashed graphs remain visible via
+         *     reachable, embedded Python interpreter usable). CLOACI-T-0916:
+         *     tenant-workload health is deliberately NOT part of readiness — one crashed
+         *     computation graph used to flip `/ready` false on EVERY replica
+         *     simultaneously, letting a single bad package eject the whole server fleet
+         *     from the load-balancer pool. Crashed graphs remain visible via
          *     `GET /v1/health/graphs` (state `stopped`/`crashed`) and metrics.
+         * @description CLOACI-T-0919 adds one more PLATFORM predicate: a wedged Python runtime.
+         *     There is exactly one embedded CPython per process, so an uninterruptible
+         *     module-scope hang disables Python package loading process-wide until
+         *     restart. That is this replica being broken — not a tenant workload
+         *     misbehaving — so it belongs in readiness, and it is replica-local (the
+         *     wedge is set by THIS process's own import thread), which is precisely the
+         *     property #231 required.
          */
         get: operations["ready"];
         put?: never;
@@ -2371,14 +2379,14 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Ready — DB reachable. Tenant-workload health (e.g. crashed computation graphs) does NOT affect readiness; see /v1/health/graphs. */
+            /** @description Ready — DB reachable and the embedded Python runtime is usable. Tenant-workload health (e.g. crashed computation graphs) does NOT affect readiness; see /v1/health/graphs. */
             200: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content?: never;
             };
-            /** @description Not ready — `reason` field explains (database unreachable) */
+            /** @description Not ready — `reason` field explains (database unreachable, or the embedded Python runtime is wedged by a package import hang and this process must be restarted) */
             503: {
                 headers: {
                     [name: string]: unknown;

--- a/crates/cloacina-python/src/import_guard.rs
+++ b/crates/cloacina-python/src/import_guard.rs
@@ -1,0 +1,357 @@
+/*
+ *  Copyright 2026 Colliery Software
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+//! Supervision for packaged-Python module imports (CLOACI-T-0919).
+//!
+//! User code runs arbitrary statements at module scope during a package
+//! import. If it never returns, the import thread never returns either — and
+//! because cloacina embeds ONE CPython interpreter per process, an abandoned
+//! import thread that keeps the GIL takes the whole Python subsystem with it.
+//! Before this module the only mitigation was a poll-join timeout that
+//! *returned* to the caller while leaving the thread running: the package load
+//! reported failure and the process quietly lost the ability to load any
+//! Python package until restart.
+//!
+//! # The ladder
+//!
+//! 1. **Interrupt.** A *pure-Python* infinite loop does NOT hold the GIL
+//!    exclusively — CPython's eval breaker switches threads every few
+//!    milliseconds — so another thread can acquire the GIL and inject an
+//!    asynchronous exception into the hung thread with
+//!    `PyThreadState_SetAsyncExc`. The exception is raised at the hung
+//!    thread's next bytecode boundary, the import unwinds, the thread joins,
+//!    and the interpreter is left healthy. This recovers the overwhelmingly
+//!    common case (`while True: pass`, a runaway comprehension, a spin-wait).
+//!
+//! 2. **Surface.** Interruption cannot beat everything: a hang inside a C
+//!    extension that never returns to the eval loop never reaches a bytecode
+//!    boundary, and code that catches `BaseException` inside its own loop can
+//!    swallow the injected exception. Those are indistinguishable from here.
+//!    When the grace join fails we latch the process-global wedged flag
+//!    (`cloacina::python_runtime::mark_python_runtime_wedged`), which drives
+//!    the `cloacina_python_runtime_wedged` gauge, a loud `error!`, and a
+//!    failing `/ready` — the operator sees a broken replica instead of
+//!    silently vanishing Python support.
+//!
+//! Note on `time.sleep`: it releases the GIL, so a sleeping thread does not
+//! block the interrupter, but the async exception only lands when the sleep
+//! returns. A long sleep therefore looks like a wedge until it finishes.
+
+use std::sync::atomic::{AtomicI64, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use pyo3::prelude::*;
+use pyo3::type_object::PyTypeInfo;
+
+use crate::loader::PythonLoaderError;
+
+/// Default timeout for Python module import (seconds).
+pub const DEFAULT_IMPORT_TIMEOUT_SECS: u64 = 60;
+
+/// Environment override for the import timeout. Exists so tests (and
+/// operators with pathologically slow packages) don't have to live with the
+/// 60s default; a hostile-fixture test cannot wait a minute.
+pub const IMPORT_TIMEOUT_ENV: &str = "CLOACINA_PYTHON_IMPORT_TIMEOUT_SECS";
+
+/// How long the interrupter thread gets to acquire the GIL. Failing to get it
+/// in this window is itself evidence of a C-level hold that never returns to
+/// the eval loop (a pure-Python loop yields the GIL every few ms).
+const GIL_ACQUIRE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// How long the hung thread gets to unwind after the async exception lands.
+const INTERRUPT_GRACE: Duration = Duration::from_secs(5);
+
+/// Async-exception injection attempts before declaring the runtime wedged.
+/// Two, not one: the exception is dropped if the target is inside a C call
+/// when it is set, so a second attempt after the grace window catches threads
+/// that returned to the eval loop in between.
+const INTERRUPT_ATTEMPTS: u32 = 2;
+
+/// Poll granularity for the join loops.
+const POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+pyo3::create_exception!(
+    cloaca,
+    ImportTimeout,
+    pyo3::exceptions::PyBaseException,
+    "Raised inside a packaged-workflow import thread that exceeded the \
+     import deadline. Inherits BaseException so a module-scope `except \
+     Exception` cannot swallow the deadline."
+);
+
+/// Effective import timeout: [`IMPORT_TIMEOUT_ENV`] if it parses as a positive
+/// integer, else [`DEFAULT_IMPORT_TIMEOUT_SECS`].
+pub fn import_timeout() -> Duration {
+    match std::env::var(IMPORT_TIMEOUT_ENV) {
+        Ok(raw) => match raw.trim().parse::<u64>() {
+            Ok(secs) if secs > 0 => Duration::from_secs(secs),
+            _ => {
+                tracing::warn!(
+                    value = %raw,
+                    "{IMPORT_TIMEOUT_ENV} is not a positive integer — using the {DEFAULT_IMPORT_TIMEOUT_SECS}s default"
+                );
+                Duration::from_secs(DEFAULT_IMPORT_TIMEOUT_SECS)
+            }
+        },
+        Err(_) => Duration::from_secs(DEFAULT_IMPORT_TIMEOUT_SECS),
+    }
+}
+
+/// Refuse to start an import when the interpreter is already known-wedged.
+///
+/// Without this, every later load spawns a thread that blocks forever trying
+/// to acquire a GIL nobody will release — leaking a thread per attempt and
+/// turning a clear failure into a hang. Fail fast with the original cause
+/// instead; only a restart fixes the wedge.
+pub fn ensure_python_runtime_usable(label: &str) -> Result<(), PythonLoaderError> {
+    match cloacina::python_runtime::python_runtime_wedged_reason() {
+        Some(reason) => Err(PythonLoaderError::RuntimeError(format!(
+            "refusing to import '{label}': {reason}. The embedded Python interpreter \
+             is unrecoverable in this process — restart it."
+        ))),
+        None => Ok(()),
+    }
+}
+
+/// Shared slot holding the Python-level thread id (`threading.get_ident()`) of
+/// an import thread, so the supervisor can target it with
+/// `PyThreadState_SetAsyncExc`. `-1` means "not recorded yet".
+#[derive(Debug, Default)]
+pub struct ImportThreadIdent(AtomicI64);
+
+impl ImportThreadIdent {
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self(AtomicI64::new(-1)))
+    }
+
+    /// Record the CURRENT thread's Python ident. Called from inside the import
+    /// thread once it holds the GIL, before any user code runs.
+    pub fn record(&self, py: Python<'_>) {
+        match py
+            .import("threading")
+            .and_then(|t| t.call_method0("get_ident"))
+            .and_then(|id| id.extract::<i64>())
+        {
+            Ok(ident) => self.0.store(ident, Ordering::SeqCst),
+            Err(e) => tracing::warn!(
+                error = %e,
+                "could not record Python thread ident — an import hang on this \
+                 thread will not be interruptible"
+            ),
+        }
+    }
+
+    fn get(&self) -> Option<i64> {
+        match self.0.load(Ordering::SeqCst) {
+            -1 => None,
+            id => Some(id),
+        }
+    }
+}
+
+/// Outcome of an interruption attempt against a hung import thread.
+#[derive(Debug, PartialEq, Eq)]
+enum InterruptOutcome {
+    /// The async exception was installed on the target thread state.
+    Injected,
+    /// The GIL could not be acquired inside [`GIL_ACQUIRE_TIMEOUT`] — strong
+    /// evidence of a C-level hold that never yields.
+    GilUnavailable,
+    /// `PyThreadState_SetAsyncExc` found no thread with that id (it already
+    /// exited), or the ident was never recorded.
+    NoSuchThread,
+}
+
+/// Inject [`ImportTimeout`] into the Python thread `ident`, from a scratch
+/// thread so a GIL that never becomes available cannot hang the supervisor.
+fn inject_async_exception(ident: i64) -> InterruptOutcome {
+    let worker = std::thread::spawn(move || -> i32 {
+        Python::with_gil(|py| {
+            // SAFETY: the GIL is held for the duration of this call (required
+            // by PyThreadState_SetAsyncExc, which walks the interpreter's
+            // thread-state list). `exc` is a borrowed reference to a type
+            // object that outlives the call — CPython INCREFs it itself.
+            let exc = ImportTimeout::type_object(py);
+            let modified =
+                unsafe { pyo3::ffi::PyThreadState_SetAsyncExc(ident as _, exc.as_ptr()) };
+
+            // Documented revert protocol: a return value > 1 means the call
+            // did something unexpected (more than one thread state matched);
+            // the caller must clear the pending exception by calling again
+            // with NULL, or those threads carry an exception nobody asked for.
+            if modified > 1 {
+                unsafe {
+                    pyo3::ffi::PyThreadState_SetAsyncExc(ident as _, std::ptr::null_mut());
+                }
+            }
+            modified
+        })
+    });
+
+    let deadline = Instant::now() + GIL_ACQUIRE_TIMEOUT;
+    while Instant::now() < deadline {
+        if worker.is_finished() {
+            return match worker.join() {
+                Ok(1) => InterruptOutcome::Injected,
+                Ok(0) => InterruptOutcome::NoSuchThread,
+                // >1 was reverted above; treat as "not usefully injected".
+                Ok(_) | Err(_) => InterruptOutcome::NoSuchThread,
+            };
+        }
+        std::thread::sleep(POLL_INTERVAL);
+    }
+    // The scratch thread is abandoned; it is parked in PyGILState_Ensure and
+    // will finish harmlessly if the GIL is ever released.
+    InterruptOutcome::GilUnavailable
+}
+
+/// Poll-join `handle` until it finishes or `deadline` elapses.
+fn join_within<T>(handle: &std::thread::JoinHandle<T>, timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if handle.is_finished() {
+            return true;
+        }
+        std::thread::sleep(POLL_INTERVAL);
+    }
+    handle.is_finished()
+}
+
+/// Wait for a packaged-Python import thread, escalating through the
+/// interrupt → surface ladder if it blows the deadline.
+///
+/// `label` names the package (or graph) in logs and in the wedged reason.
+/// `ident` must be the slot the import thread populated via
+/// [`ImportThreadIdent::record`].
+pub fn supervise_import<T>(
+    label: &str,
+    handle: std::thread::JoinHandle<Result<T, PythonLoaderError>>,
+    ident: Arc<ImportThreadIdent>,
+    timeout: Duration,
+) -> Result<T, PythonLoaderError> {
+    // Happy path: the import finishes inside the deadline.
+    if join_within(&handle, timeout) {
+        return handle.join().map_err(|_| {
+            PythonLoaderError::RuntimeError("Python import thread panicked".to_string())
+        })?;
+    }
+
+    tracing::error!(
+        package = %label,
+        timeout_secs = timeout.as_secs(),
+        "Python import exceeded its deadline — attempting to interrupt the \
+         import thread (CLOACI-T-0919)"
+    );
+
+    let Some(thread_ident) = ident.get() else {
+        return wedge(
+            label,
+            "import thread ident was never recorded (hang before the GIL was acquired)",
+        );
+    };
+
+    for attempt in 1..=INTERRUPT_ATTEMPTS {
+        match inject_async_exception(thread_ident) {
+            InterruptOutcome::Injected => {
+                if join_within(&handle, INTERRUPT_GRACE) {
+                    // Recovered: the thread unwound, the GIL is back, the
+                    // interpreter is healthy. Only THIS package load fails.
+                    cloacina::python_runtime::record_python_import_interrupted();
+                    tracing::error!(
+                        package = %label,
+                        attempt,
+                        "Python import hang INTERRUPTED — the import thread unwound and \
+                         the interpreter stayed healthy. The package failed to load; its \
+                         module-scope code must not block."
+                    );
+                    // Drain the thread's own result (an ImportTimeout PyErr)
+                    // and replace it with a message the operator can act on.
+                    let _ = handle.join();
+                    return Err(PythonLoaderError::RuntimeError(format!(
+                        "Python import for '{label}' timed out after {}s and was interrupted — \
+                         module-scope code must not block (the import thread was recovered)",
+                        timeout.as_secs()
+                    )));
+                }
+                tracing::warn!(
+                    package = %label,
+                    attempt,
+                    "async exception was injected but the import thread did not unwind \
+                     within the grace window"
+                );
+            }
+            InterruptOutcome::GilUnavailable => {
+                return wedge(
+                    label,
+                    "the GIL could not be acquired to interrupt the import thread \
+                     (C-level hold that never returns to the eval loop)",
+                );
+            }
+            InterruptOutcome::NoSuchThread => {
+                // The thread may have exited between the deadline check and
+                // the injection; give the join one more chance before wedging.
+                if join_within(&handle, INTERRUPT_GRACE) {
+                    return handle.join().map_err(|_| {
+                        PythonLoaderError::RuntimeError("Python import thread panicked".to_string())
+                    })?;
+                }
+                return wedge(
+                    label,
+                    "the import thread's Python thread state could not be found",
+                );
+            }
+        }
+    }
+
+    wedge(
+        label,
+        "the import thread ignored the injected timeout exception (C-level hang, \
+         or module-scope code swallowing BaseException)",
+    )
+}
+
+/// Latch the wedged flag and return the corresponding load error.
+fn wedge<T>(label: &str, detail: &str) -> Result<T, PythonLoaderError> {
+    let reason = format!("python runtime wedged by package {label} import hang");
+    cloacina::python_runtime::mark_python_runtime_wedged(reason.clone());
+    Err(PythonLoaderError::RuntimeError(format!(
+        "{reason}: {detail}. The embedded Python interpreter cannot be recovered \
+         in-process — restart this process and remove the offending package."
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn import_timeout_defaults_without_env() {
+        // The env var is not set in the default test environment.
+        if std::env::var(IMPORT_TIMEOUT_ENV).is_err() {
+            assert_eq!(
+                import_timeout(),
+                Duration::from_secs(DEFAULT_IMPORT_TIMEOUT_SECS)
+            );
+        }
+    }
+
+    #[test]
+    fn ident_slot_starts_empty() {
+        let slot = ImportThreadIdent::new();
+        assert_eq!(slot.get(), None);
+    }
+}

--- a/crates/cloacina-python/src/lib.rs
+++ b/crates/cloacina-python/src/lib.rs
@@ -31,6 +31,7 @@ mod computation_graph_tests;
 pub mod constructor;
 pub mod context;
 mod gil;
+pub mod import_guard;
 pub mod loader;
 pub mod namespace;
 pub mod reactor;

--- a/crates/cloacina-python/src/loader.rs
+++ b/crates/cloacina-python/src/loader.rs
@@ -25,7 +25,6 @@
 use pyo3::prelude::*;
 use pyo3::types::PyModule;
 use std::path::Path;
-use std::time::Duration;
 
 use super::task::{pop_workflow_context, push_workflow_context};
 use super::workflow_context::PyWorkflowContext;
@@ -33,10 +32,8 @@ use cloacina::runtime::Runtime;
 use cloacina::task::TaskNamespace;
 use std::sync::Arc;
 
+use crate::import_guard::{import_timeout, supervise_import, ImportThreadIdent};
 use crate::runtime_scope::{current_runtime, ScopedRuntime};
-
-/// Default timeout for Python module import (seconds).
-const IMPORT_TIMEOUT_SECS: u64 = 60;
 
 /// Python stdlib module names that must never appear in extracted packages.
 /// A malicious package could shadow these to hijack execution.
@@ -197,6 +194,10 @@ pub fn import_and_register_python_workflow_named(
     tenant_id: &str,
     runtime: Arc<Runtime>,
 ) -> Result<Vec<TaskNamespace>, PythonLoaderError> {
+    // A wedged interpreter cannot run another import — fail fast instead of
+    // parking a thread on a GIL that will never be released (CLOACI-T-0919).
+    crate::import_guard::ensure_python_runtime_usable(package_name)?;
+
     // SECURITY: Check for stdlib shadowing before importing
     validate_no_stdlib_shadowing(workflow_dir, vendor_dir)?;
 
@@ -206,7 +207,13 @@ pub fn import_and_register_python_workflow_named(
     let package_name = package_name.to_string();
     let workflow_name = workflow_name.to_string();
     let tenant_id = tenant_id.to_string();
-    let timeout = Duration::from_secs(IMPORT_TIMEOUT_SECS);
+    let timeout = import_timeout();
+
+    // CLOACI-T-0919: the supervisor needs the import thread's Python thread id
+    // so it can inject an async exception if module-scope code never returns.
+    let ident = ImportThreadIdent::new();
+    let thread_ident = ident.clone();
+    let supervise_label = package_name.clone();
 
     // PyO3 operations must happen on a thread that can acquire the GIL.
     // Wrap in a timeout to catch infinite loops during import.
@@ -223,6 +230,10 @@ pub fn import_and_register_python_workflow_named(
             Some(package_name.as_str()),
         );
         Python::with_gil(|py| {
+            // 0. Publish this thread's Python ident BEFORE any user code runs,
+            //    so a module-scope hang is interruptible (CLOACI-T-0919).
+            thread_ident.record(py);
+
             // 1. Ensure cloaca module is available
             ensure_cloaca_module(py)?;
 
@@ -414,23 +425,9 @@ pub fn import_and_register_python_workflow_named(
         })
     });
 
-    // Wait with timeout — catches infinite loops during import
-    let start = std::time::Instant::now();
-    loop {
-        if handle.is_finished() {
-            let result = handle.join().map_err(|_| {
-                PythonLoaderError::RuntimeError("Python import thread panicked".to_string())
-            })??;
-            return Ok(result);
-        }
-        if start.elapsed() > timeout {
-            return Err(PythonLoaderError::RuntimeError(format!(
-                "Python workflow import timed out after {}s",
-                timeout.as_secs()
-            )));
-        }
-        std::thread::sleep(Duration::from_millis(100));
-    }
+    // Wait with timeout — and, on timeout, escalate through the interrupt →
+    // surface ladder instead of abandoning a GIL-holding thread (T-0919).
+    supervise_import(&supervise_label, handle, ident, timeout)
 }
 
 /// Import a Python computation graph module and return the graph name.
@@ -451,21 +448,29 @@ pub fn import_python_computation_graph(
     package_name: Option<&str>,
     runtime: Arc<Runtime>,
 ) -> Result<String, PythonLoaderError> {
+    crate::import_guard::ensure_python_runtime_usable(graph_name)?;
     validate_no_stdlib_shadowing(workflow_dir, vendor_dir)?;
 
     let workflow_dir = workflow_dir.to_path_buf();
     let vendor_dir = vendor_dir.to_path_buf();
     let entry_module = entry_module.to_string();
     let graph_name = graph_name.to_string();
+    // CLOACI-T-0921: whose import this is, stamped onto every registration.
     let registration_scope =
         crate::registration_scope::RegistrationScope::new(tenant_id, package_name);
-    let timeout = Duration::from_secs(IMPORT_TIMEOUT_SECS);
+    let timeout = import_timeout();
+
+    // CLOACI-T-0919: same import-hang ladder as the workflow path.
+    let ident = ImportThreadIdent::new();
+    let thread_ident = ident.clone();
+    let supervise_label = graph_name.clone();
 
     let handle = std::thread::spawn(move || -> Result<String, PythonLoaderError> {
         let _scope =
             ScopedRuntime::new(runtime.clone()).map_err(PythonLoaderError::RuntimeError)?;
         let _registration = crate::registration_scope::ScopedRegistration::new(registration_scope);
         Python::with_gil(|py| {
+            thread_ident.record(py);
             ensure_cloaca_module(py)?;
 
             let sys = py.import("sys")?;
@@ -511,22 +516,7 @@ pub fn import_python_computation_graph(
         })
     });
 
-    let start = std::time::Instant::now();
-    loop {
-        if handle.is_finished() {
-            let result = handle.join().map_err(|_| {
-                PythonLoaderError::RuntimeError("Python CG import thread panicked".to_string())
-            })??;
-            return Ok(result);
-        }
-        if start.elapsed() > timeout {
-            return Err(PythonLoaderError::RuntimeError(format!(
-                "Python CG import timed out after {}s",
-                timeout.as_secs()
-            )));
-        }
-        std::thread::sleep(Duration::from_millis(100));
-    }
+    supervise_import(&supervise_label, handle, ident, timeout)
 }
 
 /// Python binding: `cloaca.var(name)` — resolve a `CLOACINA_VAR_{NAME}` env var.

--- a/crates/cloacina-python/src/task.rs
+++ b/crates/cloacina-python/src/task.rs
@@ -16,9 +16,10 @@
 
 use super::workflow_context::PyWorkflowContext;
 use async_trait::async_trait;
-use parking_lot::Mutex;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
+use std::cell::RefCell;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -83,29 +84,119 @@ pub struct WorkflowBuilderRef {
     pub context: PyWorkflowContext,
 }
 
-/// Global context stack for workflow-scoped task registration
-static WORKFLOW_CONTEXT_STACK: Mutex<Vec<WorkflowBuilderRef>> = Mutex::new(Vec::new());
+// ---------------------------------------------------------------------------
+// Workflow context stack (CLOACI-T-0919)
+// ---------------------------------------------------------------------------
+//
+// This stack is the NAMESPACE SOURCE for `@task` / `@cloaca.constructor`: the
+// tenant/package/workflow triple a decorator registers under. It used to be a
+// process-global `Mutex<Vec<_>>`, which was only safe because the reconciler
+// happens to serialize package loads — two concurrent imports would have
+// interleaved pushes and silently mis-namespaced each other's tasks (a task
+// landing in the wrong tenant, not an error).
+//
+// It is now thread-local, matching the registration TARGET seam
+// (`runtime_scope::ScopedRuntime`), so a namespace can never leak across
+// threads. Every producer/consumer is import-time and single-threaded
+// (`WorkflowBuilder.__enter__`/`__exit__`, the loader's push around
+// `py.import`, `TaskDecorator::__call__`, `constructor()`), so this is a
+// tightening, not a behavior change — except that concurrent loads are now
+// correct instead of accidentally correct.
 
-/// Push a workflow context onto the stack (called when entering workflow scope)
+/// Per-thread stack. The `Drop` impl exists so an import thread that dies
+/// mid-scope (e.g. the T-0919 timeout interrupt unwinding a hung import) does
+/// not leave `ACTIVE_CONTEXT_PUSHES` permanently inflated, which would make
+/// every later "no context" error claim a cross-thread problem that isn't one.
+struct ContextStack(RefCell<Vec<WorkflowBuilderRef>>);
+
+impl Drop for ContextStack {
+    fn drop(&mut self) {
+        let remaining = self.0.borrow().len();
+        if remaining > 0 {
+            ACTIVE_CONTEXT_PUSHES.fetch_sub(remaining, Ordering::SeqCst);
+        }
+    }
+}
+
+thread_local! {
+    static WORKFLOW_CONTEXT_STACK: ContextStack =
+        const { ContextStack(RefCell::new(Vec::new())) };
+}
+
+/// Number of contexts pushed process-wide, across all threads. Used ONLY to
+/// turn the "no context on this thread" error into a specific, actionable
+/// cross-thread diagnosis instead of the generic "you forgot the context
+/// manager" message.
+static ACTIVE_CONTEXT_PUSHES: AtomicUsize = AtomicUsize::new(0);
+
+/// Push a workflow context onto this THREAD's stack (called when entering
+/// workflow scope). The matching [`pop_workflow_context`] must run on the same
+/// thread — decorated modules are imported on one thread by construction.
 pub fn push_workflow_context(context: PyWorkflowContext) {
-    WORKFLOW_CONTEXT_STACK
-        .lock()
-        .push(WorkflowBuilderRef { context });
+    ACTIVE_CONTEXT_PUSHES.fetch_add(1, Ordering::SeqCst);
+    WORKFLOW_CONTEXT_STACK.with(|stack| stack.0.borrow_mut().push(WorkflowBuilderRef { context }));
 }
 
-/// Pop a workflow context from the stack (called when exiting workflow scope)
+/// Pop a workflow context from this thread's stack (called when exiting
+/// workflow scope).
 pub fn pop_workflow_context() -> Option<WorkflowBuilderRef> {
-    WORKFLOW_CONTEXT_STACK.lock().pop()
+    let popped = WORKFLOW_CONTEXT_STACK.with(|stack| stack.0.borrow_mut().pop());
+    if popped.is_some() {
+        ACTIVE_CONTEXT_PUSHES.fetch_sub(1, Ordering::SeqCst);
+    } else {
+        // A pop with nothing to pop is either unbalanced `__exit__` handling
+        // or a pop on the wrong thread. Neither is recoverable state, but it
+        // is not worth aborting a load over — say so loudly instead.
+        debug_assert!(
+            false,
+            "pop_workflow_context() on a thread with no workflow context — \
+             unbalanced push/pop, or the pop ran on a different thread than \
+             the push (CLOACI-T-0919)"
+        );
+        tracing::warn!(
+            "pop_workflow_context() called with no context on this thread \
+             (unbalanced push/pop, or cross-thread use)"
+        );
+    }
+    popped
 }
 
-/// Get the current workflow context (used by task decorator)
+/// Get the current workflow context (used by the task decorator).
+///
+/// Errors when this thread has no context. If some OTHER thread does, the
+/// error says so explicitly — that is the cross-thread misuse the global stack
+/// used to paper over by handing back a foreign namespace.
 pub fn current_workflow_context() -> PyResult<PyWorkflowContext> {
-    let stack = WORKFLOW_CONTEXT_STACK.lock();
-    stack.last().map(|ref_| ref_.context.clone()).ok_or_else(|| {
-        PyValueError::new_err(
-            "No workflow context available. Tasks must be defined within a WorkflowBuilder context manager."
-        )
-    })
+    let local =
+        WORKFLOW_CONTEXT_STACK.with(|stack| stack.0.borrow().last().map(|r| r.context.clone()));
+    if let Some(context) = local {
+        return Ok(context);
+    }
+
+    if ACTIVE_CONTEXT_PUSHES.load(Ordering::SeqCst) > 0 {
+        // Deliberately a hard error in EVERY build rather than a
+        // `debug_assert!` panic: this is reachable from user Python code
+        // (a module that spawns a thread and decorates from it), and a
+        // panic across the pyo3 boundary is strictly worse than a raised
+        // exception. The debug assertion for genuine internal misuse lives
+        // on the pop path, which user code cannot reach.
+        tracing::error!(
+            "cross-thread workflow-context use — a @task/constructor decorator ran on a \
+             thread with no workflow context while another thread holds one (CLOACI-T-0919)"
+        );
+        return Err(PyValueError::new_err(
+            "No workflow context on this thread, but one is active on a DIFFERENT thread. \
+             The workflow context is thread-local: `@task`/`cloaca.constructor` must be \
+             evaluated on the same thread that entered the WorkflowBuilder scope (i.e. at \
+             module scope during import), never from a thread spawned by the module. \
+             Registering from another thread would silently namespace the task under the \
+             wrong tenant/package.",
+        ));
+    }
+
+    Err(PyValueError::new_err(
+        "No workflow context available. Tasks must be defined within a WorkflowBuilder context manager.",
+    ))
 }
 
 /// Optional `@cloaca.task(invokes=..., post_invocation=...)` plumbing.

--- a/crates/cloacina-python/tests/python_import_edges.rs
+++ b/crates/cloacina-python/tests/python_import_edges.rs
@@ -1,0 +1,279 @@
+/*
+ *  Copyright 2026 Colliery Software
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+//! CLOACI-T-0919 — packaged-Python import edges.
+//!
+//! Two structural defects, one test binary:
+//!
+//! 1. A module-scope infinite loop used to abandon a GIL-holding thread, which
+//!    disabled the single embedded interpreter process-wide. The loader now
+//!    injects an async exception into the hung thread and only declares the
+//!    runtime wedged if that fails.
+//! 2. The `@task` namespace source was a process-global stack, so two
+//!    concurrent package loads could silently namespace each other's tasks. It
+//!    is now thread-local, like the registration target.
+//!
+//! **Not testable here:** a *true C-level* hang (a native extension that never
+//! returns to the eval loop) is what the wedged path exists for, and there is
+//! no portable way to manufacture one from a test — it would require shipping
+//! a hostile native module per platform, and a failure would leave the test
+//! binary permanently stuck. The wedged plumbing is covered instead by the
+//! flag unit test in `cloacina::python_runtime` and the `/ready` test in
+//! `cloacina-server`. What IS covered here is the interruption ladder, which
+//! is the path a pure-Python hang actually takes.
+
+use std::sync::Arc;
+use tempfile::TempDir;
+
+use cloacina_python::loader::import_and_register_python_workflow_named;
+
+/// Lay out a single-module package the way `extract_python_package` does:
+/// `workflow_dir` holds the source directly, `vendor_dir` is empty.
+fn stage_package(
+    dir: &TempDir,
+    module: &str,
+    source: &str,
+) -> (std::path::PathBuf, std::path::PathBuf) {
+    let workflow_dir = dir.path().join(format!("{module}_src"));
+    let vendor_dir = dir.path().join(format!("{module}_vendor"));
+    std::fs::create_dir_all(&workflow_dir).unwrap();
+    std::fs::create_dir_all(&vendor_dir).unwrap();
+    std::fs::write(workflow_dir.join(format!("{module}.py")), source).unwrap();
+    (workflow_dir, vendor_dir)
+}
+
+const GOOD_MODULE: &str = r#"
+import cloaca
+
+@cloaca.task(id="ok_task", dependencies=[])
+def ok_task(context):
+    return context
+"#;
+
+/// A hostile package: the module body never returns. This is a PURE-PYTHON
+/// loop, which is the interesting case — CPython's eval breaker still hands
+/// the GIL around every few milliseconds, so `PyThreadState_SetAsyncExc` can
+/// land and unwind it.
+const HOSTILE_MODULE: &str = r#"
+import cloaca
+
+while True:
+    pass
+
+@cloaca.task(id="never_registered", dependencies=[])
+def never_registered(context):
+    return context
+"#;
+
+/// The whole point of the ladder: a hostile package fails ITS OWN load through
+/// the interrupt path, and the interpreter is still usable afterwards.
+#[test]
+#[serial_test::serial(python_import)]
+fn hostile_module_scope_loop_is_interrupted_and_subsystem_survives() {
+    pyo3::prepare_freethreaded_python();
+
+    // Shorten the deadline — the 60s default is not a test-shaped number.
+    std::env::set_var(cloacina_python::import_guard::IMPORT_TIMEOUT_ENV, "2");
+
+    let dir = TempDir::new().unwrap();
+    let (hostile_src, hostile_vendor) = stage_package(&dir, "hostile_pkg", HOSTILE_MODULE);
+
+    let started = std::time::Instant::now();
+    let rt = Arc::new(cloacina::Runtime::empty());
+    let result = import_and_register_python_workflow_named(
+        &hostile_src,
+        &hostile_vendor,
+        "hostile_pkg",
+        "hostile-pkg",
+        "hostile_wf",
+        "public",
+        rt,
+    );
+
+    let err = result.expect_err("a module-scope infinite loop must fail the load");
+    let message = err.to_string();
+    assert!(
+        message.contains("interrupted"),
+        "the load must fail via the INTERRUPT path, not by abandoning the thread \
+         (got: {message})"
+    );
+    assert!(
+        !cloacina::python_runtime::is_python_runtime_wedged(),
+        "a successfully interrupted import must NOT wedge the runtime — \
+         reason: {:?}",
+        cloacina::python_runtime::python_runtime_wedged_reason()
+    );
+    // 2s deadline + one 5s grace window; anything near the 60s default would
+    // mean the env knob was ignored.
+    assert!(
+        started.elapsed() < std::time::Duration::from_secs(30),
+        "the configurable deadline was not honoured (took {:?})",
+        started.elapsed()
+    );
+
+    // The floor requirement: the interpreter is healthy, so the NEXT package
+    // loads normally. Before T-0919 this hung forever.
+    let good_dir = TempDir::new().unwrap();
+    let (good_src, good_vendor) = stage_package(&good_dir, "after_hostile_pkg", GOOD_MODULE);
+    let rt2 = Arc::new(cloacina::Runtime::empty());
+    let namespaces = import_and_register_python_workflow_named(
+        &good_src,
+        &good_vendor,
+        "after_hostile_pkg",
+        "after-hostile-pkg",
+        "after_hostile_wf",
+        "public",
+        rt2,
+    )
+    .expect("the Python subsystem must still work after an interrupted import");
+
+    assert!(
+        namespaces.iter().any(|ns| ns.task_id == "ok_task"),
+        "the follow-up package must register its task (got {:?})",
+        namespaces.iter().map(|n| n.to_string()).collect::<Vec<_>>()
+    );
+
+    std::env::remove_var(cloacina_python::import_guard::IMPORT_TIMEOUT_ENV);
+}
+
+/// CLOACI-T-0919 item 2: the `@task` namespace source is thread-local, so two
+/// packages loading CONCURRENTLY namespace their own tasks. With the old
+/// process-global stack the two imports could interleave their pushes and
+/// register tasks under each other's tenant/package — silently, with no error.
+#[test]
+#[serial_test::serial(python_import)]
+fn concurrent_loads_from_two_threads_namespace_their_own_tasks() {
+    pyo3::prepare_freethreaded_python();
+
+    let dir_a = TempDir::new().unwrap();
+    let dir_b = TempDir::new().unwrap();
+    let (src_a, vendor_a) = stage_package(&dir_a, "concurrent_pkg_a", GOOD_MODULE);
+    let (src_b, vendor_b) = stage_package(&dir_b, "concurrent_pkg_b", GOOD_MODULE);
+
+    let rt_a = Arc::new(cloacina::Runtime::empty());
+    let rt_b = Arc::new(cloacina::Runtime::empty());
+
+    let a = {
+        let rt_a = rt_a.clone();
+        std::thread::spawn(move || {
+            import_and_register_python_workflow_named(
+                &src_a,
+                &vendor_a,
+                "concurrent_pkg_a",
+                "pkg-a",
+                "wf_a",
+                "tenant_a",
+                rt_a,
+            )
+        })
+    };
+    let b = {
+        let rt_b = rt_b.clone();
+        std::thread::spawn(move || {
+            import_and_register_python_workflow_named(
+                &src_b,
+                &vendor_b,
+                "concurrent_pkg_b",
+                "pkg-b",
+                "wf_b",
+                "tenant_b",
+                rt_b,
+            )
+        })
+    };
+
+    let ns_a = a.join().unwrap().expect("package A must load");
+    let ns_b = b.join().unwrap().expect("package B must load");
+
+    for ns in &ns_a {
+        assert_eq!(ns.tenant_id, "tenant_a", "A's task leaked a foreign tenant");
+        assert_eq!(
+            ns.package_name, "pkg-a",
+            "A's task leaked a foreign package"
+        );
+        assert_eq!(ns.workflow_id, "wf_a");
+    }
+    for ns in &ns_b {
+        assert_eq!(ns.tenant_id, "tenant_b", "B's task leaked a foreign tenant");
+        assert_eq!(
+            ns.package_name, "pkg-b",
+            "B's task leaked a foreign package"
+        );
+        assert_eq!(ns.workflow_id, "wf_b");
+    }
+    assert_eq!(ns_a.len(), 1, "A registered exactly its own task");
+    assert_eq!(ns_b.len(), 1, "B registered exactly its own task");
+
+    // And the runtimes only ever saw their own tasks.
+    assert!(rt_a
+        .get_task(&cloacina::TaskNamespace::new(
+            "tenant_a", "pkg-a", "wf_a", "ok_task"
+        ))
+        .is_some());
+    assert!(rt_b
+        .get_task(&cloacina::TaskNamespace::new(
+            "tenant_b", "pkg-b", "wf_b", "ok_task"
+        ))
+        .is_some());
+}
+
+/// The other half of item 2's acceptance: evaluating a decorator on a thread
+/// that never entered the workflow scope is a DETERMINISTIC hard error naming
+/// the cross-thread cause — never a silent registration under whatever
+/// namespace some other thread happened to be holding.
+#[test]
+#[serial_test::serial(python_import)]
+fn decorating_from_a_foreign_thread_hard_errors() {
+    use cloacina_python::task::{
+        current_workflow_context, pop_workflow_context, push_workflow_context,
+    };
+    use cloacina_python::workflow_context::PyWorkflowContext;
+
+    pyo3::prepare_freethreaded_python();
+
+    // This thread enters a workflow scope...
+    push_workflow_context(PyWorkflowContext::new("tenant_x", "pkg-x", "wf_x"));
+    assert_eq!(
+        current_workflow_context().unwrap().as_components().0,
+        "tenant_x"
+    );
+
+    // ...and a DIFFERENT thread tries to register into it.
+    let foreign = std::thread::spawn(|| {
+        let err = current_workflow_context()
+            .expect_err("a foreign thread must not inherit this thread's namespace");
+        err.to_string()
+    })
+    .join()
+    .unwrap();
+
+    assert!(
+        foreign.contains("DIFFERENT thread"),
+        "the error must name the cross-thread cause (got: {foreign})"
+    );
+
+    pop_workflow_context();
+
+    // With no context anywhere, the message goes back to the ordinary
+    // "you forgot the context manager" guidance.
+    let plain = std::thread::spawn(|| current_workflow_context().unwrap_err().to_string())
+        .join()
+        .unwrap();
+    assert!(
+        plain.contains("WorkflowBuilder context manager"),
+        "without an active context the generic message applies (got: {plain})"
+    );
+}

--- a/crates/cloacina-server/src/lib.rs
+++ b/crates/cloacina-server/src/lib.rs
@@ -2081,32 +2081,50 @@ async fn health() -> impl IntoResponse {
 }
 
 /// GET /ready — readiness check, scoped to PLATFORM health only (DB
-/// reachable). CLOACI-T-0916: tenant-workload health is deliberately NOT part
-/// of readiness — one crashed computation graph used to flip `/ready` false on
-/// EVERY replica simultaneously, letting a single bad package eject the whole
-/// server fleet from the load-balancer pool. Crashed graphs remain visible via
+/// reachable, embedded Python interpreter usable). CLOACI-T-0916:
+/// tenant-workload health is deliberately NOT part of readiness — one crashed
+/// computation graph used to flip `/ready` false on EVERY replica
+/// simultaneously, letting a single bad package eject the whole server fleet
+/// from the load-balancer pool. Crashed graphs remain visible via
 /// `GET /v1/health/graphs` (state `stopped`/`crashed`) and metrics.
+///
+/// CLOACI-T-0919 adds one more PLATFORM predicate: a wedged Python runtime.
+/// There is exactly one embedded CPython per process, so an uninterruptible
+/// module-scope hang disables Python package loading process-wide until
+/// restart. That is this replica being broken — not a tenant workload
+/// misbehaving — so it belongs in readiness, and it is replica-local (the
+/// wedge is set by THIS process's own import thread), which is precisely the
+/// property #231 required.
 #[utoipa::path(
     get,
     path = "/ready",
     tag = "operational",
     responses(
-        (status = 200, description = "Ready — DB reachable. Tenant-workload health (e.g. crashed computation graphs) does NOT affect readiness; see /v1/health/graphs."),
-        (status = 503, description = "Not ready — `reason` field explains (database unreachable)"),
+        (status = 200, description = "Ready — DB reachable and the embedded Python runtime is usable. Tenant-workload health (e.g. crashed computation graphs) does NOT affect readiness; see /v1/health/graphs."),
+        (status = 503, description = "Not ready — `reason` field explains (database unreachable, or the embedded Python runtime is wedged by a package import hang and this process must be restarted)"),
     )
 )]
 async fn ready(State(state): State<AppState>) -> impl IntoResponse {
     // Verify we can acquire a connection from the pool
     let db_ready = state.database.get_postgres_connection().await.is_ok();
 
-    if db_ready {
-        (StatusCode::OK, Json(serde_json::json!({"status": "ready"})))
-    } else {
-        (
+    if !db_ready {
+        return (
             StatusCode::SERVICE_UNAVAILABLE,
             Json(serde_json::json!({"status": "not ready", "reason": "database unreachable"})),
-        )
+        );
     }
+
+    // PLATFORM predicate, not workload: this process's embedded interpreter is
+    // unusable and only a restart fixes it (CLOACI-T-0919).
+    if let Some(reason) = cloacina::python_runtime::python_runtime_wedged_reason() {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(serde_json::json!({"status": "not ready", "reason": reason})),
+        );
+    }
+
+    (StatusCode::OK, Json(serde_json::json!({"status": "ready"})))
 }
 
 /// GET /metrics — Prometheus metrics rendered from the recorder installed at startup.
@@ -2584,6 +2602,52 @@ mod tests {
         let (status, body) = send_request(app, req).await;
         assert_eq!(status, StatusCode::OK);
         assert_eq!(body["status"], "ready");
+    }
+
+    /// CLOACI-T-0919: a wedged embedded Python interpreter is PLATFORM health —
+    /// this replica can no longer load any Python package and only a restart
+    /// fixes it — so `/ready` must fail with the wedging package named. This
+    /// does NOT reopen the #231 hole: the wedge is set by this process's own
+    /// import thread, so it cannot fan out across the fleet the way a shared
+    /// tenant workload could.
+    #[tokio::test]
+    #[serial]
+    async fn ready_reports_503_when_python_runtime_is_wedged() {
+        let state = test_state().await;
+
+        // Healthy first — proves the 503 below comes from the wedge.
+        cloacina::python_runtime::reset_python_runtime_wedged_for_tests();
+        let req = axum::http::Request::builder()
+            .uri("/ready")
+            .body(Body::empty())
+            .unwrap();
+        let (status, _) = send_request(build_router(state.clone()), req).await;
+        assert_eq!(status, StatusCode::OK);
+
+        cloacina::python_runtime::mark_python_runtime_wedged(
+            "python runtime wedged by package hostile-loop import hang",
+        );
+
+        let req = axum::http::Request::builder()
+            .uri("/ready")
+            .body(Body::empty())
+            .unwrap();
+        let (status, body) = send_request(build_router(state), req).await;
+
+        // Restore before any assertion can unwind the test — the flag is
+        // process-global and latching in production.
+        cloacina::python_runtime::reset_python_runtime_wedged_for_tests();
+
+        assert_eq!(
+            status,
+            StatusCode::SERVICE_UNAVAILABLE,
+            "a wedged python runtime must fail readiness (body: {body})"
+        );
+        assert_eq!(body["status"], "not ready");
+        assert_eq!(
+            body["reason"], "python runtime wedged by package hostile-loop import hang",
+            "the reason must name the package that wedged the interpreter"
+        );
     }
 
     // ── CLOACI-T-0916: multi-replica truthfulness ─────────────────────────

--- a/crates/cloacina/src/python_runtime.rs
+++ b/crates/cloacina/src/python_runtime.rs
@@ -29,7 +29,8 @@
 //! with a clear `not attached` error at reconcile time.
 
 use std::path::Path;
-use std::sync::{Arc, OnceLock};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
 
 use crate::computation_graph::scheduler::ComputationGraphDeclaration;
 use crate::runtime::Runtime;
@@ -101,10 +102,139 @@ static PYTHON_RUNTIME: OnceLock<Arc<dyn PythonRuntime>> = OnceLock::new();
 /// this and Python packages fail at reconcile time with a clear error.
 pub fn register_python_runtime(runtime: Arc<dyn PythonRuntime>) {
     let _ = PYTHON_RUNTIME.set(runtime);
+    init_python_runtime_health_metrics();
 }
 
 /// Fetch the registered [`PythonRuntime`], if any. Returns `None` when no
 /// runtime is attached to this process.
 pub fn python_runtime() -> Option<Arc<dyn PythonRuntime>> {
     PYTHON_RUNTIME.get().cloned()
+}
+
+// ---------------------------------------------------------------------------
+// Wedged-runtime health surface (CLOACI-T-0919)
+// ---------------------------------------------------------------------------
+//
+// CPython is a single embedded interpreter per process. If user code hangs at
+// module scope during a package import AND cannot be interrupted (a C-level
+// hold that never releases the GIL), the Python subsystem is disabled
+// process-wide until restart — every later import blocks on a GIL that will
+// never be handed back. There is no in-process recovery for that state, so the
+// floor requirement is that it is LOUD: a sticky process-global flag with a
+// human-readable reason, a gauge, and a readiness failure. Operators see the
+// replica as unhealthy instead of watching Python packages silently stop
+// loading.
+//
+// The flag is deliberately one-way (latching). A wedged interpreter does not
+// un-wedge; anything that "succeeds" afterwards succeeded despite the wedge,
+// not because it cleared.
+
+static PYTHON_RUNTIME_WEDGED: AtomicBool = AtomicBool::new(false);
+static PYTHON_RUNTIME_WEDGED_REASON: Mutex<Option<String>> = Mutex::new(None);
+
+/// Latch the process-global "Python runtime is wedged" flag.
+///
+/// Called by `cloacina-python` when an import thread could not be interrupted
+/// and had to be abandoned while (presumably) holding the GIL. Emits the
+/// `cloacina_python_runtime_wedged` gauge and an `error!` naming the cause.
+/// Repeat calls keep the FIRST reason — that's the one that actually wedged
+/// the interpreter; later ones are collateral.
+pub fn mark_python_runtime_wedged(reason: impl Into<String>) {
+    let reason = reason.into();
+    let first = !PYTHON_RUNTIME_WEDGED.swap(true, Ordering::SeqCst);
+    if first {
+        if let Ok(mut slot) = PYTHON_RUNTIME_WEDGED_REASON.lock() {
+            *slot = Some(reason.clone());
+        }
+    }
+    metrics::gauge!("cloacina_python_runtime_wedged").set(1.0);
+    tracing::error!(
+        reason = %reason,
+        first_wedge = first,
+        "PYTHON RUNTIME WEDGED — the embedded interpreter is holding the GIL and \
+         cannot be recovered in-process. All further Python package loads in this \
+         process will hang or fail; /ready now reports not-ready. Restart the \
+         process to recover, and remove/fix the offending package first."
+    );
+}
+
+/// Whether the embedded Python interpreter is known-wedged in this process.
+pub fn is_python_runtime_wedged() -> bool {
+    PYTHON_RUNTIME_WEDGED.load(Ordering::SeqCst)
+}
+
+/// Reason the Python runtime is wedged, or `None` when it is healthy (or when
+/// Python is not used in this process at all).
+pub fn python_runtime_wedged_reason() -> Option<String> {
+    if !is_python_runtime_wedged() {
+        return None;
+    }
+    PYTHON_RUNTIME_WEDGED_REASON
+        .lock()
+        .ok()
+        .and_then(|slot| slot.clone())
+        .or_else(|| Some("python runtime wedged (reason unavailable)".to_string()))
+}
+
+/// Record that a hung Python import thread WAS successfully interrupted
+/// (`PyThreadState_SetAsyncExc` landed and the thread joined). The package load
+/// failed but the interpreter stayed healthy — the good outcome of the ladder.
+pub fn record_python_import_interrupted() {
+    metrics::counter!("cloacina_python_import_interrupted_total").increment(1);
+}
+
+/// Clear the wedged flag. **Test support only.**
+///
+/// The flag is latching in production for a reason (a wedged interpreter does
+/// not heal), but it is process-global, so a test that sets it would poison
+/// every later test in the same binary. Downstream crates (`cloacina-server`)
+/// need this to assert the `/ready` effect and then put the process back.
+#[doc(hidden)]
+pub fn reset_python_runtime_wedged_for_tests() {
+    PYTHON_RUNTIME_WEDGED.store(false, Ordering::SeqCst);
+    if let Ok(mut slot) = PYTHON_RUNTIME_WEDGED_REASON.lock() {
+        *slot = None;
+    }
+    metrics::gauge!("cloacina_python_runtime_wedged").set(0.0);
+}
+
+/// Publish the wedged gauge as `0` so the series exists on healthy processes
+/// (a gauge that only appears when broken is invisible to alert rules that
+/// need a baseline). Called once when a Python runtime is registered.
+pub fn init_python_runtime_health_metrics() {
+    if !is_python_runtime_wedged() {
+        metrics::gauge!("cloacina_python_runtime_wedged").set(0.0);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The flag plumbing: set → read → reason, latching on first reason.
+    /// (Process-global by design; this is the only test that touches it.)
+    #[test]
+    fn wedged_flag_latches_first_reason() {
+        reset_python_runtime_wedged_for_tests();
+        assert!(!is_python_runtime_wedged());
+        assert_eq!(python_runtime_wedged_reason(), None);
+
+        mark_python_runtime_wedged("python runtime wedged by package alpha import hang");
+        assert!(is_python_runtime_wedged());
+        assert_eq!(
+            python_runtime_wedged_reason().as_deref(),
+            Some("python runtime wedged by package alpha import hang")
+        );
+
+        // A second wedge does not overwrite the original cause.
+        mark_python_runtime_wedged("python runtime wedged by package beta import hang");
+        assert_eq!(
+            python_runtime_wedged_reason().as_deref(),
+            Some("python runtime wedged by package alpha import hang")
+        );
+
+        // Leave the process healthy for anything else in this binary.
+        reset_python_runtime_wedged_for_tests();
+        assert!(!is_python_runtime_wedged());
+    }
 }

--- a/docs/static/openapi.json
+++ b/docs/static/openapi.json
@@ -33,14 +33,15 @@
         "tags": [
           "operational"
         ],
-        "summary": "GET /ready — readiness check, scoped to PLATFORM health only (DB\nreachable). CLOACI-T-0916: tenant-workload health is deliberately NOT part\nof readiness — one crashed computation graph used to flip `/ready` false on\nEVERY replica simultaneously, letting a single bad package eject the whole\nserver fleet from the load-balancer pool. Crashed graphs remain visible via\n`GET /v1/health/graphs` (state `stopped`/`crashed`) and metrics.",
+        "summary": "GET /ready — readiness check, scoped to PLATFORM health only (DB\nreachable, embedded Python interpreter usable). CLOACI-T-0916:\ntenant-workload health is deliberately NOT part of readiness — one crashed\ncomputation graph used to flip `/ready` false on EVERY replica\nsimultaneously, letting a single bad package eject the whole server fleet\nfrom the load-balancer pool. Crashed graphs remain visible via\n`GET /v1/health/graphs` (state `stopped`/`crashed`) and metrics.",
+        "description": "CLOACI-T-0919 adds one more PLATFORM predicate: a wedged Python runtime.\nThere is exactly one embedded CPython per process, so an uninterruptible\nmodule-scope hang disables Python package loading process-wide until\nrestart. That is this replica being broken — not a tenant workload\nmisbehaving — so it belongs in readiness, and it is replica-local (the\nwedge is set by THIS process's own import thread), which is precisely the\nproperty #231 required.",
         "operationId": "ready",
         "responses": {
           "200": {
-            "description": "Ready — DB reachable. Tenant-workload health (e.g. crashed computation graphs) does NOT affect readiness; see /v1/health/graphs."
+            "description": "Ready — DB reachable and the embedded Python runtime is usable. Tenant-workload health (e.g. crashed computation graphs) does NOT affect readiness; see /v1/health/graphs."
           },
           "503": {
-            "description": "Not ready — `reason` field explains (database unreachable)"
+            "description": "Not ready — `reason` field explains (database unreachable, or the embedded Python runtime is wedged by a package import hang and this process must be restarted)"
           }
         }
       }


### PR DESCRIPTION
## Summary

The two Python-runtime edges from the deep dive (CLOACI-T-0919).

### Item 1 — an import hang no longer bricks the subsystem silently

The 60s import timeout returned to the caller while leaving the import thread alive holding the GIL: user code hanging at module scope silently disabled **all** Python operations process-wide until restart. New `import_guard.rs` implements the ladder CPython semantics actually allow:

- Timeout is configurable (`CLOACINA_PYTHON_IMPORT_TIMEOUT_SECS`, default 60).
- **Interruption works for the common case**: a pure-Python module-scope loop does *not* hold the GIL exclusively (the eval-breaker switches every ~5ms), so `PyThreadState_SetAsyncExc` genuinely interrupts it. The documented revert protocol is handled (return > 1 → call again with NULL). Failure to acquire the GIL within the outer timeout is itself the C-level-hold signal. Two attempts, 5s grace each; on success the package fails cleanly and the subsystem stays healthy.
- The injected exception derives **BaseException** deliberately, so a module-scope `except Exception` can't swallow the deadline.
- **Guaranteed floor** when interruption fails (true C-level hang): a latching wedged flag records the first reason, emits `cloacina_python_runtime_wedged`, fails subsequent loads fast rather than leaking another parked thread, and **`/ready` 503s with that reason** — extending #231's platform-scoped readiness rather than regressing it (the wedge is this replica's own runtime, not tenant workload health; the crashed-CG guard test still passes).
- The flag lives as free functions in `cloacina::python_runtime` rather than on the trait: the trait is per-impl, the wedge is per-process, and the server must read it without linking pyo3.

`openapi.json` re-emitted and the TS client regenerated (`check:generated` clean) — done proactively this time, since any `/ready` annotation change trips both drift gates.

### Item 2 — the global context-stack race

`WORKFLOW_CONTEXT_STACK` moved from a process-global `Mutex` to `thread_local`, matching the `ScopedRuntime` seam — it was safe only because the reconciler happens to serialize loads. Cross-thread decorator evaluation is now a hard `PyValueError` in every build (user-reachable code; a `debug_assert` panic across the pyo3 boundary would be worse), with the assert guarding the internal pop path.

## Test plan
- Hostile module-scope infinite-loop fixture: load fails via the interrupt path, thread joins, **and a subsequent good package still loads** (subsystem not wedged)
- Two-thread concurrent loads keep their own tenant/package/workflow; foreign-thread decoration hard-errors
- Wedged flag latches its first reason; `/ready` 503s when wedged
- Suites green: cloacina-python lib 137/137, package 13/13, reactor-library, trigger-packaging, cross-language fan-out 10/10; server `ready` 3/3
- A true C-level hang is **not portably testable** (it would wedge the test binary) — stated in the test header, covered instead by the flag and `/ready` tests

## Residuals
Module-scope code catching `BaseException` in its own loop is indistinguishable from a C hang (it wedges); the wedged flag never self-clears by design; the new env knob is documented in rustdoc only.