### PR TITLE
fix(T-0922): hold the watermark on CEL predicate errors; lint predicates at subscribe time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -744,6 +744,7 @@ dependencies = [
  "bincode",
  "bzip2 0.4.4",
  "cel-interpreter",
+ "cel-parser",
  "chrono",
  "chrono-tz",
  "cloacina-api-types",
@@ -770,6 +771,7 @@ dependencies = [
  "libloading",
  "libsqlite3-sys",
  "metrics",
+ "metrics-util",
  "once_cell",
  "parking_lot",
  "pem",
@@ -1875,6 +1877,12 @@ checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
 name = "equivalent"
@@ -3261,11 +3269,15 @@ version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdfb1365fea27e6dd9dc1dbc19f570198bc86914533ad639dae939635f096be4"
 dependencies = [
+ "aho-corasick",
  "crossbeam-epoch",
  "crossbeam-utils",
  "hashbrown 0.16.1",
+ "indexmap 2.14.0",
  "metrics",
+ "ordered-float 5.3.0",
  "quanta",
+ "radix_trie",
  "rand 0.9.4",
  "rand_xoshiro",
  "sketches-ddsketch",
@@ -3350,6 +3362,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a198f9589efc03f544388dfc4a19fe8af4323662b62f598b8dcfdac62c14771c"
 dependencies = [
  "byteorder",
+]
+
+[[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
 ]
 
 [[package]]
@@ -3661,6 +3682,15 @@ name = "ordered-float"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "ordered-float"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
 dependencies = [
  "num-traits",
 ]
@@ -4266,6 +4296,16 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
+]
 
 [[package]]
 name = "rand"
@@ -4886,7 +4926,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
 dependencies = [
- "ordered-float",
+ "ordered-float 2.10.1",
  "serde",
 ]
 

--- a/crates/cloacina-python/src/bindings/runner.rs
+++ b/crates/cloacina-python/src/bindings/runner.rs
@@ -444,6 +444,22 @@ fn reactor_subscription_to_dict(
     )?;
     dict.set_item("created_at", sub.created_at.to_string())?;
     dict.set_item("updated_at", sub.updated_at.to_string())?;
+    dict.set_item("predicate_expression", sub.predicate_expression.clone())?;
+    // CLOACI-T-0922 — predicate health. `list_reactor_subscriptions` is the
+    // only listing surface a user has for reactor subscriptions (there is no
+    // HTTP API), so the degraded/dead-letter state has to show up here or an
+    // operator can only find it by reading the row or the logs.
+    dict.set_item("predicate_degraded", sub.predicate_degraded.is_true())?;
+    dict.set_item("predicate_error_count", sub.predicate_error_count)?;
+    dict.set_item("last_predicate_error", sub.last_predicate_error.clone())?;
+    dict.set_item(
+        "last_predicate_error_at",
+        sub.last_predicate_error_at.map(|t| t.to_string()),
+    )?;
+    dict.set_item(
+        "predicate_error_firing_id",
+        sub.predicate_error_firing_id.map(|id| id.to_string()),
+    )?;
     Ok(dict.into())
 }
 

--- a/crates/cloacina/Cargo.toml
+++ b/crates/cloacina/Cargo.toml
@@ -116,6 +116,11 @@ toml = { version = "0.8" }
 anyhow = { version = "1.0" }
 bincode = { workspace = true }
 cel-interpreter = "0.10"
+# CLOACI-T-0922: the reactor-predicate subscribe-time lint needs the CEL AST to
+# tell a genuinely-unbound identifier from a comprehension iteration variable
+# (`payload.xs.exists(i, ...)`); `Program::references()` conflates the two and
+# would false-reject valid macros. Same parser cel-interpreter already uses.
+cel-parser = "0.10"
 
 [dev-dependencies]
 tracing-test = "0.2"
@@ -125,6 +130,10 @@ tempfile = "3.2"
 ed25519-dalek = { version = "2.1" }
 fidius-core = "0.5.6"
 once_cell = "1.19.0"
+# CLOACI-T-0922: the reactor predicate-error tests assert that
+# `cloacina_reactor_predicate_errors_total` actually increments, which needs a
+# recorder installed. Already in the lock graph via metrics-exporter-prometheus.
+metrics-util = { version = "0.20", features = ["debugging"] }
 serial_test = "3.2.0"
 aquamarine = "0.6.0"
 trybuild = "1.0"

--- a/crates/cloacina/src/cron_trigger_scheduler.rs
+++ b/crates/cloacina/src/cron_trigger_scheduler.rs
@@ -46,6 +46,7 @@
 
 use crate::context::Context;
 use crate::cron_evaluator::CronEvaluator;
+use crate::dal::unified::truncate_predicate_text;
 use crate::dal::UnifiedRegistryStorage;
 use crate::dal::DAL;
 use crate::database::universal_types::{UniversalTimestamp, UniversalUuid};
@@ -61,6 +62,18 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::{watch, Notify};
 use tracing::{debug, error, info, warn};
+
+/// CLOACI-T-0922 — how many consecutive CEL evaluation errors on the SAME
+/// reactor firing are tolerated before that firing is dead-lettered and the
+/// watermark force-advances past it.
+///
+/// The bound exists because holding the watermark forever would wedge the
+/// subscription: a firing whose payload shape genuinely breaks the predicate
+/// never becomes evaluable, and every later firing would queue behind it. Five
+/// poll ticks is enough to ride out a transient fault (a momentarily missing
+/// payload key, a blip in payload decode) while still resuming promptly on a
+/// structural one.
+pub const MAX_CONSECUTIVE_PREDICATE_ERRORS: i32 = 5;
 
 /// Configuration for the unified scheduler.
 #[derive(Debug, Clone)]
@@ -1116,6 +1129,11 @@ impl Scheduler {
         // can evaluate it inside the per-firing loop below.
         let predicate_expr = sub.predicate_expression.as_deref();
 
+        // CLOACI-T-0922 — the recovery write ("this predicate works again")
+        // is issued at most once per drain, guarded by this flag plus the
+        // row snapshot we already hold.
+        let mut predicate_error_cleared = false;
+
         for firing in firings {
             // Build the workflow's input context from the firing payload.
             let mut context = Context::<serde_json::Value>::new();
@@ -1158,16 +1176,35 @@ impl Scheduler {
                 serde_json::json!(firing.fired_at.0.to_rfc3339()),
             );
 
-            // CLOACI-T-0602 — predicate evaluation. If the subscription
-            // carries a CEL filter, evaluate it now. Skip dispatch when
-            // it's false; advance the watermark either way (the firing
-            // was *seen* even if we decided not to fire). Eval errors are
-            // logged warn and treated as skip — fail-closed semantics
-            // mirror the spec: a broken filter shouldn't fire workflows.
+            // CLOACI-T-0602 / T-0922 — predicate evaluation. If the
+            // subscription carries a CEL filter, evaluate it now.
+            //
+            // The three outcomes are DELIBERATELY distinct (T-0922 —
+            // they used to be two):
+            //
+            //   Ok(true)  — dispatch.
+            //   Ok(false) — the filter did its job: skip dispatch AND
+            //               advance the watermark. The firing was *seen*
+            //               and consciously rejected.
+            //   Err(_)    — the filter is BROKEN. Fail-closed still holds
+            //               (we do not dispatch), but "don't dispatch"
+            //               never implied "throw the firing away": the
+            //               watermark is HELD so the firing is re-polled
+            //               on the next tick. After
+            //               MAX_CONSECUTIVE_PREDICATE_ERRORS attempts the
+            //               firing is dead-lettered on the subscription
+            //               row and the watermark force-advances, so one
+            //               poison firing cannot wedge the subscription
+            //               forever.
             if let Some(expr) = predicate_expr {
                 match self.evaluate_predicate(sub.id, expr, &sub.tenant_id, &context) {
-                    Ok(true) => {} // proceed to dispatch
+                    Ok(true) => {
+                        self.clear_predicate_error_if_needed(sub, &mut predicate_error_cleared)
+                            .await;
+                    }
                     Ok(false) => {
+                        self.clear_predicate_error_if_needed(sub, &mut predicate_error_cleared)
+                            .await;
                         debug!(
                             subscription = %sub.id.0,
                             firing = %firing.id.0,
@@ -1190,14 +1227,89 @@ impl Scheduler {
                         }
                         continue;
                     }
-                    Err(e) => {
+                    Err(eval_err) => {
+                        metrics::counter!(
+                            "cloacina_reactor_predicate_errors_total",
+                            "reactor" => sub.reactor_name.clone(),
+                        )
+                        .increment(1);
                         warn!(
                             subscription = %sub.id.0,
                             firing = %firing.id.0,
-                            "predicate eval error (treating as skip): {}",
-                            e
+                            reactor = %sub.reactor_name,
+                            predicate = %truncate_predicate_text(expr),
+                            "reactor predicate evaluation failed; HOLDING the watermark so \
+                             the firing is retried (not dropped): {}",
+                            eval_err
                         );
-                        if let Err(e) = self
+
+                        let attempts = match self
+                            .dal
+                            .reactor_subscriptions()
+                            .record_predicate_error(sub.id.0, firing.id, &eval_err)
+                            .await
+                        {
+                            Ok(n) => n,
+                            Err(db_err) => {
+                                warn!(
+                                    subscription = %sub.id.0,
+                                    firing = %firing.id.0,
+                                    "failed to persist predicate error state; \
+                                     watermark held, firing retried next tick: {}",
+                                    db_err
+                                );
+                                // Can't count the attempt — hold anyway.
+                                // Holding is the safe direction: the firing
+                                // survives, and a persistently broken DB is
+                                // its own louder alarm.
+                                return Ok(());
+                            }
+                        };
+
+                        if attempts < MAX_CONSECUTIVE_PREDICATE_ERRORS {
+                            // Stop draining this subscription: the watermark
+                            // stays put and this firing is head-of-line again
+                            // next tick. Ordering is preserved and other
+                            // subscriptions still progress.
+                            return Ok(());
+                        }
+
+                        // Bound exceeded — dead-letter and force-advance.
+                        error!(
+                            subscription = %sub.id.0,
+                            firing = %firing.id.0,
+                            reactor = %sub.reactor_name,
+                            workflow = %sub.workflow_name,
+                            predicate = %truncate_predicate_text(expr),
+                            attempts,
+                            "reactor predicate failed {} consecutive times; DEAD-LETTERING \
+                             this firing and advancing the watermark so the subscription \
+                             resumes. Subscription marked degraded: {}",
+                            attempts, eval_err
+                        );
+                        metrics::counter!(
+                            "cloacina_reactor_predicate_dead_letters_total",
+                            "reactor" => sub.reactor_name.clone(),
+                        )
+                        .increment(1);
+
+                        if let Err(db_err) = self
+                            .dal
+                            .reactor_subscriptions()
+                            .mark_predicate_degraded(sub.id.0, firing.id, &eval_err)
+                            .await
+                        {
+                            warn!(
+                                subscription = %sub.id.0,
+                                firing = %firing.id.0,
+                                "failed to persist degraded marker; \
+                                 holding the watermark instead of advancing blind: {}",
+                                db_err
+                            );
+                            return Ok(());
+                        }
+
+                        if let Err(db_err) = self
                             .dal
                             .reactor_subscriptions()
                             .advance_watermark(sub.id.0, firing.fired_at)
@@ -1206,8 +1318,8 @@ impl Scheduler {
                             warn!(
                                 subscription = %sub.id.0,
                                 firing = %firing.id.0,
-                                "watermark advance failed after predicate error: {}",
-                                e
+                                "watermark advance failed after dead-lettering: {}",
+                                db_err
                             );
                             return Ok(());
                         }
@@ -1267,6 +1379,45 @@ impl Scheduler {
         Ok(())
     }
 
+    /// CLOACI-T-0922 — clear the persisted predicate-error state after a
+    /// clean evaluation, at most once per drain.
+    ///
+    /// `sub` is the snapshot read at the top of the poll, so it tells us
+    /// whether there is anything to clear without an extra read. Best
+    /// effort: a failure here only means the retry budget is stale, which
+    /// the next successful evaluation fixes.
+    async fn clear_predicate_error_if_needed(
+        &self,
+        sub: &crate::dal::unified::ReactorSubscription,
+        already_cleared: &mut bool,
+    ) {
+        if *already_cleared {
+            return;
+        }
+        if sub.predicate_error_count == 0 && sub.predicate_degraded.is_false() {
+            return;
+        }
+        *already_cleared = true;
+        match self
+            .dal
+            .reactor_subscriptions()
+            .clear_predicate_error(sub.id.0)
+            .await
+        {
+            Ok(()) => info!(
+                subscription = %sub.id.0,
+                reactor = %sub.reactor_name,
+                "reactor predicate evaluated cleanly again; cleared error count \
+                 and degraded marker (last_predicate_error retained as history)",
+            ),
+            Err(e) => warn!(
+                subscription = %sub.id.0,
+                "failed to clear predicate error state after recovery: {}",
+                e
+            ),
+        }
+    }
+
     /// Evaluate a CEL predicate for a subscription firing
     /// (CLOACI-T-0602).
     ///
@@ -1278,8 +1429,10 @@ impl Scheduler {
     /// Returns:
     /// - `Ok(true)`  — predicate fired, dispatch should proceed.
     /// - `Ok(false)` — predicate did not fire, skip + advance watermark.
-    /// - `Err(_)`    — compile error or runtime evaluation error.
-    ///   Caller treats as skip per the fail-closed contract.
+    /// - `Err(_)`    — compile error or runtime evaluation error. The
+    ///   caller skips dispatch (fail-closed) but HOLDS the watermark and
+    ///   retries, bounded by [`MAX_CONSECUTIVE_PREDICATE_ERRORS`]
+    ///   (CLOACI-T-0922). "Don't dispatch" never meant "drop the event".
     ///
     /// Variables exposed to the CEL expression:
     /// - `payload`  — a map keyed by boundary source name, values are
@@ -1301,8 +1454,11 @@ impl Scheduler {
             match cache.get(&sub_id) {
                 Some((cached_expr, prog)) if cached_expr == expr => prog.clone(),
                 _ => {
+                    // CLOACI-T-0922 — panic-safe compile: the CEL parser
+                    // panics on some malformed input, and this runs inside
+                    // the scheduler's poll task.
                     let prog = Arc::new(
-                        cel_interpreter::Program::compile(expr)
+                        crate::dal::unified::compile_predicate(expr)
                             .map_err(|e| format!("compile error: {}", e))?,
                     );
                     cache.insert(sub_id, (expr.to_string(), prog.clone()));

--- a/crates/cloacina/src/dal/unified/mod.rs
+++ b/crates/cloacina/src/dal/unified/mod.rs
@@ -90,7 +90,10 @@ pub use local_accounts::{LocalAccount, LocalAccountDAL, LoginOutcome};
 pub use oidc_login_flows::OidcLoginFlowDAL;
 #[cfg(feature = "postgres")]
 pub use oidc_sessions::{OidcSessionDAL, RefreshSession};
-pub use reactor_subscriptions::{ReactorFiring, ReactorSubscription, ReactorSubscriptionsDAL};
+pub use reactor_subscriptions::{
+    compile_predicate, lint_predicate_variables, truncate_predicate_text, ReactorFiring,
+    ReactorSubscription, ReactorSubscriptionsDAL, PREDICATE_VARIABLES,
+};
 pub use recovery_event::RecoveryEventDAL;
 pub use schedule::ScheduleDAL;
 pub use schedule_execution::{ScheduleExecutionDAL, ScheduleExecutionStats};

--- a/crates/cloacina/src/dal/unified/reactor_subscriptions.rs
+++ b/crates/cloacina/src/dal/unified/reactor_subscriptions.rs
@@ -68,6 +68,190 @@ pub struct ReactorSubscription {
     /// `Some(_) && false` means "skip + advance watermark". `None`
     /// preserves the original unfiltered behavior (fire on every firing).
     pub predicate_expression: Option<String>,
+    /// CLOACI-T-0922 — consecutive predicate *evaluation errors* on the
+    /// current head-of-line firing. Reset to 0 when the firing changes or
+    /// a later evaluation succeeds.
+    pub predicate_error_count: i32,
+    /// The firing `predicate_error_count` applies to.
+    pub predicate_error_firing_id: Option<UniversalUuid>,
+    /// Truncated text of the most recent predicate evaluation error.
+    /// Never cleared on recovery — it is the forensic trail.
+    pub last_predicate_error: Option<String>,
+    /// When `last_predicate_error` was recorded.
+    pub last_predicate_error_at: Option<UniversalTimestamp>,
+    /// True once a firing was dead-lettered (the consecutive-error bound
+    /// was exceeded and the watermark was force-advanced past it). Cleared
+    /// by the next successful predicate evaluation.
+    pub predicate_degraded: UniversalBool,
+}
+
+/// CLOACI-T-0922 — the complete set of variables the reactor predicate
+/// evaluator binds into the CEL context. Kept here (next to the
+/// subscribe-time validation that enforces it) so the lint and the
+/// evaluator cannot drift apart; `cron_trigger_scheduler::
+/// eval_cel_predicate_program` binds exactly these names.
+pub const PREDICATE_VARIABLES: [&str; 3] = ["payload", "reactor", "tenant"];
+
+/// Max characters of predicate/error text we persist or log. Predicates
+/// are user-authored and unbounded; log lines and DB columns are not.
+pub const PREDICATE_TEXT_TRUNCATE_LEN: usize = 240;
+
+/// Truncate `s` to `PREDICATE_TEXT_TRUNCATE_LEN` characters (char-safe),
+/// appending an ellipsis marker when anything was dropped.
+pub fn truncate_predicate_text(s: &str) -> String {
+    if s.chars().count() <= PREDICATE_TEXT_TRUNCATE_LEN {
+        return s.to_string();
+    }
+    let head: String = s.chars().take(PREDICATE_TEXT_TRUNCATE_LEN).collect();
+    format!("{}…[truncated]", head)
+}
+
+/// CLOACI-T-0922 — compile a CEL predicate, converting BOTH failure modes
+/// of the underlying parser into an error string.
+///
+/// `cel_interpreter::Program::compile` is documented to return
+/// `Err(ParseErrors)` on malformed input, but its ANTLR-generated parser
+/// panics outright on some inputs (`"payload.x >"` reaches an
+/// `unreachable!()` in `antlr4rust`). That panic pre-dates this change —
+/// the T-0602 subscribe path called `compile` bare — and it turns a typo
+/// in a user-supplied predicate into an unwind in whatever task is
+/// subscribing or polling. Catching it here keeps a bad predicate a
+/// *validation error* instead of a crash, which is the same principle this
+/// ticket applies to evaluation errors.
+pub fn compile_predicate(expr: &str) -> Result<cel_interpreter::Program, String> {
+    match std::panic::catch_unwind(|| cel_interpreter::Program::compile(expr)) {
+        Ok(Ok(program)) => Ok(program),
+        Ok(Err(e)) => Err(e.to_string()),
+        Err(_) => Err(format!(
+            "could not parse CEL predicate '{}' (the CEL parser rejected it)",
+            truncate_predicate_text(expr)
+        )),
+    }
+}
+
+/// CLOACI-T-0922 (item 4, deferred from T-0915) — reject predicates that
+/// reference identifiers outside the bound set at subscribe time.
+///
+/// The motivating incident: a predicate referencing a variable nobody
+/// binds compiles fine and then evaluates false / errors forever, which —
+/// fail-closed — silently never fires. `tennant == 'acme'` should be a
+/// loud error at the door, not a silent no-op in production.
+///
+/// # Why the AST walk instead of `Program::references()`
+///
+/// `cel_interpreter::Program::references()` does report referenced
+/// variables, but CEL's comprehension macros (`exists`, `all`, `map`,
+/// `filter`, `exists_one`) are expanded by the parser into a
+/// `Comprehension` node whose iteration variable appears as a bare
+/// `Ident` inside the loop body. `references()` therefore reports the
+/// iteration variable as if it were a free variable, and a lint built on
+/// it would reject the perfectly valid
+/// `payload.items.exists(i, i.price > 100)`. We walk the AST ourselves so
+/// comprehension-bound names (`iter_var`, `iter_var2`, `accu_var`) are
+/// treated as bound. Erring toward acceptance is deliberate: a false
+/// rejection is worse than a missed lint.
+///
+/// Returns `Ok(())` when every free identifier is in
+/// [`PREDICATE_VARIABLES`]; otherwise an error naming the offenders and
+/// the allowed set.
+pub fn lint_predicate_variables(expr: &str) -> Result<(), String> {
+    use cel_parser::ast::{EntryExpr, Expr, IdedExpr};
+    use std::collections::BTreeSet;
+
+    // Same panic caveat as `compile_predicate` — this is the same parser.
+    let parsed = match std::panic::catch_unwind(|| cel_parser::Parser::default().parse(expr)) {
+        Ok(Ok(parsed)) => parsed,
+        Ok(Err(e)) => return Err(format!("{}", e)),
+        Err(_) => {
+            return Err(format!(
+                "could not parse CEL predicate '{}' (the CEL parser rejected it)",
+                truncate_predicate_text(expr)
+            ))
+        }
+    };
+
+    fn walk(node: &IdedExpr, bound: &mut Vec<String>, free: &mut BTreeSet<String>) {
+        match &node.expr {
+            Expr::Unspecified | Expr::Literal(_) => {}
+            Expr::Ident(name) => {
+                // `@`-prefixed names are parser-internal accumulator
+                // bindings and are never user-authored.
+                if !name.starts_with('@') && !bound.iter().any(|b| b == name) {
+                    free.insert(name.clone());
+                }
+            }
+            Expr::Select(select) => walk(&select.operand, bound, free),
+            Expr::Call(call) => {
+                if let Some(target) = &call.target {
+                    walk(target, bound, free);
+                }
+                for arg in &call.args {
+                    walk(arg, bound, free);
+                }
+            }
+            Expr::List(list) => {
+                for elem in &list.elements {
+                    walk(elem, bound, free);
+                }
+            }
+            Expr::Map(map) => {
+                for entry in &map.entries {
+                    walk_entry(&entry.expr, bound, free);
+                }
+            }
+            Expr::Struct(s) => {
+                for entry in &s.entries {
+                    walk_entry(&entry.expr, bound, free);
+                }
+            }
+            Expr::Comprehension(comp) => {
+                // The range is evaluated in the OUTER scope.
+                walk(&comp.iter_range, bound, free);
+                walk(&comp.accu_init, bound, free);
+                let depth = bound.len();
+                bound.push(comp.iter_var.clone());
+                if let Some(v2) = &comp.iter_var2 {
+                    bound.push(v2.clone());
+                }
+                bound.push(comp.accu_var.clone());
+                walk(&comp.loop_cond, bound, free);
+                walk(&comp.loop_step, bound, free);
+                walk(&comp.result, bound, free);
+                bound.truncate(depth);
+            }
+        }
+    }
+
+    fn walk_entry(entry: &EntryExpr, bound: &mut Vec<String>, free: &mut BTreeSet<String>) {
+        match entry {
+            EntryExpr::StructField(field) => walk(&field.value, bound, free),
+            EntryExpr::MapEntry(e) => {
+                walk(&e.key, bound, free);
+                walk(&e.value, bound, free);
+            }
+        }
+    }
+
+    let mut bound: Vec<String> = Vec::new();
+    let mut free: BTreeSet<String> = BTreeSet::new();
+    walk(&parsed, &mut bound, &mut free);
+
+    let unknown: Vec<String> = free
+        .into_iter()
+        .filter(|name| !PREDICATE_VARIABLES.contains(&name.as_str()))
+        .collect();
+
+    if unknown.is_empty() {
+        return Ok(());
+    }
+
+    Err(format!(
+        "predicate references unknown variable(s): {}. Available variables are: {}. \
+         (Did you mean a field of `payload`, e.g. `payload.{}`?)",
+        unknown.join(", "),
+        PREDICATE_VARIABLES.join(", "),
+        unknown[0],
+    ))
 }
 
 /// Data access layer for reactor subscriptions + firings.
@@ -179,8 +363,12 @@ impl<'a> ReactorSubscriptionsDAL<'a> {
             // Compile-time validation: reject malformed expressions before
             // they reach the DB. Cheap (single parse), centralizes the
             // error message at the API boundary.
-            cel_interpreter::Program::compile(expr)
-                .map_err(|e| ValidationError::InvalidPredicate(e.to_string()))?;
+            compile_predicate(expr).map_err(ValidationError::InvalidPredicate)?;
+            // CLOACI-T-0922 — and reject well-formed expressions that
+            // reference variables nobody binds. Those compile fine and then
+            // silently never fire (fail-closed), which is exactly the class
+            // of bug the `tenant` stub incident (T-0915) produced.
+            lint_predicate_variables(expr).map_err(ValidationError::InvalidPredicate)?;
         }
         let predicate = predicate.map(str::to_string);
         crate::dispatch_backend!(
@@ -337,6 +525,142 @@ impl<'a> ReactorSubscriptionsDAL<'a> {
         Ok(())
     }
 
+    /// CLOACI-T-0922 — record a predicate evaluation error against a
+    /// subscription and return the new consecutive-error count for
+    /// `firing_id`.
+    ///
+    /// The count is per (subscription, firing): if `firing_id` differs
+    /// from the firing the stored count applies to, the count restarts at
+    /// 1. Because the watermark is held on error, the same firing stays
+    /// head-of-line until it either evaluates cleanly or gets
+    /// dead-lettered, so "consecutive errors on this firing" is exactly
+    /// "attempts spent on this firing".
+    ///
+    /// Read-modify-write on a single pooled connection. The reactor poller
+    /// is the only writer of these columns and processes a subscription
+    /// serially, so no lock is needed; a lost update under a hypothetical
+    /// second poller would only make the bound approximate, never unsafe.
+    pub async fn record_predicate_error(
+        &self,
+        subscription_id: Uuid,
+        firing_id: UniversalUuid,
+        error: &str,
+    ) -> Result<i32, ValidationError> {
+        let sid = UniversalUuid(subscription_id);
+        let now = UniversalTimestamp::now();
+        let error = truncate_predicate_text(error);
+        let count = crate::interact_on_backend!(self.dal, |conn| {
+            let (prev_count, prev_firing): (i32, Option<UniversalUuid>) =
+                reactor_trigger_subscriptions::table
+                    .filter(reactor_trigger_subscriptions::id.eq(sid))
+                    .select((
+                        reactor_trigger_subscriptions::predicate_error_count,
+                        reactor_trigger_subscriptions::predicate_error_firing_id,
+                    ))
+                    .first(conn)?;
+            let next = if prev_firing == Some(firing_id) {
+                prev_count.saturating_add(1)
+            } else {
+                1
+            };
+            diesel::update(
+                reactor_trigger_subscriptions::table
+                    .filter(reactor_trigger_subscriptions::id.eq(sid)),
+            )
+            .set((
+                reactor_trigger_subscriptions::predicate_error_count.eq(next),
+                reactor_trigger_subscriptions::predicate_error_firing_id.eq(Some(firing_id)),
+                reactor_trigger_subscriptions::last_predicate_error.eq(Some(error)),
+                reactor_trigger_subscriptions::last_predicate_error_at.eq(Some(now)),
+                reactor_trigger_subscriptions::updated_at.eq(now),
+            ))
+            .execute(conn)?;
+            Ok::<i32, diesel::result::Error>(next)
+        })?;
+        Ok(count)
+    }
+
+    /// CLOACI-T-0922 — mark a subscription degraded because a firing was
+    /// dead-lettered: its predicate errored more times than the bound
+    /// allows, so the caller is about to force-advance the watermark past
+    /// it. The error text + firing id stay on the row as the durable
+    /// record of what was dropped.
+    ///
+    /// Resets the consecutive-error counter so the NEXT firing starts with
+    /// a full retry budget.
+    pub async fn mark_predicate_degraded(
+        &self,
+        subscription_id: Uuid,
+        firing_id: UniversalUuid,
+        error: &str,
+    ) -> Result<(), ValidationError> {
+        let sid = UniversalUuid(subscription_id);
+        let now = UniversalTimestamp::now();
+        let error = truncate_predicate_text(error);
+        crate::interact_on_backend!(self.dal, |conn| {
+            diesel::update(
+                reactor_trigger_subscriptions::table
+                    .filter(reactor_trigger_subscriptions::id.eq(sid)),
+            )
+            .set((
+                reactor_trigger_subscriptions::predicate_degraded.eq(UniversalBool::from(true)),
+                reactor_trigger_subscriptions::predicate_error_count.eq(0),
+                reactor_trigger_subscriptions::predicate_error_firing_id.eq(Some(firing_id)),
+                reactor_trigger_subscriptions::last_predicate_error.eq(Some(error)),
+                reactor_trigger_subscriptions::last_predicate_error_at.eq(Some(now)),
+                reactor_trigger_subscriptions::updated_at.eq(now),
+            ))
+            .execute(conn)
+        })?;
+        Ok(())
+    }
+
+    /// CLOACI-T-0922 — a predicate evaluated cleanly, so clear the retry
+    /// counter and the degraded flag.
+    ///
+    /// `last_predicate_error` / `last_predicate_error_at` are deliberately
+    /// NOT cleared: recovery should not erase the evidence that firings
+    /// were dropped. "Currently degraded" is `predicate_degraded`; "what
+    /// went wrong last" is the `last_predicate_error*` pair.
+    pub async fn clear_predicate_error(
+        &self,
+        subscription_id: Uuid,
+    ) -> Result<(), ValidationError> {
+        let sid = UniversalUuid(subscription_id);
+        let now = UniversalTimestamp::now();
+        crate::interact_on_backend!(self.dal, |conn| {
+            diesel::update(
+                reactor_trigger_subscriptions::table
+                    .filter(reactor_trigger_subscriptions::id.eq(sid)),
+            )
+            .set((
+                reactor_trigger_subscriptions::predicate_error_count.eq(0),
+                reactor_trigger_subscriptions::predicate_error_firing_id.eq(None::<UniversalUuid>),
+                reactor_trigger_subscriptions::predicate_degraded.eq(UniversalBool::from(false)),
+                reactor_trigger_subscriptions::updated_at.eq(now),
+            ))
+            .execute(conn)
+        })?;
+        Ok(())
+    }
+
+    /// CLOACI-T-0922 — fetch a single subscription by id. Used by the
+    /// health/inspection path so an operator (or a test) can read the
+    /// degraded state without scanning a tenant's whole subscription list.
+    pub async fn get_subscription(
+        &self,
+        subscription_id: Uuid,
+    ) -> Result<Option<ReactorSubscription>, ValidationError> {
+        let sid = UniversalUuid(subscription_id);
+        let row = crate::interact_on_backend!(self.dal, |conn| {
+            reactor_trigger_subscriptions::table
+                .filter(reactor_trigger_subscriptions::id.eq(sid))
+                .first::<ReactorSubscription>(conn)
+                .optional()
+        })?;
+        Ok(row)
+    }
+
     /// Remove a subscription. Returns true if a row was deleted.
     pub async fn unsubscribe(
         &self,
@@ -383,5 +707,128 @@ impl<'a> ReactorSubscriptionsDAL<'a> {
                 .load::<ReactorSubscription>(conn)
         })?;
         Ok(rows)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ─────────────────────────────────────────────────────────────────
+    // CLOACI-T-0922 — subscribe-time unbound-variable lint.
+    //
+    // The bar is asymmetric on purpose: a FALSE REJECTION breaks a valid
+    // production predicate, while a missed lint only restores today's
+    // behaviour. Every "accepts" case below is therefore a regression pin.
+    // ─────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn lint_accepts_the_bound_variables() {
+        lint_predicate_variables("payload.x > 1 && tenant == 'acme'").expect("payload + tenant");
+        lint_predicate_variables("reactor == 'pricing'").expect("reactor");
+        lint_predicate_variables("payload.price > 100 && payload.region == 'us-east'")
+            .expect("nested payload selects");
+        lint_predicate_variables("tenant == 'acme' || tenant == 'public'").expect("tenant only");
+    }
+
+    #[test]
+    fn lint_rejects_a_typod_identifier() {
+        let err = lint_predicate_variables("payload.x > 1 && tennant == 'acme'")
+            .expect_err("typo'd `tennant` must be rejected");
+        assert!(
+            err.contains("tennant"),
+            "error should name the offending variable, got: {}",
+            err
+        );
+        assert!(
+            err.contains("payload") && err.contains("reactor") && err.contains("tenant"),
+            "error should list the allowed variables, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn lint_rejects_a_bare_unknown_identifier() {
+        assert!(lint_predicate_variables("foo").is_err());
+        assert!(lint_predicate_variables("payload.a == bar").is_err());
+    }
+
+    /// The whole reason the lint walks the AST instead of using
+    /// `Program::references()`: comprehension macros bind their iteration
+    /// variable as a bare `Ident` in the loop body, and `references()`
+    /// reports it as free. These MUST be accepted.
+    #[test]
+    fn lint_accepts_comprehension_iteration_variables() {
+        lint_predicate_variables("payload.items.exists(i, i.price > 100)").expect("exists");
+        lint_predicate_variables("payload.items.all(x, x > 0)").expect("all");
+        lint_predicate_variables("payload.items.filter(v, v != 0).size() > 0").expect("filter");
+        lint_predicate_variables("payload.items.map(m, m.id).size() > 1").expect("map");
+        lint_predicate_variables("payload.a.exists(i, payload.b.exists(j, i == j))")
+            .expect("nested comprehensions");
+    }
+
+    /// An iteration variable is only bound INSIDE its comprehension. Once
+    /// the scope closes, the same name is free again.
+    #[test]
+    fn lint_rejects_iteration_variable_used_outside_its_scope() {
+        assert!(
+            lint_predicate_variables("payload.items.exists(i, i > 0) && i > 1").is_err(),
+            "`i` outside the comprehension body is a free variable"
+        );
+    }
+
+    #[test]
+    fn lint_accepts_builtin_functions_and_literals() {
+        lint_predicate_variables("size(payload.items) > 0").expect("size()");
+        lint_predicate_variables("has(payload.price)").expect("has()");
+        lint_predicate_variables("payload.name.startsWith('acme')").expect("receiver call");
+        lint_predicate_variables("1 > 0").expect("no variables at all");
+        lint_predicate_variables("payload.tags == ['a', 'b']").expect("list literal");
+        lint_predicate_variables("{'k': payload.v}['k'] == 1").expect("map literal");
+    }
+
+    /// The CEL parser panics (not errors) on some malformed input —
+    /// `"payload.x >"` hits an `unreachable!()` inside `antlr4rust`.
+    /// Both entry points must convert that into an ordinary error rather
+    /// than unwinding into the subscriber / poller task.
+    #[test]
+    fn malformed_predicates_error_instead_of_panicking() {
+        let previous = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| {})); // keep the test output clean
+
+        let compile = std::panic::catch_unwind(|| compile_predicate("payload.x >"));
+        let lint = std::panic::catch_unwind(|| lint_predicate_variables("payload.x >"));
+
+        std::panic::set_hook(previous);
+
+        let compile = compile.expect("compile_predicate must not unwind");
+        assert!(compile.is_err(), "malformed predicate must be an error");
+        let lint = lint.expect("lint_predicate_variables must not unwind");
+        assert!(lint.is_err(), "malformed predicate must be an error");
+    }
+
+    #[test]
+    fn compile_predicate_accepts_valid_expressions() {
+        assert!(compile_predicate("payload.x > 1 && tenant == 'acme'").is_ok());
+        assert!(compile_predicate("this is not cel ((").is_err());
+    }
+
+    #[test]
+    fn lint_allowed_set_matches_the_documented_variables() {
+        assert_eq!(PREDICATE_VARIABLES, ["payload", "reactor", "tenant"]);
+    }
+
+    #[test]
+    fn truncate_predicate_text_is_char_safe_and_marks_truncation() {
+        let short = "payload.x > 1";
+        assert_eq!(truncate_predicate_text(short), short);
+
+        let long = "é".repeat(PREDICATE_TEXT_TRUNCATE_LEN + 50);
+        let out = truncate_predicate_text(&long);
+        assert!(out.ends_with("…[truncated]"));
+        assert_eq!(
+            out.chars().count(),
+            PREDICATE_TEXT_TRUNCATE_LEN + "…[truncated]".chars().count()
+        );
     }
 }

--- a/crates/cloacina/src/database/migrations/postgres/048_reactor_predicate_error_tracking/down.sql
+++ b/crates/cloacina/src/database/migrations/postgres/048_reactor_predicate_error_tracking/down.sql
@@ -1,0 +1,5 @@
+ALTER TABLE reactor_trigger_subscriptions DROP COLUMN predicate_degraded;
+ALTER TABLE reactor_trigger_subscriptions DROP COLUMN last_predicate_error_at;
+ALTER TABLE reactor_trigger_subscriptions DROP COLUMN last_predicate_error;
+ALTER TABLE reactor_trigger_subscriptions DROP COLUMN predicate_error_firing_id;
+ALTER TABLE reactor_trigger_subscriptions DROP COLUMN predicate_error_count;

--- a/crates/cloacina/src/database/migrations/postgres/048_reactor_predicate_error_tracking/up.sql
+++ b/crates/cloacina/src/database/migrations/postgres/048_reactor_predicate_error_tracking/up.sql
@@ -1,0 +1,32 @@
+-- CLOACI-T-0922 — CEL predicate errors must not silently black-hole a
+-- subscription.
+--
+-- Before this change an `Err(_)` out of predicate evaluation took the same
+-- path as `Ok(false)`: skip the firing AND advance the watermark. That turned
+-- a transient or structural fault into permanent, invisible data loss.
+--
+-- The dispatcher now HOLDS the watermark on an evaluation error and retries
+-- the firing on the next poll tick. These columns make the retry bounded and
+-- the failure durable, so one poison firing cannot wedge the subscription
+-- forever and an operator can see what happened after the fact:
+--
+--   predicate_error_count      consecutive eval failures on the CURRENT
+--                              head-of-line firing (reset when the firing
+--                              changes or a later evaluation succeeds)
+--   predicate_error_firing_id  the firing the count applies to
+--   last_predicate_error       truncated error text (forensic trail; never
+--                              cleared, so the evidence survives recovery)
+--   last_predicate_error_at    when that error was recorded
+--   predicate_degraded         TRUE once a firing was dead-lettered (bound
+--                              exceeded, watermark force-advanced); cleared
+--                              by the next successful evaluation
+ALTER TABLE reactor_trigger_subscriptions
+    ADD COLUMN predicate_error_count INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE reactor_trigger_subscriptions
+    ADD COLUMN predicate_error_firing_id UUID;
+ALTER TABLE reactor_trigger_subscriptions
+    ADD COLUMN last_predicate_error TEXT;
+ALTER TABLE reactor_trigger_subscriptions
+    ADD COLUMN last_predicate_error_at TIMESTAMP;
+ALTER TABLE reactor_trigger_subscriptions
+    ADD COLUMN predicate_degraded BOOLEAN NOT NULL DEFAULT FALSE;

--- a/crates/cloacina/src/database/migrations/sqlite/048_reactor_predicate_error_tracking/down.sql
+++ b/crates/cloacina/src/database/migrations/sqlite/048_reactor_predicate_error_tracking/down.sql
@@ -1,0 +1,6 @@
+-- SQLite 3.35+ supports DROP COLUMN (the workspace already requires it).
+ALTER TABLE reactor_trigger_subscriptions DROP COLUMN predicate_degraded;
+ALTER TABLE reactor_trigger_subscriptions DROP COLUMN last_predicate_error_at;
+ALTER TABLE reactor_trigger_subscriptions DROP COLUMN last_predicate_error;
+ALTER TABLE reactor_trigger_subscriptions DROP COLUMN predicate_error_firing_id;
+ALTER TABLE reactor_trigger_subscriptions DROP COLUMN predicate_error_count;

--- a/crates/cloacina/src/database/migrations/sqlite/048_reactor_predicate_error_tracking/up.sql
+++ b/crates/cloacina/src/database/migrations/sqlite/048_reactor_predicate_error_tracking/up.sql
@@ -1,0 +1,17 @@
+-- CLOACI-T-0922 — SQLite mirror of postgres migration 048. See the postgres
+-- twin for the full rationale: the reactor dispatcher now holds the watermark
+-- when a CEL predicate errors (instead of skipping + advancing, which silently
+-- destroyed the firing) and needs a durable, bounded retry counter plus a
+-- dead-letter marker.
+--
+-- ADD COLUMN only — no DROP+CREATE table rewrite.
+ALTER TABLE reactor_trigger_subscriptions
+    ADD COLUMN predicate_error_count INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE reactor_trigger_subscriptions
+    ADD COLUMN predicate_error_firing_id TEXT;
+ALTER TABLE reactor_trigger_subscriptions
+    ADD COLUMN last_predicate_error TEXT;
+ALTER TABLE reactor_trigger_subscriptions
+    ADD COLUMN last_predicate_error_at TIMESTAMP;
+ALTER TABLE reactor_trigger_subscriptions
+    ADD COLUMN predicate_degraded BOOLEAN NOT NULL DEFAULT FALSE;

--- a/crates/cloacina/src/database/schema.rs
+++ b/crates/cloacina/src/database/schema.rs
@@ -544,6 +544,17 @@ mod unified_schema {
             // every firing"; non-NULL is evaluated against the firing
             // payload before dispatch.
             predicate_expression -> Nullable<Text>,
+            // CLOACI-T-0922 — bounded retry + dead-letter state for CEL
+            // predicate evaluation errors. An eval error HOLDS the
+            // watermark (the firing is retried); after
+            // MAX_CONSECUTIVE_PREDICATE_ERRORS the firing is dead-lettered
+            // (`predicate_degraded`) and the watermark force-advances so a
+            // poison firing cannot wedge the subscription forever.
+            predicate_error_count -> Integer,
+            predicate_error_firing_id -> Nullable<DbUuid>,
+            last_predicate_error -> Nullable<Text>,
+            last_predicate_error_at -> Nullable<DbTimestamp>,
+            predicate_degraded -> DbBool,
         }
     }
 

--- a/crates/cloacina/src/runner/default_runner/reactor_subscriptions_api.rs
+++ b/crates/cloacina/src/runner/default_runner/reactor_subscriptions_api.rs
@@ -53,13 +53,23 @@ impl DefaultRunner {
     /// * `tenant` - Tenant scope. `None` ⇒ `"public"`.
     /// * `predicate` - Optional CEL filter expression (CLOACI-T-0602).
     ///   `None` keeps the original fire-on-every-firing behaviour. When
-    ///   `Some(_)`, the expression is compiled at subscribe time;
-    ///   invalid CEL is rejected with `ExecutionFailed` before any DB
-    ///   write. At dispatch time the scheduler evaluates it against the
-    ///   firing payload and skips dispatch when it returns false (the
-    ///   watermark still advances). Variables available in the
-    ///   expression: `payload` (the deserialised boundary cache, keys
-    ///   are source names), `reactor` (string), `tenant` (string).
+    ///   `Some(_)`, the expression is validated at subscribe time and
+    ///   rejected with `ExecutionFailed` before any DB write if it is
+    ///   invalid CEL *or* references a variable outside the bound set
+    ///   (CLOACI-T-0922 — a typo'd identifier used to compile fine and
+    ///   then silently never match).
+    ///
+    ///   Variables available in the expression: `payload` (the
+    ///   deserialised boundary cache, keys are source names), `reactor`
+    ///   (string), `tenant` (string).
+    ///
+    ///   At dispatch time the scheduler evaluates it against the firing
+    ///   payload. `false` skips dispatch and advances the watermark. An
+    ///   evaluation *error* also skips dispatch (fail-closed) but HOLDS
+    ///   the watermark so the firing is retried; after five consecutive
+    ///   failures on the same firing it is dead-lettered onto the
+    ///   subscription row (`predicate_degraded`, `last_predicate_error`)
+    ///   and the watermark advances so the subscription resumes.
     ///
     /// # Examples
     /// ```ignore

--- a/crates/cloacina/tests/integration/scheduler/reactor_predicate.rs
+++ b/crates/cloacina/tests/integration/scheduler/reactor_predicate.rs
@@ -32,6 +32,7 @@ use crate::fixtures::get_or_init_fixture;
 use async_trait::async_trait;
 use chrono::Timelike;
 use cloacina::context::Context;
+use cloacina::cron_trigger_scheduler::MAX_CONSECUTIVE_PREDICATE_ERRORS;
 use cloacina::cron_trigger_scheduler::{Scheduler, SchedulerConfig};
 use cloacina::database::universal_types::UniversalTimestamp;
 use cloacina::executor::{
@@ -40,9 +41,10 @@ use cloacina::executor::{
 };
 use cloacina::runner::{DefaultRunner, DefaultRunnerConfig};
 use cloacina::Runtime;
+use metrics_util::debugging::{DebugValue, DebuggingRecorder, Snapshotter};
 use serial_test::serial;
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
 use tokio::sync::watch;
 use uuid::Uuid;
@@ -164,6 +166,70 @@ fn build_firing_payload(source: &str, value: serde_json::Value) -> Vec<u8> {
     bincode::serialize(&map).expect("bincode encode")
 }
 
+/// Scheduler config used by every test in this file. We drive the reactor
+/// poll manually via `poll_reactor_subscriptions_once`, but every field
+/// still gets a valid value so construction can't be rejected.
+fn test_scheduler_config() -> SchedulerConfig {
+    SchedulerConfig {
+        cron_poll_interval: Duration::from_secs(30),
+        max_catchup_executions: 0,
+        max_acceptable_delay: Duration::from_secs(300),
+        trigger_base_poll_interval: Duration::from_millis(50),
+        trigger_poll_timeout: Duration::from_secs(5),
+        reactor_poll_interval: Duration::from_millis(50),
+        reactor_poll_batch_limit: 100,
+        reactor_firings_prune_interval: Duration::from_secs(3600),
+        reactor_firings_retention: Duration::from_secs(86400),
+    }
+}
+
+/// A μs-aligned timestamp. Postgres `TIMESTAMP` stores microsecond
+/// precision, so sub-μs nanos are lost on roundtrip; aligning the inputs
+/// keeps watermark comparisons well-defined on both backends.
+fn aligned_now() -> UniversalTimestamp {
+    let now = UniversalTimestamp::now().0;
+    let truncated_nanos = (now.timestamp_subsec_nanos() / 1_000) * 1_000;
+    UniversalTimestamp(
+        now.with_nanosecond(truncated_nanos)
+            .expect("truncate nanos"),
+    )
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// CLOACI-T-0922 — metric capture.
+//
+// `DebuggingRecorder::install` is process-global and one-shot, so it is
+// installed lazily and shared. `Snapshotter::snapshot` SWAPS counters to
+// zero, so every snapshot is the delta since the previous one.
+// ─────────────────────────────────────────────────────────────────────
+static METRICS_SNAPSHOTTER: OnceLock<Snapshotter> = OnceLock::new();
+
+fn metrics_snapshotter() -> &'static Snapshotter {
+    METRICS_SNAPSHOTTER.get_or_init(|| {
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+        recorder
+            .install()
+            .expect("no other global metrics recorder should be installed in this test binary");
+        snapshotter
+    })
+}
+
+/// Sum of the counter `name` across all label sets, since the last
+/// snapshot. Returns 0 when the counter was never touched.
+fn counter_delta(name: &str) -> u64 {
+    metrics_snapshotter()
+        .snapshot()
+        .into_vec()
+        .into_iter()
+        .filter(|(ck, _, _, _)| ck.key().name() == name)
+        .filter_map(|(_, _, _, value)| match value {
+            DebugValue::Counter(n) => Some(n),
+            _ => None,
+        })
+        .sum()
+}
+
 /// End-to-end: subscribe with a CEL filter, insert two firings (one
 /// matching the predicate, one not), run a single scheduler tick, and
 /// verify:
@@ -205,20 +271,7 @@ async fn test_predicate_filters_dispatch_and_advances_watermark_for_skips() {
     let scheduler = Scheduler::new(
         Arc::new(cloacina::dal::DAL::new(database)),
         executor.clone(),
-        SchedulerConfig {
-            // Fast tick + plenty of headroom; we drive the poll manually
-            // via `poll_reactor_subscriptions_once`, but supply valid
-            // values so a misconfigured field doesn't reject construction.
-            cron_poll_interval: Duration::from_secs(30),
-            max_catchup_executions: 0,
-            max_acceptable_delay: Duration::from_secs(300),
-            trigger_base_poll_interval: Duration::from_millis(50),
-            trigger_poll_timeout: Duration::from_secs(5),
-            reactor_poll_interval: Duration::from_millis(50),
-            reactor_poll_batch_limit: 100,
-            reactor_firings_prune_interval: Duration::from_secs(3600),
-            reactor_firings_retention: Duration::from_secs(86400),
-        },
+        test_scheduler_config(),
         shutdown_rx,
         runtime,
         Arc::new(tokio::sync::Notify::new()),
@@ -241,14 +294,7 @@ async fn test_predicate_filters_dispatch_and_advances_watermark_for_skips() {
     // The watermark we read back later will be μs-aligned; align the
     // inputs the same way so the >= comparison at the end of the test
     // is well-defined on both backends.
-    let ts_first = {
-        let now = UniversalTimestamp::now().0;
-        let truncated_nanos = (now.timestamp_subsec_nanos() / 1_000) * 1_000;
-        UniversalTimestamp(
-            now.with_nanosecond(truncated_nanos)
-                .expect("truncate nanos"),
-        )
-    };
+    let ts_first = aligned_now();
     dal.reactor_subscriptions()
         .insert_firing(
             &reactor,
@@ -326,5 +372,420 @@ async fn test_predicate_filters_dispatch_and_advances_watermark_for_skips() {
         ts_second.0,
     );
 
+    // CLOACI-T-0922 — the distinction that used to be missing: a
+    // predicate that returns FALSE is a working predicate. It must not
+    // leave any error/degraded residue behind.
+    assert_eq!(
+        sub.predicate_error_count, 0,
+        "a false predicate is not an error and must not count against the retry budget"
+    );
+    assert!(
+        sub.predicate_degraded.is_false(),
+        "a false predicate must not mark the subscription degraded"
+    );
+    assert!(
+        sub.last_predicate_error.is_none(),
+        "a false predicate must not record an error, got: {:?}",
+        sub.last_predicate_error
+    );
+
     runner.shutdown().await.unwrap();
+}
+
+/// CLOACI-T-0922 — an *erroring* predicate must NOT advance the watermark.
+///
+/// This is the regression that motivated the ticket: `Err(_)` used to take
+/// the same path as `Ok(false)` (skip + advance), which silently and
+/// permanently destroyed the firing. Fail-closed means "don't dispatch";
+/// it never meant "throw the event away".
+///
+/// Asserts, across two consecutive polls of the same firing:
+///   - no dispatch (fail-closed still holds)
+///   - the watermark is still unset, so the firing is re-polled
+///   - the consecutive-error count climbs 1 -> 2 (durably, on the row)
+///   - `cloacina_reactor_predicate_errors_total` increments per error
+#[tokio::test]
+#[serial]
+async fn test_predicate_error_holds_watermark_and_counts() {
+    let fixture = get_or_init_fixture().await;
+    let mut fixture = fixture.lock().unwrap_or_else(|e| e.into_inner());
+    fixture.reset_database().await;
+    fixture.initialize().await;
+
+    let database = fixture.get_database();
+    let dal = fixture.get_dal();
+
+    let runner = DefaultRunner::with_config(
+        &fixture.get_database_url(),
+        DefaultRunnerConfig::builder()
+            .enable_cron_scheduling(false)
+            .build()
+            .unwrap(),
+    )
+    .await
+    .expect("runner");
+
+    let executor = Arc::new(RecordingExecutor::default());
+    executor.set_inner(runner.clone());
+
+    let (_shutdown_tx, shutdown_rx) = watch::channel(false);
+    let scheduler = Scheduler::new(
+        Arc::new(cloacina::dal::DAL::new(database)),
+        executor.clone(),
+        test_scheduler_config(),
+        shutdown_rx,
+        Arc::new(Runtime::empty()),
+        Arc::new(tokio::sync::Notify::new()),
+    );
+
+    let tenant = format!("tenant-{}", Uuid::new_v4());
+    let reactor = "rt_predicate_err".to_string();
+    let workflow = "wf_predicate_err".to_string();
+
+    // `payload.value` on a firing that carries no `value` key is a CEL
+    // *evaluation* error (no such key) — it compiles fine and passes the
+    // subscribe-time lint (it only references `payload`), which is exactly
+    // the payload-shape-drift scenario the ticket describes.
+    let sub_id = dal
+        .reactor_subscriptions()
+        .subscribe(&reactor, &workflow, &tenant, Some("payload.value > 100"))
+        .await
+        .expect("subscribe with predicate");
+
+    let ts = aligned_now();
+    dal.reactor_subscriptions()
+        .insert_firing(
+            &reactor,
+            &tenant,
+            Some(build_firing_payload(
+                "other",
+                serde_json::Value::Number(1.into()),
+            )),
+            ts,
+        )
+        .await
+        .expect("insert firing");
+
+    // Reset the metric delta window before the poll we measure.
+    let _ = counter_delta("cloacina_reactor_predicate_errors_total");
+
+    scheduler
+        .poll_reactor_subscriptions_once()
+        .await
+        .expect("first tick");
+
+    assert!(
+        executor.snapshot().is_empty(),
+        "a broken predicate must never dispatch (fail-closed), got: {:?}",
+        executor.snapshot()
+    );
+
+    let sub = dal
+        .reactor_subscriptions()
+        .get_subscription(sub_id)
+        .await
+        .expect("get subscription")
+        .expect("subscription row exists");
+    assert!(
+        sub.last_seen_fired_at.is_none(),
+        "watermark MUST be held on a predicate error so the firing is retried; \
+         it advanced to {:?} instead",
+        sub.last_seen_fired_at
+    );
+    assert_eq!(
+        sub.predicate_error_count, 1,
+        "first failure should record one attempt"
+    );
+    assert_eq!(
+        sub.predicate_error_firing_id.map(|id| id.0),
+        Some(
+            dal.reactor_subscriptions()
+                .poll_unconsumed(&tenant, &reactor, None, 10)
+                .await
+                .expect("poll firings")[0]
+                .id
+                .0
+        ),
+        "the attempt count must be attributed to the failing firing"
+    );
+    assert!(
+        sub.last_predicate_error.is_some(),
+        "the error text must be recorded durably"
+    );
+    assert!(
+        sub.predicate_degraded.is_false(),
+        "one failure is far short of the bound; not degraded yet"
+    );
+
+    // Second tick: the SAME firing must still be head-of-line.
+    scheduler
+        .poll_reactor_subscriptions_once()
+        .await
+        .expect("second tick");
+
+    let sub = dal
+        .reactor_subscriptions()
+        .get_subscription(sub_id)
+        .await
+        .expect("get subscription")
+        .expect("subscription row exists");
+    assert!(
+        sub.last_seen_fired_at.is_none(),
+        "watermark still held on the second failure"
+    );
+    assert_eq!(
+        sub.predicate_error_count, 2,
+        "consecutive failures on the same firing must accumulate"
+    );
+
+    assert_eq!(
+        counter_delta("cloacina_reactor_predicate_errors_total"),
+        2,
+        "every predicate evaluation error must increment the counter"
+    );
+
+    runner.shutdown().await.unwrap();
+}
+
+/// CLOACI-T-0922 — the bound: holding the watermark forever would wedge
+/// the subscription, so after `MAX_CONSECUTIVE_PREDICATE_ERRORS` attempts
+/// the poison firing is dead-lettered (recorded on the row + counted) and
+/// the watermark force-advances.
+///
+/// Then the recovery half: a later firing that evaluates cleanly clears
+/// the retry budget and the degraded flag, while `last_predicate_error`
+/// survives as the forensic trail of what was dropped.
+#[tokio::test]
+#[serial]
+async fn test_predicate_error_dead_letters_at_the_bound_then_recovers() {
+    let fixture = get_or_init_fixture().await;
+    let mut fixture = fixture.lock().unwrap_or_else(|e| e.into_inner());
+    fixture.reset_database().await;
+    fixture.initialize().await;
+
+    let database = fixture.get_database();
+    let dal = fixture.get_dal();
+
+    let runner = DefaultRunner::with_config(
+        &fixture.get_database_url(),
+        DefaultRunnerConfig::builder()
+            .enable_cron_scheduling(false)
+            .build()
+            .unwrap(),
+    )
+    .await
+    .expect("runner");
+
+    let executor = Arc::new(RecordingExecutor::default());
+    executor.set_inner(runner.clone());
+
+    let (_shutdown_tx, shutdown_rx) = watch::channel(false);
+    let scheduler = Scheduler::new(
+        Arc::new(cloacina::dal::DAL::new(database)),
+        executor.clone(),
+        test_scheduler_config(),
+        shutdown_rx,
+        Arc::new(Runtime::empty()),
+        Arc::new(tokio::sync::Notify::new()),
+    );
+
+    let tenant = format!("tenant-{}", Uuid::new_v4());
+    let reactor = "rt_predicate_deadletter".to_string();
+    let workflow = "wf_predicate_deadletter".to_string();
+
+    let sub_id = dal
+        .reactor_subscriptions()
+        .subscribe(&reactor, &workflow, &tenant, Some("payload.value > 100"))
+        .await
+        .expect("subscribe with predicate");
+
+    // The poison firing: no `value` key, so the predicate errors forever.
+    let ts_poison = aligned_now();
+    dal.reactor_subscriptions()
+        .insert_firing(
+            &reactor,
+            &tenant,
+            Some(build_firing_payload(
+                "other",
+                serde_json::Value::Number(1.into()),
+            )),
+            ts_poison,
+        )
+        .await
+        .expect("insert poison firing");
+
+    let _ = counter_delta("cloacina_reactor_predicate_dead_letters_total");
+
+    // Poll up to (but not including) the bound: still held.
+    for tick in 1..MAX_CONSECUTIVE_PREDICATE_ERRORS {
+        scheduler
+            .poll_reactor_subscriptions_once()
+            .await
+            .expect("tick");
+        let sub = dal
+            .reactor_subscriptions()
+            .get_subscription(sub_id)
+            .await
+            .expect("get subscription")
+            .expect("row");
+        assert!(
+            sub.last_seen_fired_at.is_none(),
+            "watermark must still be held at attempt {} of {}",
+            tick,
+            MAX_CONSECUTIVE_PREDICATE_ERRORS
+        );
+        assert!(sub.predicate_degraded.is_false());
+    }
+
+    // The tick that hits the bound dead-letters and force-advances.
+    scheduler
+        .poll_reactor_subscriptions_once()
+        .await
+        .expect("bound tick");
+
+    let sub = dal
+        .reactor_subscriptions()
+        .get_subscription(sub_id)
+        .await
+        .expect("get subscription")
+        .expect("row");
+    let watermark = sub
+        .last_seen_fired_at
+        .expect("watermark must advance past a dead-lettered firing so the subscription resumes");
+    assert!(
+        watermark.0 >= ts_poison.0,
+        "watermark {:?} should have advanced past the poison firing {:?}",
+        watermark.0,
+        ts_poison.0
+    );
+    assert!(
+        sub.predicate_degraded.is_true(),
+        "dead-lettering a firing must mark the subscription degraded"
+    );
+    assert!(
+        sub.last_predicate_error.is_some(),
+        "the dead-lettered firing's error must be recorded durably"
+    );
+    assert!(
+        sub.last_predicate_error_at.is_some(),
+        "the dead-letter must be timestamped"
+    );
+    assert_eq!(
+        sub.predicate_error_count, 0,
+        "the next firing gets a fresh retry budget"
+    );
+    assert!(
+        executor.snapshot().is_empty(),
+        "a dead-lettered firing is never dispatched"
+    );
+    assert_eq!(
+        counter_delta("cloacina_reactor_predicate_dead_letters_total"),
+        1,
+        "the dead-letter must be counted exactly once"
+    );
+
+    // ── Recovery: a well-shaped firing evaluates cleanly again. ──
+    let ts_good = UniversalTimestamp(ts_poison.0 + chrono::Duration::milliseconds(1));
+    dal.reactor_subscriptions()
+        .insert_firing(
+            &reactor,
+            &tenant,
+            Some(build_firing_payload(
+                "value",
+                serde_json::Value::Number(150.into()),
+            )),
+            ts_good,
+        )
+        .await
+        .expect("insert good firing");
+
+    scheduler
+        .poll_reactor_subscriptions_once()
+        .await
+        .expect("recovery tick");
+
+    let calls = executor.snapshot();
+    assert_eq!(
+        calls.len(),
+        1,
+        "the subscription must not be wedged — the next good firing dispatches, got: {:?}",
+        calls
+    );
+    assert_eq!(calls[0].0, workflow);
+
+    let sub = dal
+        .reactor_subscriptions()
+        .get_subscription(sub_id)
+        .await
+        .expect("get subscription")
+        .expect("row");
+    assert!(
+        sub.predicate_degraded.is_false(),
+        "a clean evaluation clears the degraded marker"
+    );
+    assert_eq!(sub.predicate_error_count, 0);
+    assert!(
+        sub.last_predicate_error.is_some(),
+        "recovery must NOT erase the record of the firing that was dropped"
+    );
+    assert!(
+        sub.last_seen_fired_at.expect("watermark").0 >= ts_good.0,
+        "watermark advances past the dispatched firing"
+    );
+
+    runner.shutdown().await.unwrap();
+}
+
+/// CLOACI-T-0922 item 4 — the subscribe-time unbound-variable lint is
+/// reachable through the real DAL entry point, not just as a pure
+/// function. `tenant` is bound; `tennant` is a typo that used to compile
+/// fine and then silently never fire.
+#[tokio::test]
+#[serial]
+async fn test_subscribe_rejects_predicate_with_unbound_variable() {
+    let fixture = get_or_init_fixture().await;
+    let mut fixture = fixture.lock().unwrap_or_else(|e| e.into_inner());
+    fixture.reset_database().await;
+    fixture.initialize().await;
+
+    let dal = fixture.get_dal();
+    let tenant = format!("tenant-{}", Uuid::new_v4());
+
+    dal.reactor_subscriptions()
+        .subscribe(
+            "rt_lint",
+            "wf_lint",
+            &tenant,
+            Some("payload.x > 1 && tenant == 'acme'"),
+        )
+        .await
+        .expect("a predicate over the bound variables must be accepted");
+
+    let err = dal
+        .reactor_subscriptions()
+        .subscribe(
+            "rt_lint_bad",
+            "wf_lint_bad",
+            &tenant,
+            Some("payload.x > 1 && tennant == 'acme'"),
+        )
+        .await
+        .expect_err("a predicate referencing an unbound variable must be rejected");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("tennant"),
+        "the rejection should name the offending variable, got: {}",
+        msg
+    );
+
+    // ...and the bad subscription must not have been written.
+    let subs = dal
+        .reactor_subscriptions()
+        .list_subscriptions(&tenant)
+        .await
+        .expect("list");
+    assert!(
+        subs.iter().all(|s| s.reactor_name != "rt_lint_bad"),
+        "a rejected predicate must never land in the DB"
+    );
 }

--- a/docs/content/embed/how-to/subscribe-workflow-to-reactor.md
+++ b/docs/content/embed/how-to/subscribe-workflow-to-reactor.md
@@ -91,7 +91,15 @@ CEL variables available to the predicate:
 - `reactor` — metadata about the firing reactor (name, etc.).
 - `tenant` — the tenant the firing is scoped to.
 
-CEL predicates are **compiled at subscribe time** — a malformed predicate errors at registration, not on every firing. Evaluation is **fail-closed** — if the CEL evaluation itself errors at firing time, the firing is skipped (logged with the error) rather than dispatched. See `examples/features/computation-graphs/filtered-reactor` for a runnable worked example.
+CEL predicates are **validated at subscribe time** — a malformed predicate, or one that references a variable outside the three above (a typo'd `tennant`, say), errors at registration rather than silently never matching on every firing.
+
+Evaluation is **fail-closed**: a predicate that errors at firing time never dispatches the workflow. It does not, however, discard the firing (CLOACI-T-0922):
+
+- The predicate returns `false` → the firing is skipped and the watermark advances. It was seen and consciously filtered out.
+- The predicate **errors** → the watermark is **held** and the firing is retried on the next poll tick. Each failure increments `cloacina_reactor_predicate_errors_total{reactor}` and logs at `warn` with the subscription id, firing id, and the expression.
+- After 5 consecutive failures on the same firing, that firing is **dead-lettered**: the subscription is marked degraded (`predicate_degraded`, with `last_predicate_error`, `last_predicate_error_at`, and `predicate_error_firing_id` recording what was dropped), `cloacina_reactor_predicate_dead_letters_total{reactor}` increments, and the watermark advances so one poison firing cannot wedge the subscription. The degraded marker clears on the next successful evaluation; the `last_predicate_error*` fields persist as history.
+
+Those fields are on the `reactor_trigger_subscriptions` row and are returned by `list_reactor_subscriptions`. See `examples/features/computation-graphs/filtered-reactor` for a runnable worked example.
 
 ### 3. Verify the subscription is registered
 

--- a/docs/content/engine/computation-graphs/how-to/filter-reactor-firings-with-cel.md
+++ b/docs/content/engine/computation-graphs/how-to/filter-reactor-firings-with-cel.md
@@ -9,7 +9,7 @@ aliases:
 
 # Filter reactor firings with CEL
 
-Reactors fire at the rate of their accumulators — every boundary, every source tick. For workflows subscribed to a reactor, that can mean far more workflow executions than the subscriber actually wants. CLOACI-T-0602 ships a **CEL predicate** on each `reactor_subscriptions` row: only firings where the predicate evaluates to `true` are dispatched to the workflow. Filtered-out firings advance the watermark and are not retried.
+Reactors fire at the rate of their accumulators — every boundary, every source tick. For workflows subscribed to a reactor, that can mean far more workflow executions than the subscriber actually wants. CLOACI-T-0602 ships a **CEL predicate** on each `reactor_subscriptions` row: only firings where the predicate evaluates to `true` are dispatched to the workflow. Firings the predicate rejects (`false`) advance the watermark and are not retried; firings whose predicate *errors* are held and retried — see [Fail-closed evaluation](#fail-closed-evaluation-but-no-silent-data-loss).
 
 This is the surgical alternative to "subscribe to the reactor, filter in the workflow's first task" — the filter runs in the dispatcher before any workflow row is inserted.
 
@@ -98,21 +98,36 @@ Check field presence + collection size before dispatching.
 
 ## Compile time vs evaluation time
 
-The predicate is **compiled once at subscribe time**. A malformed predicate (syntax error, reference to an undeclared identifier the compiler can see) errors at `subscribe_workflow_to_reactor` — you find out at registration, not on every firing. Predicate-parse errors surface as `Error::CelParse(...)`.
+The predicate is **compiled once at subscribe time**. A malformed predicate errors at `subscribe_workflow_to_reactor` — you find out at registration, not on every firing. So does a predicate that references a variable outside `payload`, `reactor`, and `tenant` (CLOACI-T-0922): `tennant == 'acme'` is valid CEL but nothing binds `tennant`, so it would compile fine and then never match. Comprehension iteration variables are of course fine — `payload.items.exists(i, i.price > 100)` binds `i` itself.
 
 The compiled predicate is **evaluated on every firing** during the subscription poll cycle. CEL evaluation is fast (microseconds for typical predicates), but it is not free — predicates that walk large nested payloads will add up across high-firing-rate reactors.
 
-## Fail-closed evaluation
+## Fail-closed evaluation, but no silent data loss
 
-If the predicate **panics or returns a non-bool result** at firing time (e.g., `payload.missing_field > 0` against a payload without `missing_field`), evaluation is treated as **`false`**, the firing is skipped, and the error is logged. The watermark advances. This is deliberate — a predicate bug should not block the subscription's progress.
+A predicate that **errors** at firing time (e.g., `payload.missing_field > 0` against a payload without `missing_field`, or an expression that returns a non-bool) never dispatches the workflow. Fail-closed is about dispatch only — the firing itself is **not** thrown away (CLOACI-T-0922 changed this; it used to be skipped *and* the watermark advanced, which destroyed the firing silently):
 
-If you need strict matching (any evaluation error should *halt* the subscription), the predicate itself must guard:
+| Outcome | Dispatch? | Watermark |
+|---|---|---|
+| `true` | yes | advances after dispatch |
+| `false` | no — filtered | advances (the firing was seen and rejected) |
+| error | no — fail-closed | **held**; the firing is retried next poll tick |
+
+Retries are bounded. After **5 consecutive errors on the same firing**, that firing is dead-lettered and the watermark advances, so a firing whose shape permanently breaks the predicate cannot wedge the subscription behind it.
+
+What you can observe:
+
+- `cloacina_reactor_predicate_errors_total{reactor}` — one increment per evaluation error.
+- `cloacina_reactor_predicate_dead_letters_total{reactor}` — one increment per firing dropped at the bound.
+- A `warn` log per error and an `error` log per dead-letter, each carrying the subscription id, firing id, and the (truncated) expression.
+- On the `reactor_trigger_subscriptions` row, also returned by `list_reactor_subscriptions`: `predicate_degraded`, `predicate_error_count`, `predicate_error_firing_id`, `last_predicate_error`, `last_predicate_error_at`. `predicate_degraded` clears on the next successful evaluation; the `last_predicate_error*` fields are kept as history.
+
+To avoid the error path altogether, guard the predicate so it always returns a bool:
 
 ```cel
 has(payload.value) && payload.value > 100
 ```
 
-`has()` returns a bool and never errors; the right-hand comparison only runs if the field exists.
+`has()` returns a bool and never errors; the right-hand comparison only runs if the field exists. A guarded predicate degrades to `false` (skip + advance) instead of erroring — which is what you want when a missing field genuinely means "not interesting", and what you do **not** want when it means "something upstream broke".
 
 ## Idempotency key recipe
 


### PR DESCRIPTION
## Summary

A predicate that **errored** took byte-for-byte the same path as one that returned **false**: skip dispatch *and* advance the watermark. Fail-closed correctly says "a broken filter must not fire workflows" — that got conflated with "move past the firing", so a predicate broken by payload-shape drift discarded firings permanently, with no metric, no dead-letter, and no health signal (CLOACI-T-0922, deep-dive register #5).

- `Ok(true)` dispatches; `Ok(false)` skips and advances (unchanged, regression-pinned).
- `Err` **holds the watermark** and returns, so the firing is head-of-line again next tick — ordering preserved, other subscriptions unaffected.
- After 5 attempts on the same firing: dead-letter counter, subscription marked degraded, force-advance so one poison firing can't wedge the subscription forever.
- The attempt counter is **persisted** (migration 048, ADD COLUMN only, both backends), so it survives restart. Because the watermark is held, "consecutive errors" and "attempts on this firing" are the same thing — which makes the subscription row the natural home. A clean evaluation clears the count and degraded flag but deliberately **never** clears `last_predicate_error*`: recovery must not erase the evidence.

**Observability, honestly scoped**: there's no HTTP API for reactor subscriptions, so an operator sees two new counters, the warn/error lines (subscription id, firing id, truncated expression), and the DB row via `list_reactor_subscriptions` — whose Python binding now also exposes the five new fields plus `predicate_expression`, neither of which it surfaced before.

**Subscribe-time lint shipped** (deferred from T-0915), at the DAL chokepoint. Note: `cel_interpreter`'s own `Program::references()` conflates comprehension iteration variables with free ones and would have false-rejected valid expressions like `payload.items.exists(i, i.price > 100)` — so the lint walks the `cel-parser` AST treating `iter_var`/`accu_var` as bound. Tests pin that comprehensions are accepted and that an iteration variable used *outside* its scope is still rejected.

**Adjacent pre-existing bug fixed**: `Program::compile` on a malformed expression **panics** (`unreachable!` inside antlr4rust) rather than returning `Err`, and T-0602's subscribe path called it bare — a typo'd predicate could unwind the subscriber task. New `compile_predicate()` catches it; both subscribe and the scheduler's compile cache use it now.

## Test plan
- 741 lib tests pass (10 new: lint accept/reject, comprehension scoping, the panic fix, truncation)
- 32 reactor integration tests against dev postgres: watermark-held-with-count-incrementing, dead-letter-at-the-bound, recovery-clears-degraded-but-retains-evidence, `Ok(false)` regression pin, lint rejection through the real DAL with the bad row never written
- Metric assertions via a `metrics-util` `DebuggingRecorder` (new dev-dep); new runtime dep `cel-parser`

## Notes
Migration numbered 048 to avoid colliding with T-0923's 046/047 (developed concurrently); together they form a contiguous sequence. Docs corrected — `filter-reactor-firings-with-cel.md` documented the old "error treated as false" behavior and was actively wrong.

## Residuals
`predicate_degraded` self-heals, so a permanent "data was dropped" alarm lives only in `last_predicate_error*` plus the monotonic counter; the bound isn't configurable; the counter is a two-statement RMW — exact for today's single poller, approximate (never unsafe) if a second ever races.