### PR TITLE
docs(metis): file T-0922/T-0923; record deep-dive ticket progress

### DIFF
--- a/.metis/backlog/bugs/CLOACI-T-0918.md
+++ b/.metis/backlog/bugs/CLOACI-T-0918.md
@@ -4,15 +4,15 @@ level: task
 title: "Installer and packaging leftovers — root install.sh 404s Intel macs, stale sandbox comments, dead code"
 short_code: "CLOACI-T-0918"
 created_at: 2026-08-02T16:33:41.487632+00:00
-updated_at: 2026-08-04T01:08:07.306953+00:00
-parent:
+updated_at: 2026-08-04T09:08:42.829774+00:00
+parent: 
 blocked_by: []
 archived: false
 
 tags:
   - "#task"
   - "#bug"
-  - "#phase/active"
+  - "#phase/completed"
 
 
 exit_criteria_met: false
@@ -47,16 +47,15 @@ Sweep the small concrete leftovers the deep dive found in installers and the pac
 
 ## Acceptance Criteria
 
-## Acceptance Criteria
-
-- [ ] Exactly one installer, correct org, correct target map, clear unsupported-platform error
-- [ ] No comment in the compiler/packaging path claims the excised sandbox
-- [ ] manifest_schema.rs removed or test-scoped
-- [ ] input_strategy in FFI metadata reflects the manifest
-- [ ] Rejected unload / partial load leave no ghost tracking state or orphaned schedules (tests)
-- [ ] Compile-phase cargo spawn runs env-cleared with an explicit allowlist; a test asserts DATABASE_URL is absent from the build env
-- [ ] --cargo-flag is additive; full replacement requires the explicit escape hatch
+- [x] One installer (root install.sh deleted; scripts/install.sh canonical per unified_release.yml); target allowlist matches the release build matrix; Intel macOS gets an explicit cargo-install pointer instead of a 404; 4 doc pages converged
+- [x] No comment claims the excised sandbox (run_cargo_fetch doc, log line, config.rs dev-workspace comment); dead landlock dep removed
+- [x] manifest_schema.rs deleted (654 lines) — parse_duration_str RESCUED to cloacina::packaging (it had 2 production consumers, contra the ticket's "test-only" assumption) with unit coverage preserved
+- [x] input_strategy honored: FFI wire default documented as unknowable-at-emit (wire compat), host now applies manifest [metadata] input_strategy — which it NEVER did before, silently ignoring sequential; test proves manifest wins
+- [x] Rejected unload retains residual tracking (retry next cycle) + partial-load rollback unregisters every created schedule row across all 3 language branches; tests for both
+- [x] Compile-phase cargo env-cleared behind allowlist; tests assert DATABASE_URL absent + allowlist passthrough (phase-1 fetch deliberately inherits)
+- [x] --cargo-flag additive; --cargo-flags-replace is the explicit hatch; all replace-reliant call sites migrated (demo compose, chart, angreal) + docs
 
 ## Status Updates
 
 - 2026-08-02: Filed from the architecture deep dive (packaging-pipeline + quality-release reports; DEEPDIVE.md register medium tier). Verified against main @ 5216e632.
+- 2026-08-04: DONE — merged to main in PR #232 (squash). Two findings were WORSE/different than filed and are the most valuable outcomes: (a) manifest_schema.rs was not fully dead — parse_duration_str had production consumers in packaging_bridge + python trigger; deleting blind would have broken the build, so it moved to cloacina::packaging; (b) input_strategy was ignored END-TO-END — the shell's hardcoded "latest" was only half the story; the host never read the manifest value, so packaged sequential graphs silently ran latest. Both now fixed with tests. Also excised the dead landlock dependency (pure I-0105 leftover).

--- a/.metis/backlog/bugs/CLOACI-T-0919.md
+++ b/.metis/backlog/bugs/CLOACI-T-0919.md
@@ -4,15 +4,15 @@ level: task
 title: "Python runtime edges — unkillable import hang bricks the subsystem, global workflow-context stack race"
 short_code: "CLOACI-T-0919"
 created_at: 2026-08-02T16:33:45.835985+00:00
-updated_at: 2026-08-02T16:33:45.835985+00:00
-parent:
+updated_at: 2026-08-04T04:59:55.885467+00:00
+parent: 
 blocked_by: []
 archived: false
 
 tags:
   - "#task"
-  - "#phase/backlog"
   - "#bug"
+  - "#phase/active"
 
 
 exit_criteria_met: false
@@ -37,6 +37,10 @@ Fix the two residual structural edges in the Python integration found by the dee
 
 1. IMPORT HANG BRICKS THE PYTHON SUBSYSTEM. Packaged-Python import runs on a dedicated thread under with_gil with a 60s poll-join timeout — but a timeout cannot KILL the thread. User code looping at module scope (import time) keeps the GIL held forever: the leak is not one package failing but the process-wide Python runtime silently disabled until restart (single-interpreter design has no answer). Mitigations to evaluate, in order of invasiveness: Py_SetInterruptFromThread/PyThreadState_SetAsyncExc injection at timeout; sys.settrace-based cooperative deadline installed pre-import; documenting + alerting (loud health state: python_runtime=wedged) so operators at least SEE it. The last is table stakes even if interruption proves unsafe.
 2. WORKFLOW_CONTEXT_STACK IS PROCESS-GLOBAL. Registration targeting was made thread-local (ScopedRuntime, errors on nesting) but the @task namespace source is still a process-global stack (crates/cloacina-python/src/task.rs:87) — safe today ONLY because the reconciler serializes package loads. Any future concurrent load (or a user importing cloaca-decorated modules from two threads) mis-namespaces tasks silently. Fix: move the stack to the same thread-local ScopedRuntime seam; add a debug assertion that catches cross-thread use.
+
+## Acceptance Criteria
+
+## Acceptance Criteria
 
 ## Acceptance Criteria
 

--- a/.metis/backlog/bugs/CLOACI-T-0921.md
+++ b/.metis/backlog/bugs/CLOACI-T-0921.md
@@ -4,15 +4,15 @@ level: task
 title: "Flat name-global registries cross tenant lines in-process — audit and key by tenant/package"
 short_code: "CLOACI-T-0921"
 created_at: 2026-08-02T17:44:00.940671+00:00
-updated_at: 2026-08-02T17:44:00.940671+00:00
-parent:
+updated_at: 2026-08-04T05:05:01.821436+00:00
+parent: 
 blocked_by: []
 archived: false
 
 tags:
   - "#task"
-  - "#phase/backlog"
   - "#bug"
+  - "#phase/active"
 
 
 exit_criteria_met: false
@@ -40,6 +40,10 @@ Audit every process-wide name-keyed registry against the tenant-is-THE-isolation
 3. Audit scope beyond the two known: any other process-global map keyed by bare entity name (trigger registries, reactor maps, workflow name lookups in the shared runtime) — enumerate and classify each as (a) already tenant/package-scoped, (b) name-collision-safe by construction, or (c) violator.
 
 Context: workflow task namespaces already carry tenant::package:: prefixes (TaskNamespace), so the pattern exists — these registries predate or bypassed it. Server multi-tenancy makes this reachable today: one server process hosts many tenants' packages.
+
+## Acceptance Criteria
+
+## Acceptance Criteria
 
 ## Acceptance Criteria
 

--- a/.metis/backlog/bugs/CLOACI-T-0922.md
+++ b/.metis/backlog/bugs/CLOACI-T-0922.md
@@ -1,0 +1,64 @@
+---
+id: cel-predicate-errors-silently
+level: task
+title: "CEL predicate errors silently black-hole subscriptions — hold the watermark, dead-letter, and lint unbound variables"
+short_code: "CLOACI-T-0922"
+created_at: 2026-08-05T22:33:06.974265+00:00
+updated_at: 2026-08-05T22:33:06.974265+00:00
+parent: 
+blocked_by: []
+archived: false
+
+tags:
+  - "#task"
+  - "#phase/backlog"
+  - "#bug"
+
+
+exit_criteria_met: false
+initiative_id: NULL
+---
+
+# CEL predicate errors silently black-hole subscriptions — hold the watermark, dead-letter, and lint unbound variables
+
+## Objective
+
+Stop a broken reactor-subscription predicate from silently and permanently discarding firings. Deep-dive risk register #5 (HIGH), split out of CLOACI-T-0915 which fixed the adjacent `tenant`-stub bug but deliberately left this behavior alone.
+
+## Backlog Item Details
+
+### Type
+- [x] Bug - Production issue that needs fixing
+
+### Priority
+- [x] P1 - High (important for user experience)
+
+### Impact Assessment
+- **Affected Users**: any tenant using CEL predicates on reactor->workflow subscriptions.
+- **Expected vs Actual**: expected — a predicate that errors is visible and recoverable. Actual — the firing is skipped AND the watermark advances past it, so the firing is unrecoverable and the failure is invisible: no metric, no dead-letter, no health signal. A predicate broken by payload-shape drift black-holes the subscription forever while everything reports healthy.
+
+## Findings
+
+1. In `process_reactor_subscription` (crates/cloacina/src/cron_trigger_scheduler.rs, the per-firing loop ~:1160-1200), `Ok(false)` and `Err(_)` take the same path: log, `advance_watermark`, `continue`. For `Ok(false)` that is correct (the filter did its job). For `Err(_)` it converts a transient/structural fault into permanent silent data loss.
+2. The fail-closed doctrine ("a broken filter should not fire workflows") is right about NOT dispatching — but it does not require advancing the watermark. The two decisions were conflated.
+3. No observability: no `cloacina_reactor_predicate_errors_total` counter, no dead-letter row, nothing in the graph/reactor health surface.
+4. Related gap (finding 1 of T-0915, deliberately deferred there): predicates referencing variables that are not bound (the `tenant` stub incident) compile fine and evaluate false/error forever. A load-time or subscribe-time lint over the known variable set (`payload`, `reactor`, `tenant`) would have caught that class at the door.
+
+## Proposed shape (adjust on implementation)
+
+- Distinguish the two outcomes: `Ok(false)` -> skip + advance watermark (unchanged). `Err(_)` -> do NOT advance; retry the firing with a bounded attempt count.
+- After N consecutive errors on the same firing: write a dead-letter record (or mark the subscription degraded) and THEN advance so one poison firing cannot wedge the subscription forever. Surface the degraded state on the reactor/subscription health view.
+- Add `cloacina_reactor_predicate_errors_total{subscription,reactor}` and log at warn with the expression text truncated.
+- Add the subscribe-time lint for unbound variable references; reject with a clear error naming the allowed variables.
+
+## Acceptance Criteria
+
+- [ ] A predicate that errors does not advance the watermark on the first failure; the firing is retried
+- [ ] A persistently-failing firing is dead-lettered/degraded (bounded), never silently dropped, and the state is visible on a health surface
+- [ ] `Ok(false)` behavior unchanged (skip + advance) with a test pinning the distinction
+- [ ] Predicate errors are counted in a metric and logged
+- [ ] Subscribe-time lint rejects predicates referencing unbound variables (test: `tenant` ok, `tennant` rejected)
+
+## Status Updates
+
+- 2026-08-05: Filed from the architecture deep dive (DEEPDIVE.md consolidated risk register #5; cg-runtime report S1.6). Split out of CLOACI-T-0915 (completed) which fixed the tenant stub but explicitly left the watermark/dead-letter behavior and the lint for a separate change.

--- a/.metis/backlog/bugs/CLOACI-T-0923.md
+++ b/.metis/backlog/bugs/CLOACI-T-0923.md
@@ -1,0 +1,60 @@
+---
+id: auth-lifecycle-edges-oidc-refresh
+level: task
+title: "Auth lifecycle edges — OIDC refresh is 501, no login brute-force defense"
+short_code: "CLOACI-T-0923"
+created_at: 2026-08-05T22:33:46.884336+00:00
+updated_at: 2026-08-05T22:33:46.884336+00:00
+parent: 
+blocked_by: []
+archived: false
+
+tags:
+  - "#task"
+  - "#phase/backlog"
+  - "#bug"
+
+
+exit_criteria_met: false
+initiative_id: NULL
+---
+
+# Auth lifecycle edges — OIDC refresh is 501, no login brute-force defense
+
+## Objective
+
+Close the two auth-lifecycle gaps the deep dive found (risk register #24, MEDIUM). One is an unfulfilled use case from I-0118; the other is an explicitly-deferred open question ("required before production") that is still open.
+
+## Backlog Item Details
+
+### Type
+- [x] Bug - Production issue that needs fixing
+
+### Priority
+- [x] P2 - Medium (nice to have)
+
+### Impact Assessment
+- **Affected Users**: browser/UI users of OIDC SSO (hard logout every 15 minutes with no refresh) and any internet-exposed deployment using local password accounts (unthrottled credential stuffing).
+
+## Findings
+
+1. OIDC REFRESH RETURNS 501. Logins mint 15-minute API keys; there is no refresh path, so an SSO session dies hard at 15 minutes and the user must re-authenticate through the whole flow. I-0118 UC2 ("stay signed in") is unfulfilled. The refresh route exists but is unimplemented — verify current shape in crates/cloacina-server (routes/oidc_auth.rs / session.rs) before designing.
+2. NO BRUTE-FORCE DEFENSE ON `/v1/auth/local/login`. Argon2id hashing makes each attempt expensive server-side, but nothing rate-limits or locks out repeated failures against a known username; I-0118 OQ-13 flagged this as "required before production" and it was never resolved.
+3. ACCEPTED, NOT A BUG: cross-replica API-key revocation lag is bounded by the 30s identity LRU cache TTL. The deep dive judged this a reasonable trade; document it rather than change it (a revoked key remaining valid for <=30s on other replicas should be stated in the security docs).
+
+## Proposed shape (adjust on implementation)
+
+- Refresh: mint a new short-lived key against the still-valid session/refresh material, rotating the old one; respect the same god/tenant scoping rules as the original mint (every mint path hard-codes is_admin=false — preserve that). Consider whether the OIDC provider's own refresh token should be stored (encrypted) or whether a server-side session record suffices.
+- Throttle: per-(username, source-IP) failure counter with exponential backoff or temporary lockout, persisted (multi-replica correctness — mirror the T-0916 pattern of DB-backed state rather than per-replica maps), with a metric and audit events on lockout.
+- Document the 30s revocation window in the security model docs.
+
+## Acceptance Criteria
+
+- [ ] OIDC sessions can refresh without a full re-auth; refresh respects tenant/role scoping and cannot escalate to god
+- [ ] Repeated failed local logins are throttled/locked out, enforced consistently across replicas, with audit + metric
+- [ ] The 30s cross-replica key-revocation window is documented in the security model
+- [ ] Tests: refresh happy path + scope preservation; lockout triggers and expires; throttle state shared across two server handles
+
+## Status Updates
+
+- 2026-08-05: Filed from the architecture deep dive (DEEPDIVE.md consolidated risk register #24; control-plane report S7.3-7.6). Item 3 is documentation-only by deliberate judgment.

--- a/.metis/backlog/tech-debt/CLOACI-T-0917.md
+++ b/.metis/backlog/tech-debt/CLOACI-T-0917.md
@@ -4,15 +4,15 @@ level: task
 title: "CI verification-lattice holes — path filters, constructor suite, server-side lockstep, publish tiers"
 short_code: "CLOACI-T-0917"
 created_at: 2026-08-02T16:33:33.333322+00:00
-updated_at: 2026-08-04T01:06:09.137022+00:00
-parent:
+updated_at: 2026-08-04T10:15:38.500736+00:00
+parent: 
 blocked_by: []
 archived: false
 
 tags:
   - "#task"
   - "#tech-debt"
-  - "#phase/active"
+  - "#phase/completed"
 
 
 exit_criteria_met: false
@@ -45,14 +45,13 @@ Close the verification-lattice blind spots found by the 2026-08-02 deep dive. Pa
 
 ## Acceptance Criteria
 
-## Acceptance Criteria
-
-- [ ] A PR touching only crates/cloacina-python triggers the test matrix; same for tests/python and crates/cloacina-server
-- [ ] constructors-wasm suite has a CI lane (documented cadence)
-- [ ] version_lockstep.py enforced server-side; the false comment corrected
-- [ ] Publish-tier completeness mechanically checked against workspace membership
-- [ ] Retry/continue-on-error tolerances re-justified or removed
+- [x] Test matrix now triggers for cloacina-python, tests/python, cloacina-server, -compiler, -agent, -client, -constructor-contract, clients/python; scripts/** triggers quick-checks
+- [x] constructors-wasm suite has a CI home: nightly constructor-suite job (ubuntu, wasm32-wasip2, 60min cap, target-scoped invocation) — release-blocking since unified_release calls nightly
+- [x] version_lockstep.py runs in quick-checks (it lives in .angreal/, not scripts/ as filed); false pre-commit comment corrected
+- [x] scripts/check_publish_tiers.py asserts exactly-once coverage vs cargo metadata both directions; passes today (15/15)
+- [x] python-tutorials continue-on-error removed (post-I-0140); three x3 retry sites kept with justification + removal criteria; repo grep confirms no other allow-failure sites
 
 ## Status Updates
 
 - 2026-08-02: Filed from the architecture deep dive (quality-release report; DEEPDIVE.md recommendations #1-3). Verified against main @ 5216e632.
+- 2026-08-04: DONE — merged to main in PR #233 (squash). Corrections to the filing: version_lockstep.py is in .angreal/ not scripts/; the "tiers" in unified_release.yml are bare `publish <crate>` shell calls, not YAML lists (the checker regex-parses them and fails loud if that shape changes). Constructor-suite placement decided on measured data: the suite compiles fixture crates inside tests and exceeded the 10-minute per-PR budget mid-run (11/14 green before cutoff, zero constructor-target failures), so nightly — and the invocation MUST be target-scoped because an unscoped `cargo test -p cloacina` drags in the postgres-dependent fixtures target. providers/* are not workspace members (they ship via provider_release waves) and are documented as out of scope in the tier checker.

--- a/.metis/backlog/tech-debt/CLOACI-T-0920.md
+++ b/.metis/backlog/tech-debt/CLOACI-T-0920.md
@@ -4,15 +4,15 @@ level: task
 title: "Provider contract hygiene — converge the two contract crates, surface the native trust cliff at the call site"
 short_code: "CLOACI-T-0920"
 created_at: 2026-08-02T16:33:50.270635+00:00
-updated_at: 2026-08-02T16:33:50.270635+00:00
-parent:
+updated_at: 2026-08-04T05:01:34.149590+00:00
+parent: 
 blocked_by: []
 archived: false
 
 tags:
   - "#task"
-  - "#phase/backlog"
   - "#tech-debt"
+  - "#phase/active"
 
 
 exit_criteria_met: false
@@ -37,6 +37,10 @@ Two hygiene items on the provider/constructor surface from the deep dive. Neithe
 
 1. TWO CONTRACT CRATES. The promoted crates/cloacina-constructor-contract coexists with the original spike copy under examples/constructor-contract, and the seed providers still path-dep the EXAMPLES copy. The kwarg-config machinery makes this dangerous: fidius binds config as positional, width-sensitive bincode reconstructed from ConfigField declaration order + Rust type names in a generated JSON manifest — the exact kind of contract where a silently-diverged crate copy breaks consumers invisibly (wave doctrine already says: renaming a config key is breaking even if no Rust signature moved). Fix: seeds depend on the promoted crate; delete or tombstone the spike copy; add a guard that no in-repo crate path-deps the examples copy.
 2. NATIVE TRUST CLIFF IS INVISIBLE AT THE CONSUMPTION SITE. runtime is an emission target, so a provider can change wasm→native between versions — and a consumer's grants = {...} silently flips from enforced to decorative (load_native_member takes no grants at all, by design per I-0139(e)). Load-time log + CLI banner exist, but nothing at the constructor!(...) call site or at version-bump time warns the AUTHOR. Fix options: a manifest-recorded runtime pin in the consumer (constructor!(..., runtime = "wasm") that fails the load if the resolved provider is native), and/or a wave-guard rule flagging runtime changes as major-version-only; at minimum a compile/load-time warning when grants are present but unenforced.
+
+## Acceptance Criteria
+
+## Acceptance Criteria
 
 ## Acceptance Criteria
 


### PR DESCRIPTION
Bookkeeping only — no code.

Files the last two risk-register entries as tickets:
- **T-0922** — CEL predicate errors silently black-hole subscriptions: an `Err` skips dispatch *and* advances the watermark, so a predicate broken by payload-shape drift discards firings permanently with no metric, dead-letter, or health signal. Fail-closed correctly says "don't dispatch" — that got conflated with "advance past it". Also folds in the unbound-variable lint deferred from T-0915.
- **T-0923** — auth lifecycle edges: OIDC refresh returns 501 (sessions hard-die at 15 min, I-0118 UC2 unfulfilled) and local login has no brute-force defense (OQ-13, "required before production", never resolved). The 30s cross-replica key-revocation window is documentation-only by deliberate judgment.

Also records phase transitions and completion detail for the deep-dive tickets whose work has landed or is in flight.