### PR TITLE
fix(T-0923): OIDC session refresh, login throttling, and a username-enumeration timing oracle

### DIFF
--- a/clients/typescript/generated/types.ts
+++ b/clients/typescript/generated/types.ts
@@ -2613,6 +2613,15 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorBody"];
                 };
             };
+            /** @description Too many failed attempts — throttled; see Retry-After */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorBody"];
+                };
+            };
             /** @description Internal error */
             500: {
                 headers: {
@@ -2680,7 +2689,7 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorBody"];
                 };
             };
-            /** @description Invalid key, or the login is no longer valid */
+            /** @description Invalid key, the account is disabled, or the login session has passed its absolute deadline */
             401: {
                 headers: {
                     [name: string]: unknown;

--- a/crates/cloacina-server/src/lib.rs
+++ b/crates/cloacina-server/src/lib.rs
@@ -265,6 +265,10 @@ pub struct AppState {
     pub oidc_policy: Arc<crate::oidc::MappingPolicy>,
     /// CLOACI-T-0790: short-lived in-flight OIDC login state (state/nonce/PKCE).
     pub oidc_login: Arc<crate::oidc::LoginFlowStore>,
+    /// CLOACI-T-0923: brute-force throttle settings for `/v1/auth/local/login`
+    /// (I-0118 OQ-13). Resolved once from the environment at startup; the
+    /// counters themselves live in the DB so a lockout holds across replicas.
+    pub login_throttle: crate::routes::local_auth::LoginThrottleConfig,
     /// CLOACI-T-0810: fleet actuator that reconciles each tenant's running agent
     /// count toward its `desired_count`. Selected by `CLOACINA_FLEET_ACTUATOR`
     /// and validated fail-closed at boot by the substrate guard. `NoopActuator`
@@ -473,6 +477,21 @@ pub async fn run(
     metrics::describe_counter!(
         "cloacina_api_requests_total",
         "Total API requests by HTTP method and response status code"
+    );
+    metrics::describe_counter!(
+        "cloacina_auth_login_attempts_total",
+        "Total local-login attempts (CLOACI-T-0923). `outcome` is bounded: \
+         `ok` (password verified, key minted), `denied` (unknown user, wrong \
+         password, or disabled account — deliberately indistinguishable), or \
+         `throttled` (refused before the password check because a throttle key \
+         was locked). A sustained `denied` rate is the credential-stuffing \
+         signal; `throttled` shows the defense engaging."
+    );
+    metrics::describe_counter!(
+        "cloacina_auth_login_lockouts_total",
+        "Total local-login lockouts, counted once on the lock edge rather than \
+         once per refused attempt (CLOACI-T-0923). `scope` is bounded to \
+         `username` | `ip`. Pairs with the `auth.login.lockout` audit event."
     );
     metrics::describe_histogram!(
         "cloacina_api_request_duration_seconds",
@@ -946,6 +965,10 @@ pub async fn run(
         oidc: oidc_provider,
         oidc_policy,
         oidc_login,
+        // CLOACI-T-0923: local-login brute-force throttle (I-0118 OQ-13).
+        // Read once here; the counters themselves are DB rows, so a lockout is
+        // enforced by every replica.
+        login_throttle: crate::routes::local_auth::LoginThrottleConfig::from_env(),
         fleet_actuator: fleet_actuator.clone(),
     };
 
@@ -2363,6 +2386,9 @@ mod tests {
             oidc_login: Arc::new(crate::oidc::LoginFlowStore::new(
                 std::time::Duration::from_secs(600),
             )),
+            // CLOACI-T-0923: production defaults. Tests that exercise lockout
+            // override this field with a fast-expiring policy.
+            login_throttle: crate::routes::local_auth::LoginThrottleConfig::default(),
             // CLOACI-T-0810: tests don't actuate — a Noop actuator keeps handlers
             // that read `fleet_actuator` constructible without a Docker daemon.
             fleet_actuator: Arc::new(crate::actuator::NoopActuator),
@@ -5576,6 +5602,486 @@ mod tests {
             after,
             Some(7),
             "leadership must be re-acquirable once the lock is released"
+        );
+    }
+
+    // ── Auth lifecycle: OIDC refresh + login throttle (CLOACI-T-0923) ──────
+
+    use crate::identity::{mint_for_principal, ResolvedPrincipal};
+    use crate::routes::local_auth::LoginThrottleConfig;
+    use cloacina::dal::unified::login_throttle::ThrottlePolicy;
+
+    const TEST_ISSUER: &str = "https://idp.test/realms/cloacina";
+
+    /// Mint a key the way an OIDC callback does, and open its login session.
+    /// Returns `(plaintext_key, key_id)`.
+    async fn mint_oidc_session(
+        state: &AppState,
+        tenant: Option<&str>,
+        role: &str,
+        key_ttl: std::time::Duration,
+        session_deadline: chrono::DateTime<chrono::Utc>,
+    ) -> (String, uuid::Uuid) {
+        let principal = ResolvedPrincipal {
+            tenant: tenant.map(str::to_string),
+            role: role.to_string(),
+            provenance: format!("oidc:{TEST_ISSUER}:sub-{}", uuid::Uuid::new_v4()),
+        };
+        let (plaintext, info) = mint_for_principal(state, &principal, key_ttl)
+            .await
+            .expect("mint minted-login key");
+        cloacina::dal::DAL::new(state.database.clone())
+            .oidc_sessions()
+            .create_session(info.id, TEST_ISSUER, session_deadline)
+            .await
+            .expect("open oidc session");
+        (plaintext, info.id)
+    }
+
+    fn refresh_request(token: &str) -> axum::http::Request<Body> {
+        axum::http::Request::builder()
+            .method("POST")
+            .uri("/v1/auth/refresh")
+            .header("Authorization", format!("Bearer {token}"))
+            .body(Body::empty())
+            .unwrap()
+    }
+
+    /// UC2 happy path: an OIDC login refreshes without another trip through the
+    /// IdP, keeps EXACTLY its tenant + role, never gains god mode, and the old
+    /// key is rotated out.
+    #[tokio::test]
+    #[serial]
+    async fn oidc_refresh_preserves_scope_and_rotates_the_old_key() {
+        let state = test_state().await;
+        let (token, old_key_id) = mint_oidc_session(
+            &state,
+            Some("public"),
+            "write",
+            std::time::Duration::from_secs(900),
+            chrono::Utc::now() + chrono::Duration::hours(8),
+        )
+        .await;
+
+        let (status, body) =
+            send_request(build_router(state.clone()), refresh_request(&token)).await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "OIDC refresh must no longer be 501: {body}"
+        );
+
+        // Scope is preserved verbatim — refresh is not a re-authorization.
+        assert_eq!(body["tenant_id"], "public");
+        assert_eq!(body["role"], "write");
+        let new_token = body["key"]
+            .as_str()
+            .expect("refresh returns a key")
+            .to_string();
+        assert_ne!(new_token, token, "refresh must issue a NEW key");
+
+        // The new key is real, still scoped, and is NOT admin. `whoami` reads
+        // straight off the authenticated key, so this asserts the persisted
+        // grant rather than the response body echoing itself.
+        let (status, who) = send_request(
+            build_router(state.clone()),
+            axum::http::Request::builder()
+                .uri("/v1/auth/whoami")
+                .header("Authorization", format!("Bearer {new_token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "refreshed key must authenticate");
+        assert_eq!(who["tenant_id"], "public");
+        assert_eq!(who["role"], "write");
+        assert_eq!(
+            who["is_admin"], false,
+            "a refreshed key must never acquire god mode"
+        );
+
+        // The old key is revoked, so a stolen pre-refresh key is dead.
+        state.key_cache.clear().await;
+        let (status, _) = send_request(build_router(state.clone()), refresh_request(&token)).await;
+        assert_eq!(
+            status,
+            StatusCode::UNAUTHORIZED,
+            "the pre-refresh key must be revoked"
+        );
+
+        // ...and the session row followed the new key rather than being orphaned.
+        let dal = cloacina::dal::DAL::new(state.database.clone());
+        assert!(
+            dal.oidc_sessions()
+                .get_session(old_key_id)
+                .await
+                .expect("session lookup")
+                .is_none(),
+            "the session must not still point at the rotated-out key"
+        );
+    }
+
+    /// Refresh can extend the key but never the session: past the absolute
+    /// deadline the user is pushed back through the full OIDC flow, and the
+    /// key they were holding is revoked rather than left alive for its TTL.
+    #[tokio::test]
+    #[serial]
+    async fn oidc_refresh_stops_at_the_absolute_session_deadline() {
+        let state = test_state().await;
+        let (token, _) = mint_oidc_session(
+            &state,
+            Some("public"),
+            "read",
+            std::time::Duration::from_secs(900),
+            chrono::Utc::now() - chrono::Duration::minutes(1),
+        )
+        .await;
+
+        let (status, _) = send_request(build_router(state.clone()), refresh_request(&token)).await;
+        assert_eq!(
+            status,
+            StatusCode::UNAUTHORIZED,
+            "a session past its deadline must not refresh"
+        );
+
+        state.key_cache.clear().await;
+        let (status, _) = send_request(
+            build_router(state.clone()),
+            axum::http::Request::builder()
+                .uri("/v1/auth/whoami")
+                .header("Authorization", format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+        assert_eq!(
+            status,
+            StatusCode::UNAUTHORIZED,
+            "the key must be revoked when its session ends, not left to lapse"
+        );
+    }
+
+    /// A key whose 15-minute TTL already lapsed cannot refresh: `require_auth`
+    /// rejects it before the handler runs. Sane, and the documented reason the
+    /// SPA must refresh on a timer rather than on demand after idling.
+    #[tokio::test]
+    #[serial]
+    async fn refresh_after_the_key_expired_is_rejected_not_resurrected() {
+        let state = test_state().await;
+        // TTL of zero → `expires_at == now`, which `validate_hash` treats as
+        // expired (it requires `expires_at > now`).
+        let (token, _) = mint_oidc_session(
+            &state,
+            Some("public"),
+            "read",
+            std::time::Duration::from_secs(0),
+            chrono::Utc::now() + chrono::Duration::hours(8),
+        )
+        .await;
+
+        let (status, _) = send_request(build_router(state.clone()), refresh_request(&token)).await;
+        assert_eq!(
+            status,
+            StatusCode::UNAUTHORIZED,
+            "an expired key must not be refreshable even inside a live session"
+        );
+    }
+
+    /// A minted key with no session row (never opened, or logged out) is not
+    /// refreshable — logout must be final.
+    #[tokio::test]
+    #[serial]
+    async fn oidc_refresh_denied_without_a_session_row() {
+        let state = test_state().await;
+        let principal = ResolvedPrincipal {
+            tenant: Some("public".into()),
+            role: "read".into(),
+            provenance: format!("oidc:{TEST_ISSUER}:sub-{}", uuid::Uuid::new_v4()),
+        };
+        let (token, _) =
+            mint_for_principal(&state, &principal, std::time::Duration::from_secs(900))
+                .await
+                .expect("mint");
+
+        let (status, _) = send_request(build_router(state.clone()), refresh_request(&token)).await;
+        assert_eq!(
+            status,
+            StatusCode::UNAUTHORIZED,
+            "no session row ⇒ no refresh"
+        );
+    }
+
+    // ── Login throttle (I-0118 OQ-13) ─────────────────────────────────────
+
+    /// A state whose throttle locks fast and forgets fast, with the IP scope
+    /// off (every test request shares one `unknown` peer, so an IP counter
+    /// would leak between tests).
+    fn with_fast_throttle(state: &mut AppState, threshold: i32, lock: chrono::Duration) {
+        state.login_throttle = LoginThrottleConfig {
+            username: ThrottlePolicy {
+                threshold,
+                base_lock: lock,
+                max_lock: lock,
+                decay: chrono::Duration::minutes(15),
+            },
+            ip: None,
+            trust_proxy_headers: false,
+        };
+    }
+
+    /// Create a local account with a unique username (the test DB persists
+    /// across runs). Returns the username.
+    async fn create_local_account(state: &AppState, password: &str) -> String {
+        let username = format!("t0923-{}", uuid::Uuid::new_v4().simple());
+        cloacina::dal::DAL::new(state.database.clone())
+            .local_accounts()
+            .create(&username, password, Some("public"), "read")
+            .await
+            .expect("create local account");
+        username
+    }
+
+    fn login_request(username: &str, password: &str) -> axum::http::Request<Body> {
+        axum::http::Request::builder()
+            .method("POST")
+            .uri("/v1/auth/local/login")
+            .header("Content-Type", "application/json")
+            .body(Body::from(
+                serde_json::json!({
+                    "username": username,
+                    "password": password,
+                    "tenant": "public",
+                })
+                .to_string(),
+            ))
+            .unwrap()
+    }
+
+    /// The core OQ-13 contract: repeated failures lock the account's *login*,
+    /// the lock refuses even the CORRECT password while it holds, and it
+    /// expires on its own without operator intervention.
+    #[tokio::test]
+    #[serial]
+    async fn login_lockout_triggers_blocks_the_right_password_then_expires() {
+        let mut state = test_state().await;
+        with_fast_throttle(&mut state, 3, chrono::Duration::milliseconds(600));
+        let password = "correct-horse-battery-staple";
+        let username = create_local_account(&state, password).await;
+
+        // Up to the threshold: ordinary 401s.
+        for i in 0..3 {
+            let (status, _) = send_request(
+                build_router(state.clone()),
+                login_request(&username, "wrong"),
+            )
+            .await;
+            assert_eq!(
+                status,
+                StatusCode::UNAUTHORIZED,
+                "attempt {i} should be 401"
+            );
+        }
+
+        // The crossing attempt locks the key.
+        let response = build_router(state.clone())
+            .oneshot(login_request(&username, "wrong"))
+            .await
+            .expect("request");
+        assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert!(
+            response
+                .headers()
+                .contains_key(axum::http::header::RETRY_AFTER),
+            "a throttled response must tell the client when to come back"
+        );
+
+        // The whole point: while locked, even the right password is refused.
+        // Without this the lock would only slow an attacker down, not stop one
+        // who guesses correctly on the next try.
+        let (status, _) = send_request(
+            build_router(state.clone()),
+            login_request(&username, password),
+        )
+        .await;
+        assert_eq!(
+            status,
+            StatusCode::TOO_MANY_REQUESTS,
+            "a live lock must gate the password check, not follow it"
+        );
+
+        // ...and it lifts by itself.
+        tokio::time::sleep(std::time::Duration::from_millis(900)).await;
+        let (status, body) = send_request(
+            build_router(state.clone()),
+            login_request(&username, password),
+        )
+        .await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "the lock must expire without an admin unlocking anything: {body}"
+        );
+    }
+
+    /// A legitimate user who eventually remembers their password must not be
+    /// left one strike from a lockout.
+    #[tokio::test]
+    #[serial]
+    async fn successful_login_clears_the_failure_counter() {
+        let mut state = test_state().await;
+        with_fast_throttle(&mut state, 3, chrono::Duration::seconds(60));
+        let password = "right-password-eventually";
+        let username = create_local_account(&state, password).await;
+
+        for _ in 0..3 {
+            send_request(
+                build_router(state.clone()),
+                login_request(&username, "nope"),
+            )
+            .await;
+        }
+        let (status, _) = send_request(
+            build_router(state.clone()),
+            login_request(&username, password),
+        )
+        .await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "3 failures is at, not over, the threshold"
+        );
+
+        // If the counter had carried over, the very next failure would lock.
+        for i in 0..3 {
+            let (status, _) = send_request(
+                build_router(state.clone()),
+                login_request(&username, "nope"),
+            )
+            .await;
+            assert_eq!(
+                status,
+                StatusCode::UNAUTHORIZED,
+                "post-success failure {i} must be counted from zero"
+            );
+        }
+    }
+
+    /// Multi-replica correctness (the T-0916 lesson): two independently built
+    /// server states over the same database must share throttle state — a
+    /// lockout earned on one is enforced by the other, and clearing it on one
+    /// releases the other.
+    #[tokio::test]
+    #[serial]
+    async fn throttle_state_is_shared_across_two_server_handles() {
+        let mut state_a = test_state().await;
+        with_fast_throttle(&mut state_a, 3, chrono::Duration::seconds(60));
+        let mut state_b = test_state().await;
+        with_fast_throttle(&mut state_b, 3, chrono::Duration::seconds(60));
+
+        let password = "shared-state-password";
+        let username = create_local_account(&state_a, password).await;
+
+        // Replica A absorbs two failures, replica B the next two.
+        for _ in 0..2 {
+            send_request(build_router(state_a.clone()), login_request(&username, "x")).await;
+        }
+        let (status, _) =
+            send_request(build_router(state_b.clone()), login_request(&username, "x")).await;
+        assert_eq!(
+            status,
+            StatusCode::UNAUTHORIZED,
+            "B must continue A's count, not start its own"
+        );
+        let (status, _) =
+            send_request(build_router(state_b.clone()), login_request(&username, "x")).await;
+        assert_eq!(status, StatusCode::TOO_MANY_REQUESTS, "4th failure locks");
+
+        // The lock decided on B is enforced on A — the whole reason this state
+        // is a DB row and not a per-replica map.
+        let (status, _) = send_request(
+            build_router(state_a.clone()),
+            login_request(&username, password),
+        )
+        .await;
+        assert_eq!(
+            status,
+            StatusCode::TOO_MANY_REQUESTS,
+            "a lockout must not be escapable by hitting a different replica"
+        );
+    }
+
+    /// An unknown username throttles exactly like a real one, so the 429 is not
+    /// a user-enumeration oracle.
+    #[tokio::test]
+    #[serial]
+    async fn unknown_usernames_throttle_identically_to_real_ones() {
+        let mut state = test_state().await;
+        with_fast_throttle(&mut state, 2, chrono::Duration::seconds(60));
+        let ghost = format!("t0923-ghost-{}", uuid::Uuid::new_v4().simple());
+
+        for _ in 0..2 {
+            let (status, _) =
+                send_request(build_router(state.clone()), login_request(&ghost, "x")).await;
+            assert_eq!(status, StatusCode::UNAUTHORIZED);
+        }
+        let (status, _) =
+            send_request(build_router(state.clone()), login_request(&ghost, "x")).await;
+        assert_eq!(
+            status,
+            StatusCode::TOO_MANY_REQUESTS,
+            "a nonexistent account must reach the same 429 a real one does"
+        );
+    }
+
+    /// The source-IP scope catches a single host spraying many DIFFERENT
+    /// usernames — none of which alone crosses the username threshold.
+    #[tokio::test]
+    #[serial]
+    async fn ip_scope_catches_a_username_spray() {
+        let mut state = test_state().await;
+        // Trust XFF so the test can present a distinct client address; without
+        // it every test request shares one peer and the counters would bleed.
+        state.login_throttle = LoginThrottleConfig {
+            username: ThrottlePolicy {
+                threshold: 100,
+                base_lock: chrono::Duration::seconds(60),
+                max_lock: chrono::Duration::seconds(60),
+                decay: chrono::Duration::minutes(15),
+            },
+            ip: Some(ThrottlePolicy {
+                threshold: 3,
+                base_lock: chrono::Duration::seconds(60),
+                max_lock: chrono::Duration::seconds(60),
+                decay: chrono::Duration::minutes(15),
+            }),
+            trust_proxy_headers: true,
+        };
+        let attacker_ip = format!("198.51.100.{}", (uuid::Uuid::new_v4().as_u128() % 250) + 1);
+
+        let spray = |user: String| {
+            let mut req = login_request(&user, "x");
+            req.headers_mut().insert(
+                "x-forwarded-for",
+                axum::http::HeaderValue::from_str(&attacker_ip).unwrap(),
+            );
+            req
+        };
+
+        for _ in 0..3 {
+            let user = format!("t0923-spray-{}", uuid::Uuid::new_v4().simple());
+            let (status, _) = send_request(build_router(state.clone()), spray(user)).await;
+            assert_eq!(
+                status,
+                StatusCode::UNAUTHORIZED,
+                "no single username is anywhere near its own threshold"
+            );
+        }
+        let user = format!("t0923-spray-{}", uuid::Uuid::new_v4().simple());
+        let (status, _) = send_request(build_router(state.clone()), spray(user)).await;
+        assert_eq!(
+            status,
+            StatusCode::TOO_MANY_REQUESTS,
+            "the source-IP counter must catch what the username counter cannot"
         );
     }
 }

--- a/crates/cloacina-server/src/routes/local_auth.rs
+++ b/crates/cloacina-server/src/routes/local_auth.rs
@@ -25,23 +25,166 @@
 //! No refresh-token row is stored for local accounts: the key's `local:<id>`
 //! provenance + the account's `status` column ARE the refresh validity, which
 //! `/auth/refresh` (T-0794) re-checks.
+//!
+//! ## Brute-force throttle (CLOACI-T-0923, closes I-0118 OQ-13)
+//!
+//! Argon2id makes each guess expensive for the *server*; it does nothing to
+//! bound how many guesses an attacker gets. Every attempt is therefore gated on
+//! (and every failure recorded against) the DB-backed
+//! [`cloacina::dal::unified::login_throttle`] counters — persisted, not a
+//! per-replica map, so a lockout holds across replicas. See that module for the
+//! dual-key (username + source-IP) rationale.
+
+use std::net::SocketAddr;
 
 use axum::{
-    extract::{Path, State},
-    http::StatusCode,
-    response::IntoResponse,
+    extract::{ConnectInfo, Path, State},
+    http::{header, Extensions, HeaderMap, HeaderValue, StatusCode},
+    response::{IntoResponse, Response},
     Json,
 };
 use serde::{Deserialize, Serialize};
 use tracing::{info, warn};
 use utoipa::ToSchema;
 
+use cloacina::dal::unified::login_throttle::{
+    ip_key, username_key, ThrottlePolicy, SCOPE_IP, SCOPE_USERNAME,
+};
 use cloacina::dal::unified::{LocalAccount, LoginOutcome};
+use cloacina::security::audit;
 use cloacina_api_types::common::ListResponse;
 
 use crate::identity::{mint_for_principal, ResolvedPrincipal, DEFAULT_MINTED_KEY_TTL};
 use crate::routes::error::ApiError;
 use crate::AppState;
+
+/// Operator-tunable brute-force throttle settings, resolved once at startup and
+/// carried on [`AppState`] (CLOACI-T-0923).
+#[derive(Debug, Clone, Copy)]
+pub struct LoginThrottleConfig {
+    /// Username-scoped policy — the primary defense.
+    pub username: ThrottlePolicy,
+    /// Source-IP-scoped policy, or `None` when the IP scope is disabled.
+    pub ip: Option<ThrottlePolicy>,
+    /// Whether `X-Forwarded-For` may be believed when deriving the client IP.
+    pub trust_proxy_headers: bool,
+}
+
+impl Default for LoginThrottleConfig {
+    fn default() -> Self {
+        Self {
+            username: ThrottlePolicy::username_default(),
+            ip: Some(ThrottlePolicy::ip_default()),
+            trust_proxy_headers: false,
+        }
+    }
+}
+
+impl LoginThrottleConfig {
+    /// Read the throttle knobs from the environment.
+    ///
+    /// - `CLOACINA_LOGIN_THROTTLE_USER_THRESHOLD` (default 5) — consecutive
+    ///   failures per username before it locks.
+    /// - `CLOACINA_LOGIN_THROTTLE_IP_THRESHOLD` (default 50; **`0` disables the
+    ///   IP scope**) — consecutive failures from one source address.
+    /// - `CLOACINA_LOGIN_THROTTLE_BASE_LOCK_S` (default 30) — first lock
+    ///   window; each further failure doubles it.
+    /// - `CLOACINA_LOGIN_THROTTLE_MAX_LOCK_S` (default 900) — backoff ceiling,
+    ///   and also the idle window after which a counter is forgotten.
+    /// - `CLOACINA_TRUST_PROXY_HEADERS` (default off) — see [`client_ip`].
+    ///
+    /// **Deploying behind a reverse proxy:** the socket peer is then the proxy
+    /// for *every* user, so one shared IP counter would cover the whole
+    /// deployment. Either set `CLOACINA_TRUST_PROXY_HEADERS=1` (only safe when
+    /// the proxy overwrites `X-Forwarded-For`) so real client addresses are
+    /// used, or set `CLOACINA_LOGIN_THROTTLE_IP_THRESHOLD=0` to turn the IP
+    /// scope off and rely on the username scope alone.
+    pub fn from_env() -> Self {
+        fn num(var: &str, default: i64) -> i64 {
+            std::env::var(var)
+                .ok()
+                .and_then(|v| v.trim().parse::<i64>().ok())
+                .filter(|v| *v >= 0)
+                .unwrap_or(default)
+        }
+        let base_lock = chrono::Duration::seconds(num("CLOACINA_LOGIN_THROTTLE_BASE_LOCK_S", 30));
+        let max_lock = chrono::Duration::seconds(num("CLOACINA_LOGIN_THROTTLE_MAX_LOCK_S", 900));
+        let decay = max_lock;
+
+        let user_threshold = num("CLOACINA_LOGIN_THROTTLE_USER_THRESHOLD", 5).max(1) as i32;
+        let ip_threshold = num("CLOACINA_LOGIN_THROTTLE_IP_THRESHOLD", 50) as i32;
+
+        Self {
+            username: ThrottlePolicy {
+                threshold: user_threshold,
+                base_lock,
+                max_lock,
+                decay,
+            },
+            // The IP scope is a blunt instrument: cap its backoff at the
+            // ceiling immediately rather than doubling, so a shared-NAT office
+            // never compounds its way into an hours-long block.
+            ip: (ip_threshold > 0).then_some(ThrottlePolicy {
+                threshold: ip_threshold,
+                base_lock: max_lock,
+                max_lock,
+                decay,
+            }),
+            trust_proxy_headers: matches!(
+                std::env::var("CLOACINA_TRUST_PROXY_HEADERS")
+                    .unwrap_or_default()
+                    .trim(),
+                "1" | "true" | "TRUE" | "yes"
+            ),
+        }
+    }
+}
+
+/// Derive the client address used for the IP-scoped counter.
+///
+/// Defaults to the **socket peer**, which cannot be forged. `X-Forwarded-For`
+/// is consulted only when the operator opts in, because an unauthenticated
+/// caller controls that header outright: believing it by default would let an
+/// attacker mint a fresh IP identity per request (evading the counter entirely)
+/// *and* forge failures against someone else's address. When trusted, the
+/// left-most entry is taken — the original client as recorded by the first
+/// proxy — which is only meaningful if that proxy overwrites rather than
+/// appends.
+fn client_ip(headers: &HeaderMap, peer: Option<SocketAddr>, trust_proxy: bool) -> String {
+    if trust_proxy {
+        if let Some(first) = headers
+            .get("x-forwarded-for")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.split(',').next())
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+        {
+            return first.to_string();
+        }
+    }
+    peer.map(|p| p.ip().to_string())
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+/// 429 for a throttled attempt, carrying `Retry-After`.
+///
+/// Deliberately the *same* response whether or not the username exists: an
+/// unknown username accumulates failures exactly like a real one, so this
+/// status is never an enumeration oracle. It is a distinct status from the
+/// 401 so a legitimate locked-out human (and the SPA) can tell "wrong password"
+/// from "wait and try again".
+fn throttled_response(retry_after_secs: i64) -> Response {
+    let mut resp = ApiError::new(
+        StatusCode::TOO_MANY_REQUESTS,
+        "login_throttled",
+        "too many failed login attempts — try again later",
+    )
+    .into_response();
+    if let Ok(v) = HeaderValue::from_str(&retry_after_secs.max(1).to_string()) {
+        resp.headers_mut().insert(header::RETRY_AFTER, v);
+    }
+    resp
+}
 
 /// A local-login attempt. `tenant` selects which tenant's account namespace to
 /// authenticate against (`None` = a global account).
@@ -72,14 +215,54 @@ pub struct LocalLoginResponse {
     responses(
         (status = 200, description = "Logged in — minted key returned once", body = LocalLoginResponse),
         (status = 401, description = "Invalid username or password", body = cloacina_api_types::ErrorBody),
+        (status = 429, description = "Too many failed attempts — throttled; see Retry-After", body = cloacina_api_types::ErrorBody),
         (status = 500, description = "Internal error", body = cloacina_api_types::ErrorBody),
     )
 )]
 pub async fn local_login(
     State(state): State<AppState>,
+    // `ConnectInfo` is read out of the extensions rather than extracted
+    // directly: axum 0.8 has no optional impl for it, and this route must not
+    // 500 when the router is driven without connect-info (tests, `oneshot`).
+    // Absent peer just means the IP scope degrades to a single `unknown` key.
+    extensions: Extensions,
+    headers: HeaderMap,
     Json(body): Json<LocalLoginRequest>,
 ) -> impl IntoResponse {
     let dal = cloacina::dal::DAL::new(state.database.clone());
+    let cfg = state.login_throttle;
+
+    let peer = extensions
+        .get::<ConnectInfo<SocketAddr>>()
+        .map(|ConnectInfo(a)| *a);
+    let user_key = username_key(body.tenant.as_deref(), &body.username);
+    let source_ip = client_ip(&headers, peer, cfg.trust_proxy_headers);
+    let source_key = ip_key(&source_ip);
+
+    // ---- gate: refuse locked keys BEFORE paying for an argon2 verify --------
+    // Both scopes are checked; either one locked refuses the attempt.
+    let mut scopes: Vec<(&str, &str, ThrottlePolicy)> =
+        vec![(user_key.as_str(), SCOPE_USERNAME, cfg.username)];
+    if let Some(p) = cfg.ip {
+        scopes.push((source_key.as_str(), SCOPE_IP, p));
+    }
+    for (key, scope, _) in &scopes {
+        match dal.login_throttle().locked_until(key).await {
+            Ok(Some(until)) => {
+                let secs = (until - chrono::Utc::now()).num_seconds();
+                metrics::counter!("cloacina_auth_login_attempts_total", "outcome" => "throttled")
+                    .increment(1);
+                warn!(scope = %scope, retry_after_s = secs, "local login refused — throttled");
+                return throttled_response(secs);
+            }
+            Ok(None) => {}
+            // Fail OPEN on a throttle-store error, deliberately: the throttle
+            // is a mitigation, not the authentication decision, and a DB blip
+            // must not lock every user out of the platform. The failure is
+            // logged, and the password check below still has to pass.
+            Err(e) => warn!("login throttle lookup failed (allowing attempt): {}", e),
+        }
+    }
 
     let outcome = match dal
         .local_accounts()
@@ -96,11 +279,63 @@ pub async fn local_login(
     let account = match outcome {
         LoginOutcome::Ok(a) => a,
         // Same opaque error for unknown user / wrong password / disabled — no
-        // enumeration (OQ-13 throttling is a follow-up).
+        // enumeration. `authenticate` also burns an equivalent argon2 verify
+        // for an unknown username so the two are indistinguishable by timing.
         LoginOutcome::Denied => {
-            return ApiError::unauthorized("invalid username or password").into_response()
+            // Record against BOTH scopes. Note this counts failures for
+            // usernames that do not exist exactly like real ones — that is
+            // what keeps the eventual 429 from leaking account existence.
+            let now = chrono::Utc::now();
+            let mut lock_expiry: Option<i64> = None;
+            for (key, scope, policy) in &scopes {
+                match dal
+                    .login_throttle()
+                    .record_failure(key, scope, *policy)
+                    .await
+                {
+                    Ok(st) => {
+                        if let Some(until) = st.locked_until.filter(|t| *t > now) {
+                            let secs = (until - now).num_seconds();
+                            // Report the longest live lock, so `Retry-After` is
+                            // never optimistic about when the caller may return.
+                            lock_expiry = Some(lock_expiry.map_or(secs, |c: i64| c.max(secs)));
+                            // Audit + count the lock EDGE only: while a lock
+                            // holds, every further attempt would otherwise
+                            // re-emit the same incident.
+                            if st.newly_locked {
+                                audit::log_login_lockout(key, scope, st.failure_count, secs);
+                                metrics::counter!("cloacina_auth_login_lockouts_total", "scope" => (*scope).to_string())
+                                    .increment(1);
+                            }
+                        }
+                    }
+                    Err(e) => warn!("login throttle record failed: {}", e),
+                }
+            }
+            // The attempt that crosses the threshold is answered with the 429,
+            // not a 401 that would leave the caller unaware they are now
+            // locked. This is not an enumeration leak: an unknown username
+            // reaches the identical 429 on the identical attempt number.
+            if let Some(secs) = lock_expiry {
+                metrics::counter!("cloacina_auth_login_attempts_total", "outcome" => "throttled")
+                    .increment(1);
+                return throttled_response(secs);
+            }
+            metrics::counter!("cloacina_auth_login_attempts_total", "outcome" => "denied")
+                .increment(1);
+            return ApiError::unauthorized("invalid username or password").into_response();
         }
     };
+
+    // ---- success: the legitimate user must not inherit their own failures ---
+    // Only the username counter is cleared. The IP counter is left to decay:
+    // clearing it on success would let an attacker who holds one valid account
+    // reset the spray counter at will (see the DAL module docs).
+    if let Err(e) = dal.login_throttle().clear(&user_key).await {
+        warn!("login throttle clear failed: {}", e);
+    }
+    // Opportunistic hygiene — keeps the table bounded without a sweeper task.
+    let _ = dal.login_throttle().prune_idle(cfg.username.decay).await;
 
     let principal = ResolvedPrincipal {
         tenant: account.tenant_id.clone(),
@@ -110,6 +345,7 @@ pub async fn local_login(
 
     match mint_for_principal(&state, &principal, DEFAULT_MINTED_KEY_TTL).await {
         Ok((plaintext, info)) => {
+            metrics::counter!("cloacina_auth_login_attempts_total", "outcome" => "ok").increment(1);
             info!(
                 account_id = %account.id,
                 tenant = ?account.tenant_id,

--- a/crates/cloacina-server/src/routes/oidc_auth.rs
+++ b/crates/cloacina-server/src/routes/oidc_auth.rs
@@ -35,6 +35,7 @@ use base64::Engine as _;
 
 use crate::identity::{mint_for_principal, DEFAULT_MINTED_KEY_TTL};
 use crate::routes::error::ApiError;
+use crate::routes::session::oidc_session_max_age;
 use crate::AppState;
 
 /// One minted tenant membership handed back to the SPA after an OIDC login.
@@ -124,14 +125,39 @@ pub async fn oidc_callback(
         .into_response();
     }
 
+    // CLOACI-T-0923: open a server-side login session per minted key. Its
+    // `expires_at` is the session's ABSOLUTE deadline — `/v1/auth/refresh`
+    // rotates the key inside that window without another trip through the IdP,
+    // and past it a full re-auth (fresh IdP check + fresh allowlist
+    // resolution) is forced. Without this row refresh has nothing to
+    // authorize against and stays a 501, which is exactly the state T-0923
+    // found: a 15-minute hard logout.
+    let dal = cloacina::dal::DAL::new(state.database.clone());
+    let session_deadline = chrono::Utc::now()
+        + chrono::Duration::from_std(oidc_session_max_age())
+            .unwrap_or_else(|_| chrono::Duration::hours(8));
+
     let mut memberships = Vec::with_capacity(principals.len());
     for p in &principals {
         match mint_for_principal(&state, p, DEFAULT_MINTED_KEY_TTL).await {
-            Ok((plaintext, info)) => memberships.push(Membership {
-                key: plaintext,
-                tenant: info.tenant_id.unwrap_or_default(),
-                role: info.permissions,
-            }),
+            Ok((plaintext, info)) => {
+                if let Err(e) = dal
+                    .oidc_sessions()
+                    .create_session(info.id, &provider.config.issuer_url, session_deadline)
+                    .await
+                {
+                    // Fail closed on the *session*, not the login: the key is
+                    // already minted and usable for its 15 minutes; the user
+                    // simply cannot refresh it. Better a short session than a
+                    // failed sign-in.
+                    warn!("oidc session persist failed (login not refreshable): {e}");
+                }
+                memberships.push(Membership {
+                    key: plaintext,
+                    tenant: info.tenant_id.unwrap_or_default(),
+                    role: info.permissions,
+                })
+            }
             Err(e) => return e.into_response(),
         }
     }

--- a/crates/cloacina-server/src/routes/session.rs
+++ b/crates/cloacina-server/src/routes/session.rs
@@ -23,8 +23,45 @@
 //! Provider dispatch keys off the minted key's `issued_via` provenance:
 //! - `local:<account_id>` — refresh = re-check the account is still `active`
 //!   (no external call; the local-accounts strand, T-0795/0796).
-//! - `oidc:<issuer>:<sub>` — refresh = exchange the stored IdP refresh token;
-//!   lands with the OIDC phase (T-0790). Returns 501 until then.
+//! - `oidc:<issuer>:<sub>` — refresh = re-mint inside the server-side login
+//!   session opened by the callback (CLOACI-T-0923; was a 501 before that).
+//!
+//! # Why a session record and not the IdP's refresh token (CLOACI-T-0923)
+//!
+//! T-0793 built an encrypted store for the IdP refresh token, and the obvious
+//! implementation of refresh is to spend that token at the IdP's token endpoint
+//! and re-derive everything from the fresh ID token. We deliberately did not:
+//!
+//! * **It needs the IdP to cooperate.** Refresh tokens require `offline_access`
+//!   (or an issuer-specific equivalent) and are not universally issued; the
+//!   token endpoint is only *recommended* to return a new `id_token` on the
+//!   refresh grant. A design that silently degrades to "no refresh" on half of
+//!   the IdPs it meets does not close UC2.
+//! * **It puts the IdP on the hot path.** Every session in the deployment
+//!   re-contacts the issuer at least every 15 minutes; an IdP outage becomes a
+//!   platform-wide forced logout.
+//! * **It buys custody of a long-lived credential** — precisely the thing the
+//!   short-TTL minted-key design exists to avoid — plus refresh-token rotation
+//!   bookkeeping. That is full token-lifecycle management, not "stay signed in".
+//!
+//! Instead the callback opens an `oidc_sessions` row whose `expires_at` is the
+//! session's **absolute** deadline. Refresh re-mints a fresh 15-minute key
+//! inside that window, rotates the session onto it, and revokes the old key.
+//! The one thing we give up — noticing that the IdP deactivated the user
+//! mid-session — is bounded by that deadline
+//! (`CLOACINA_OIDC_SESSION_MAX_AGE_S`, default 8h), after which a full re-auth
+//! re-checks the IdP *and* re-resolves the current allowlist. That is a
+//! deliberate, documented, tunable trade rather than an unbounded one.
+//!
+//! # Scope preservation (both providers)
+//!
+//! The re-mint reads `tenant_id` + `permissions` from the **persisted key row**,
+//! which is the durable record of the original allowlist resolution — not from
+//! anything the caller sends. [`mint_for_principal`] has no `is_admin`
+//! parameter at all, so a refreshed key is structurally incapable of gaining
+//! god mode however the request is shaped.
+
+use std::time::Duration;
 
 use axum::{extract::State, http::StatusCode, response::IntoResponse, Extension, Json};
 use serde::Serialize;
@@ -36,6 +73,25 @@ use crate::routes::auth::AuthenticatedKey;
 use crate::routes::error::ApiError;
 use crate::routes::local_auth::LocalLoginResponse;
 use crate::AppState;
+
+/// Default absolute lifetime of an OIDC login session: the wall past which
+/// refreshing stops working and the user must sign in through the IdP again.
+pub const DEFAULT_OIDC_SESSION_MAX_AGE: Duration = Duration::from_secs(8 * 60 * 60);
+
+/// Absolute OIDC session lifetime, from `CLOACINA_OIDC_SESSION_MAX_AGE_S`.
+///
+/// This is the deployment's dial on the one thing the session-record design
+/// trades away: how long an IdP-side deactivation can go unnoticed. Lower it
+/// (e.g. 3600) when the IdP is the authority on employment status and you want
+/// same-hour offboarding; raise it for kiosk-style long sessions.
+pub fn oidc_session_max_age() -> Duration {
+    std::env::var("CLOACINA_OIDC_SESSION_MAX_AGE_S")
+        .ok()
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .filter(|s| *s > 0)
+        .map(Duration::from_secs)
+        .unwrap_or(DEFAULT_OIDC_SESSION_MAX_AGE)
+}
 
 #[derive(Debug, Serialize, ToSchema)]
 pub struct LogoutResponse {
@@ -86,7 +142,7 @@ pub async fn whoami(Extension(auth): Extension<AuthenticatedKey>) -> impl IntoRe
     responses(
         (status = 200, description = "Re-minted key returned once", body = LocalLoginResponse),
         (status = 400, description = "Key is not a refreshable login key", body = cloacina_api_types::ErrorBody),
-        (status = 401, description = "Invalid key, or the login is no longer valid", body = cloacina_api_types::ErrorBody),
+        (status = 401, description = "Invalid key, the account is disabled, or the login session has passed its absolute deadline", body = cloacina_api_types::ErrorBody),
         (status = 501, description = "Refresh for this provider not yet supported", body = cloacina_api_types::ErrorBody),
     ),
     security(("api_key" = []))
@@ -156,7 +212,70 @@ pub async fn refresh(
         };
     }
 
-    // ---- other providers (oidc:…): the IdP refresh exchange lands in T-0790 ----
+    // ---- oidc provider: re-mint inside the server-side login session --------
+    if provenance.starts_with("oidc:") {
+        // The session row is the authority on "is this login still alive".
+        // Absent (never opened, or logged out) or past its absolute deadline →
+        // the user must go through the IdP again.
+        let session = match dal.oidc_sessions().get_session(auth.key_id).await {
+            Ok(s) => s,
+            Err(e) => {
+                warn!("refresh: oidc session lookup failed: {}", e);
+                return ApiError::internal("refresh failed").into_response();
+            }
+        };
+        let still_open = matches!(
+            session,
+            Some((_, Some(deadline))) if deadline > chrono::Utc::now()
+        );
+        if !still_open {
+            // Session over: kill the key so the browser cannot keep using it
+            // for the remainder of its TTL, and force a full re-auth.
+            let _ = dal.api_keys().revoke_key(auth.key_id).await;
+            let _ = dal.oidc_sessions().delete(auth.key_id).await;
+            state.key_cache.clear().await;
+            return ApiError::unauthorized("login session has expired — sign in again")
+                .into_response();
+        }
+
+        // Scope comes from the persisted key row (the stored result of the
+        // original allowlist mapping), never from the request. `is_admin` is
+        // not a parameter of the mint path at all.
+        let principal = ResolvedPrincipal {
+            tenant: info.tenant_id.clone(),
+            role: info.permissions.clone(),
+            provenance: provenance.clone(),
+        };
+        return match mint_for_principal(&state, &principal, DEFAULT_MINTED_KEY_TTL).await {
+            Ok((plaintext, new_info)) => {
+                // Rotate the session onto the new key BEFORE revoking the old
+                // one: if the rotation fails, the caller still holds a valid
+                // key and can retry, rather than being logged out by our bug.
+                // The session's absolute deadline is deliberately not extended.
+                match dal.oidc_sessions().rotate(auth.key_id, new_info.id).await {
+                    Ok(true) => {}
+                    Ok(false) | Err(_) => {
+                        warn!("refresh: oidc session rotation failed — leaving old key valid");
+                        let _ = dal.api_keys().revoke_key(new_info.id).await;
+                        return ApiError::internal("refresh failed").into_response();
+                    }
+                }
+                let _ = dal.api_keys().revoke_key(auth.key_id).await;
+                state.key_cache.clear().await;
+                info!(provenance = %provenance, "refresh: re-minted OIDC session key");
+                Json(LocalLoginResponse {
+                    key: plaintext,
+                    tenant_id: new_info.tenant_id,
+                    role: new_info.permissions,
+                    expires_at: new_info.expires_at.map(|t| t.to_rfc3339()),
+                })
+                .into_response()
+            }
+            Err(e) => e.into_response(),
+        };
+    }
+
+    // ---- unknown provenance prefix — not a refreshable login key ----
     ApiError::new(
         StatusCode::NOT_IMPLEMENTED,
         "refresh_unsupported",

--- a/crates/cloacina/src/dal/unified/local_accounts/mod.rs
+++ b/crates/cloacina/src/dal/unified/local_accounts/mod.rs
@@ -55,6 +55,19 @@ pub fn verify_password(plaintext: &str, phc: &str) -> bool {
     }
 }
 
+/// A throwaway argon2id hash of a random secret, built once per process with
+/// exactly the parameters [`hash_password`] uses (CLOACI-T-0923).
+///
+/// Verifying an unknown username's password against this makes the "no such
+/// user" path cost the same argon2 work as the "wrong password" path, closing
+/// the timing side-channel that would otherwise enumerate accounts regardless
+/// of how uniform the HTTP error body is. Nothing ever matches it: the input
+/// is a fresh UUID that is discarded immediately.
+fn decoy_password_hash() -> &'static str {
+    static DECOY: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+    DECOY.get_or_init(|| hash_password(&uuid::Uuid::new_v4().to_string()).unwrap_or_default())
+}
+
 /// Public view of a local account (never includes the password hash).
 #[derive(Debug, Clone)]
 pub struct LocalAccount {
@@ -202,7 +215,18 @@ impl<'a> LocalAccountDAL<'a> {
             Some(r) if verify_password(password, &r.password_hash) && r.status == "active" => {
                 Ok(LoginOutcome::Ok(to_account(&r)))
             }
-            _ => Ok(LoginOutcome::Denied),
+            Some(_) => Ok(LoginOutcome::Denied),
+            None => {
+                // CLOACI-T-0923: an unknown username used to return without
+                // hashing anything, so "no such user" answered in microseconds
+                // while "wrong password" paid the full argon2id cost — a clean
+                // timing oracle for user enumeration that no amount of
+                // uniform-error-body care could close. Burn an equivalent
+                // verification against a fixed decoy hash so both paths cost
+                // the same argon2 work.
+                let _ = verify_password(password, decoy_password_hash());
+                Ok(LoginOutcome::Denied)
+            }
         }
     }
 

--- a/crates/cloacina/src/dal/unified/login_throttle.rs
+++ b/crates/cloacina/src/dal/unified/login_throttle.rs
@@ -1,0 +1,507 @@
+/*
+ *  Copyright 2025-2026 Colliery Software
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+//! Unified login-throttle DAL — brute-force defense for local login
+//! (CLOACI-T-0923, closes I-0118 OQ-13 "required before production").
+//!
+//! Argon2id makes each guess expensive for the **server**, not for the
+//! attacker. Nothing previously bounded sustained guessing against a known
+//! username, so `/v1/auth/local/login` was an open credential-stuffing target.
+//!
+//! **Persisted, not per-replica.** A counter in one replica's memory is evaded
+//! by spraying attempts across replicas behind a load balancer, and a lockout
+//! decided on replica A is invisible to replica B. Same lesson (and same DAL
+//! shape) as the T-0916 `ws_tickets` move.
+//!
+//! # Why dual-keyed
+//!
+//! Every failed attempt increments **two** independent counters, and a login is
+//! refused if **either** is locked:
+//!
+//! | key | catches | threshold |
+//! |-----|---------|-----------|
+//! | `u:<tenant-or-_>/<username>` | an attacker rotating source IPs against one account | low (5) |
+//! | `ip:<source>` | one host spraying many usernames, none of which alone trips | high (50) |
+//!
+//! Neither scope alone is sufficient: username-only lets a single host walk an
+//! entire user list; IP-only is defeated by a botnet or an open proxy pool. The
+//! obvious third option — a composite `(username, ip)` key — is strictly the
+//! worst, because it resets on every new source IP and therefore stops neither
+//! attack. The IP threshold is deliberately an order of magnitude higher than
+//! the username one so a shared-NAT office does not lock itself out over a
+//! handful of typos.
+//!
+//! # Not an enumeration oracle
+//!
+//! The caller records a failure for an **unknown** username exactly as for a
+//! real one, so a locked key's `429` says only "this key has been failing",
+//! never "this account exists". See `routes/local_auth.rs`.
+//!
+//! # Decay and reset
+//!
+//! A counter whose last failure is older than [`ThrottlePolicy::decay`] starts
+//! over. A successful login clears the *username* key outright (a legitimate
+//! user who finally remembers their password is not left in a hole). The IP key
+//! is deliberately **not** cleared on success — otherwise an attacker with one
+//! valid account of their own could zero the spray counter at will — and is
+//! left to decay instead.
+
+use super::models::{NewUnifiedLoginThrottle, UnifiedLoginThrottle};
+use super::DAL;
+use crate::database::schema::unified::login_throttle;
+use crate::database::universal_types::UniversalTimestamp;
+use crate::error::ValidationError;
+use chrono::{DateTime, Duration as ChronoDuration, Utc};
+use diesel::prelude::*;
+
+/// Scope label stored on a row (also the metric/audit label).
+pub const SCOPE_USERNAME: &str = "username";
+/// Scope label for source-IP rows.
+pub const SCOPE_IP: &str = "ip";
+
+/// Build the username-scoped throttle key. `tenant` is the login request's
+/// tenant selector; `None` (a global account) collapses to `_` so the two
+/// namespaces never collide.
+pub fn username_key(tenant: Option<&str>, username: &str) -> String {
+    format!("u:{}/{}", tenant.unwrap_or("_"), username)
+}
+
+/// Build the source-IP-scoped throttle key.
+pub fn ip_key(ip: &str) -> String {
+    format!("ip:{ip}")
+}
+
+/// Tunables for one throttle scope.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ThrottlePolicy {
+    /// Consecutive failures tolerated before the key locks.
+    pub threshold: i32,
+    /// Lock duration for the first failure past the threshold. Each further
+    /// failure doubles it, up to `max_lock`.
+    pub base_lock: ChronoDuration,
+    /// Ceiling on the exponential backoff.
+    pub max_lock: ChronoDuration,
+    /// Idle period after which a counter is considered stale and starts over.
+    pub decay: ChronoDuration,
+}
+
+impl ThrottlePolicy {
+    /// Default username-scoped policy: 5 strikes, then 30s doubling to a 15min
+    /// cap, counters forgotten after 15 idle minutes.
+    pub fn username_default() -> Self {
+        Self {
+            threshold: 5,
+            base_lock: ChronoDuration::seconds(30),
+            max_lock: ChronoDuration::minutes(15),
+            decay: ChronoDuration::minutes(15),
+        }
+    }
+
+    /// Default source-IP policy: an order of magnitude looser than the username
+    /// policy so shared NAT does not self-inflict a lockout, but still bounds a
+    /// single host spraying a user list.
+    pub fn ip_default() -> Self {
+        Self {
+            threshold: 50,
+            base_lock: ChronoDuration::minutes(15),
+            max_lock: ChronoDuration::minutes(15),
+            decay: ChronoDuration::minutes(15),
+        }
+    }
+
+    /// Lock window for the `n`-th consecutive failure (1-based). Failures at or
+    /// below `threshold` do not lock.
+    fn lock_for(&self, failure_count: i32) -> Option<ChronoDuration> {
+        let over = failure_count - self.threshold;
+        if over <= 0 {
+            return None;
+        }
+        // 2^(over-1), saturating well before ChronoDuration overflows.
+        let shift = (over - 1).clamp(0, 20) as u32;
+        let scaled = self
+            .base_lock
+            .checked_mul(1i32 << shift)
+            .unwrap_or(self.max_lock);
+        Some(if scaled > self.max_lock {
+            self.max_lock
+        } else {
+            scaled
+        })
+    }
+}
+
+/// The post-write state of a throttle key.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ThrottleState {
+    pub scope: String,
+    /// Consecutive failures after this write.
+    pub failure_count: i32,
+    /// Set when the key is locked; the wall past which attempts are accepted
+    /// again.
+    pub locked_until: Option<DateTime<Utc>>,
+    /// True when *this* write is what pushed the key into a lock (the edge the
+    /// caller audits + counts, so a lockout is logged once, not once per
+    /// subsequent attempt).
+    pub newly_locked: bool,
+}
+
+impl ThrottleState {
+    /// Whether the key is locked as of `now`.
+    pub fn is_locked_at(&self, now: DateTime<Utc>) -> bool {
+        self.locked_until.map(|t| t > now).unwrap_or(false)
+    }
+}
+
+/// Data access layer for failed-login counters.
+#[derive(Clone)]
+pub struct LoginThrottleDAL<'a> {
+    dal: &'a DAL,
+}
+
+impl<'a> LoginThrottleDAL<'a> {
+    pub fn new(dal: &'a DAL) -> Self {
+        Self { dal }
+    }
+
+    /// Is `key` currently locked? Returns the lock expiry when it is.
+    ///
+    /// Read-only and cheap — this is the pre-password-verify gate, so it must
+    /// not itself become the expensive part of a login attempt.
+    pub async fn locked_until(&self, key: &str) -> Result<Option<DateTime<Utc>>, ValidationError> {
+        let key = key.to_string();
+        let now = UniversalTimestamp::now();
+        let row: Option<UnifiedLoginThrottle> = crate::interact_on_backend!(self.dal, |conn| {
+            login_throttle::table
+                .filter(login_throttle::throttle_key.eq(&key))
+                .first::<UnifiedLoginThrottle>(conn)
+                .optional()
+        })
+        .map_err(ValidationError::from)?;
+        Ok(row
+            .and_then(|r| r.locked_until)
+            .filter(|t| t.0 > now.0)
+            .map(|t| t.0))
+    }
+
+    /// Record one failed attempt against `key` and return the resulting state.
+    ///
+    /// Read-modify-write inside a single transaction so two concurrent
+    /// attempts (on any replica) cannot both read the same count and write the
+    /// same increment. A counter idle longer than `policy.decay` restarts at 1.
+    pub async fn record_failure(
+        &self,
+        key: &str,
+        scope: &str,
+        policy: ThrottlePolicy,
+    ) -> Result<ThrottleState, ValidationError> {
+        let key = key.to_string();
+        let scope = scope.to_string();
+        let now = UniversalTimestamp::now();
+
+        let state: ThrottleState = crate::interact_on_backend!(self.dal, |conn| {
+            conn.transaction::<ThrottleState, diesel::result::Error, _>(|conn| {
+                let existing: Option<UnifiedLoginThrottle> = login_throttle::table
+                    .filter(login_throttle::throttle_key.eq(&key))
+                    .first::<UnifiedLoginThrottle>(conn)
+                    .optional()?;
+
+                // Was the key already locked before this write? Used to report
+                // the lock *edge* exactly once.
+                let was_locked = existing
+                    .as_ref()
+                    .and_then(|r| r.locked_until)
+                    .map(|t| t.0 > now.0)
+                    .unwrap_or(false);
+
+                let (failure_count, first_failure_at) = match &existing {
+                    // Stale counter — the attacker (or the forgetful human)
+                    // went quiet long enough; start over.
+                    Some(r) if now.0 - r.last_failure_at.0 > policy.decay => (1, now),
+                    Some(r) => (r.failure_count.saturating_add(1), r.first_failure_at),
+                    None => (1, now),
+                };
+
+                let locked_until = policy
+                    .lock_for(failure_count)
+                    .map(|d| UniversalTimestamp(now.0 + d));
+
+                let row = NewUnifiedLoginThrottle {
+                    throttle_key: key.clone(),
+                    scope: scope.clone(),
+                    failure_count,
+                    first_failure_at,
+                    last_failure_at: now,
+                    locked_until,
+                };
+
+                if existing.is_some() {
+                    diesel::update(
+                        login_throttle::table.filter(login_throttle::throttle_key.eq(&key)),
+                    )
+                    .set(&row)
+                    .execute(conn)?;
+                } else {
+                    diesel::insert_into(login_throttle::table)
+                        .values(&row)
+                        .execute(conn)?;
+                }
+
+                Ok(ThrottleState {
+                    scope: scope.clone(),
+                    failure_count,
+                    locked_until: locked_until.map(|t| t.0),
+                    newly_locked: locked_until.is_some() && !was_locked,
+                })
+            })
+        })
+        .map_err(ValidationError::from)?;
+
+        Ok(state)
+    }
+
+    /// Forget `key` entirely — called on a successful login so a legitimate
+    /// user's counter never carries over. Returns true if a row was removed.
+    pub async fn clear(&self, key: &str) -> Result<bool, ValidationError> {
+        let key = key.to_string();
+        let n: usize = crate::interact_on_backend!(self.dal, |conn| {
+            diesel::delete(login_throttle::table.filter(login_throttle::throttle_key.eq(&key)))
+                .execute(conn)
+        })
+        .map_err(ValidationError::from)?;
+        Ok(n > 0)
+    }
+
+    /// Drop counters idle for longer than `older_than` **and** not currently
+    /// locked. Keeps the table bounded without a dedicated sweeper; the login
+    /// route calls it opportunistically.
+    pub async fn prune_idle(&self, older_than: ChronoDuration) -> Result<usize, ValidationError> {
+        let now = UniversalTimestamp::now();
+        let cutoff = UniversalTimestamp(now.0 - older_than);
+        crate::interact_on_backend!(self.dal, |conn| {
+            diesel::delete(
+                login_throttle::table
+                    .filter(login_throttle::last_failure_at.lt(cutoff))
+                    .filter(
+                        login_throttle::locked_until
+                            .is_null()
+                            .or(login_throttle::locked_until.lt(now)),
+                    ),
+            )
+            .execute(conn)
+        })
+        .map_err(ValidationError::from)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::database::Database;
+
+    #[test]
+    fn keys_are_scoped_and_do_not_collide() {
+        assert_eq!(username_key(Some("acme"), "bob"), "u:acme/bob");
+        assert_eq!(username_key(None, "bob"), "u:_/bob");
+        assert_ne!(username_key(Some("acme"), "bob"), ip_key("acme/bob"));
+    }
+
+    #[test]
+    fn backoff_is_exponential_and_capped() {
+        let p = ThrottlePolicy::username_default();
+        assert_eq!(p.lock_for(1), None, "under threshold must not lock");
+        assert_eq!(p.lock_for(5), None, "at threshold must not lock");
+        assert_eq!(p.lock_for(6), Some(ChronoDuration::seconds(30)));
+        assert_eq!(p.lock_for(7), Some(ChronoDuration::seconds(60)));
+        assert_eq!(p.lock_for(8), Some(ChronoDuration::seconds(120)));
+        // Capped, and never overflows however far the attacker pushes.
+        assert_eq!(p.lock_for(100), Some(ChronoDuration::minutes(15)));
+        assert_eq!(p.lock_for(i32::MAX), Some(ChronoDuration::minutes(15)));
+    }
+
+    #[test]
+    fn ip_policy_is_far_looser_than_username_policy() {
+        // A shared-NAT office must not lock out because five people fat-finger
+        // their passwords.
+        assert!(
+            ThrottlePolicy::ip_default().threshold
+                > ThrottlePolicy::username_default().threshold * 5
+        );
+    }
+
+    #[cfg(feature = "sqlite")]
+    fn shared_url() -> String {
+        format!(
+            "file:login_throttle_test_{}?mode=memory&cache=shared",
+            uuid::Uuid::new_v4()
+        )
+    }
+
+    #[cfg(feature = "sqlite")]
+    async fn dal_for(url: &str) -> DAL {
+        let db = Database::new(url, "", 5);
+        db.run_migrations()
+            .await
+            .expect("migrations should succeed");
+        DAL::new(db)
+    }
+
+    #[cfg(feature = "sqlite")]
+    fn fast_policy() -> ThrottlePolicy {
+        ThrottlePolicy {
+            threshold: 3,
+            base_lock: ChronoDuration::milliseconds(150),
+            max_lock: ChronoDuration::milliseconds(150),
+            decay: ChronoDuration::minutes(15),
+        }
+    }
+
+    #[cfg(feature = "sqlite")]
+    #[tokio::test]
+    async fn locks_after_threshold_then_expires() {
+        let dal = dal_for(&shared_url()).await;
+        let t = dal.login_throttle();
+        let key = username_key(Some("acme"), "bob");
+        let p = fast_policy();
+
+        for _ in 0..3 {
+            let s = t.record_failure(&key, SCOPE_USERNAME, p).await.unwrap();
+            assert!(s.locked_until.is_none(), "must not lock at/below threshold");
+        }
+        assert!(t.locked_until(&key).await.unwrap().is_none());
+
+        let s = t.record_failure(&key, SCOPE_USERNAME, p).await.unwrap();
+        assert_eq!(s.failure_count, 4);
+        assert!(s.newly_locked, "the crossing attempt reports the edge");
+        assert!(t.locked_until(&key).await.unwrap().is_some());
+
+        // A further failure while locked is not a *new* lockout (so the audit
+        // event / metric fires once per lock, not once per attempt).
+        let s = t.record_failure(&key, SCOPE_USERNAME, p).await.unwrap();
+        assert!(!s.newly_locked);
+
+        tokio::time::sleep(std::time::Duration::from_millis(400)).await;
+        assert!(
+            t.locked_until(&key).await.unwrap().is_none(),
+            "lock must expire on its own"
+        );
+    }
+
+    #[cfg(feature = "sqlite")]
+    #[tokio::test]
+    async fn success_clears_the_counter() {
+        let dal = dal_for(&shared_url()).await;
+        let t = dal.login_throttle();
+        let key = username_key(None, "carol");
+        let p = fast_policy();
+
+        t.record_failure(&key, SCOPE_USERNAME, p).await.unwrap();
+        t.record_failure(&key, SCOPE_USERNAME, p).await.unwrap();
+        assert!(t.clear(&key).await.unwrap(), "row existed");
+
+        // Next failure starts from scratch, so the user is not one strike from
+        // a lockout after finally logging in.
+        let s = t.record_failure(&key, SCOPE_USERNAME, p).await.unwrap();
+        assert_eq!(s.failure_count, 1);
+    }
+
+    /// The multi-replica contract (mirrors the T-0916 ws-ticket test): failures
+    /// recorded through one DAL handle are seen — and the lock enforced — by a
+    /// DIFFERENT handle over the same database.
+    #[cfg(feature = "sqlite")]
+    #[tokio::test]
+    async fn throttle_state_is_shared_across_handles() {
+        let url = shared_url();
+        let dal_a = dal_for(&url).await;
+        let dal_b = DAL::new(Database::new(&url, "", 5));
+        let key = username_key(Some("acme"), "dave");
+        let p = ThrottlePolicy {
+            threshold: 3,
+            base_lock: ChronoDuration::seconds(60),
+            max_lock: ChronoDuration::seconds(60),
+            decay: ChronoDuration::minutes(15),
+        };
+
+        // Replica A takes two strikes, replica B takes the next two.
+        dal_a
+            .login_throttle()
+            .record_failure(&key, SCOPE_USERNAME, p)
+            .await
+            .unwrap();
+        dal_a
+            .login_throttle()
+            .record_failure(&key, SCOPE_USERNAME, p)
+            .await
+            .unwrap();
+        let s = dal_b
+            .login_throttle()
+            .record_failure(&key, SCOPE_USERNAME, p)
+            .await
+            .unwrap();
+        assert_eq!(s.failure_count, 3, "B must continue A's count, not restart");
+        let s = dal_b
+            .login_throttle()
+            .record_failure(&key, SCOPE_USERNAME, p)
+            .await
+            .unwrap();
+        assert!(s.newly_locked);
+
+        // ...and the lock decided on B is enforced on A.
+        assert!(dal_a
+            .login_throttle()
+            .locked_until(&key)
+            .await
+            .unwrap()
+            .is_some());
+
+        // Clearing on A releases B too.
+        dal_a.login_throttle().clear(&key).await.unwrap();
+        assert!(dal_b
+            .login_throttle()
+            .locked_until(&key)
+            .await
+            .unwrap()
+            .is_none());
+    }
+
+    #[cfg(feature = "sqlite")]
+    #[tokio::test]
+    async fn stale_counters_decay_and_prune() {
+        let dal = dal_for(&shared_url()).await;
+        let t = dal.login_throttle();
+        let key = username_key(None, "erin");
+        let p = ThrottlePolicy {
+            threshold: 3,
+            base_lock: ChronoDuration::milliseconds(50),
+            max_lock: ChronoDuration::milliseconds(50),
+            decay: ChronoDuration::milliseconds(100),
+        };
+
+        t.record_failure(&key, SCOPE_USERNAME, p).await.unwrap();
+        t.record_failure(&key, SCOPE_USERNAME, p).await.unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        let s = t.record_failure(&key, SCOPE_USERNAME, p).await.unwrap();
+        assert_eq!(s.failure_count, 1, "idle counter restarts");
+
+        // Idle + unlocked rows are pruned; a live lock is not.
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        assert_eq!(
+            t.prune_idle(ChronoDuration::milliseconds(100))
+                .await
+                .unwrap(),
+            1
+        );
+    }
+}

--- a/crates/cloacina/src/dal/unified/mod.rs
+++ b/crates/cloacina/src/dal/unified/mod.rs
@@ -56,6 +56,7 @@ pub mod execution_event;
 pub mod fleet_agents;
 #[cfg(feature = "postgres")]
 pub mod local_accounts;
+pub mod login_throttle;
 pub mod models;
 #[cfg(feature = "postgres")]
 pub mod oidc_login_flows;
@@ -86,6 +87,7 @@ pub use execution_event::ExecutionEventDAL;
 pub use fleet_agents::{FleetAgent, FleetAgentDAL, FleetAgentRegistration};
 #[cfg(feature = "postgres")]
 pub use local_accounts::{LocalAccount, LocalAccountDAL, LoginOutcome};
+pub use login_throttle::{LoginThrottleDAL, ThrottlePolicy, ThrottleState};
 #[cfg(feature = "postgres")]
 pub use oidc_login_flows::OidcLoginFlowDAL;
 #[cfg(feature = "postgres")]
@@ -178,6 +180,12 @@ impl DAL {
     #[cfg(feature = "postgres")]
     pub fn local_accounts(&self) -> LocalAccountDAL<'_> {
         LocalAccountDAL::new(self)
+    }
+
+    /// Returns the login brute-force throttle DAL. CLOACI-T-0923.
+    /// Unified (both backends) so its semantics are testable without Postgres.
+    pub fn login_throttle(&self) -> LoginThrottleDAL<'_> {
+        LoginThrottleDAL::new(self)
     }
 
     /// Returns an OIDC login-flow-state DAL (Postgres only). CLOACI-T-0801.

--- a/crates/cloacina/src/dal/unified/models.rs
+++ b/crates/cloacina/src/dal/unified/models.rs
@@ -21,10 +21,11 @@
 
 use crate::database::schema::unified::{
     accumulator_boundaries, accumulator_checkpoints, contexts, delivery_outbox, execution_events,
-    fleet_agents, key_trust_acls, package_artifacts, package_providers, package_signatures,
-    reactor_state, recovery_events, schedule_executions, schedules, secrets, signing_keys,
-    state_accumulator_buffers, task_execution_metadata, task_executions, tenant_data_keys,
-    trusted_keys, workflow_executions, workflow_packages, workflow_registry, ws_tickets,
+    fleet_agents, key_trust_acls, login_throttle, package_artifacts, package_providers,
+    package_signatures, reactor_state, recovery_events, schedule_executions, schedules, secrets,
+    signing_keys, state_accumulator_buffers, task_execution_metadata, task_executions,
+    tenant_data_keys, trusted_keys, workflow_executions, workflow_packages, workflow_registry,
+    ws_tickets,
 };
 use crate::database::universal_types::{
     UniversalBinary, UniversalBool, UniversalTimestamp, UniversalUuid,
@@ -309,6 +310,36 @@ pub struct NewUnifiedWsTicket {
     pub created_at: UniversalTimestamp,
     pub expires_at: UniversalTimestamp,
     pub redeemed_at: Option<UniversalTimestamp>,
+}
+
+// ============================================================================
+// Unified Login-Throttle Models (CLOACI-T-0923)
+// ============================================================================
+
+/// One failed-login counter. `throttle_key` is opaque and carries its own scope
+/// prefix (`u:<tenant-or-_>/<username>` or `ip:<source>`) so the two scopes
+/// share a table without colliding.
+#[derive(Debug, Clone, Queryable, Selectable)]
+#[diesel(table_name = login_throttle)]
+pub struct UnifiedLoginThrottle {
+    pub throttle_key: String,
+    pub scope: String,
+    pub failure_count: i32,
+    pub first_failure_at: UniversalTimestamp,
+    pub last_failure_at: UniversalTimestamp,
+    pub locked_until: Option<UniversalTimestamp>,
+}
+
+#[derive(Debug, Clone, Insertable, AsChangeset)]
+#[diesel(table_name = login_throttle)]
+#[diesel(treat_none_as_null = true)]
+pub struct NewUnifiedLoginThrottle {
+    pub throttle_key: String,
+    pub scope: String,
+    pub failure_count: i32,
+    pub first_failure_at: UniversalTimestamp,
+    pub last_failure_at: UniversalTimestamp,
+    pub locked_until: Option<UniversalTimestamp>,
 }
 
 // ============================================================================

--- a/crates/cloacina/src/dal/unified/oidc_sessions/mod.rs
+++ b/crates/cloacina/src/dal/unified/oidc_sessions/mod.rs
@@ -14,13 +14,25 @@
  *  limitations under the License.
  */
 
-//! Encrypted server-side refresh-token store (CLOACI-T-0793). **Postgres only.**
+//! Server-side OIDC **login-session** store (CLOACI-T-0793, T-0923).
+//! **Postgres only** — like the rest of the auth strand (`api_keys`,
+//! `local_accounts`, `oidc_login_flows`), because the API server runs on
+//! Postgres.
 //!
-//! One row per minted login key. The refresh token is encrypted at rest with
-//! AES-256-GCM (reusing [`crate::crypto::key_encryption`]) under a 32-byte
-//! server key; the plaintext is never logged or returned to the browser. A
-//! sweeper deletes lapsed rows. `/auth/refresh` + `/auth/logout` (T-0794)
-//! consume this store.
+//! One row per live login session. `key_id` is the session's *currently valid*
+//! minted key — [`OidcSessionDAL::rotate`] moves it onto the freshly minted key
+//! on every refresh — and `expires_at` is the session's **absolute** deadline:
+//! the wall past which no amount of refreshing keeps the user in and a full
+//! OIDC re-auth is required. `/auth/refresh` + `/auth/logout` consume this
+//! store.
+//!
+//! T-0793 originally built the row to hold an IdP refresh token, encrypted at
+//! rest with AES-256-GCM under a 32-byte server key. T-0923 chose a session
+//! record over IdP-token custody (rationale in `routes/session.rs`), so
+//! `refresh_enc` is NULL in practice; the column and the
+//! [`encrypt_token`]/[`decrypt_token`] helpers are kept so a deployment that
+//! later wants true token custody needs no migration. If it is ever populated
+//! the plaintext must never be logged or returned to the browser.
 
 use crate::dal::unified::DAL;
 use crate::error::ValidationError;
@@ -46,11 +58,14 @@ pub fn decrypt_token(ciphertext: &[u8], enc_key: &[u8]) -> Result<Vec<u8>, Valid
 }
 
 /// A decrypted refresh session: the provider that issued it + the plaintext
-/// refresh token. Never logged.
+/// refresh token (empty when no token is stored — the T-0923 session-record
+/// design). Never logged.
 #[derive(Debug, Clone)]
 pub struct RefreshSession {
     pub provider: String,
     pub refresh_token: Vec<u8>,
+    /// The session's absolute deadline. `None` = unbounded (never produced by
+    /// [`OidcSessionDAL::create_session`]).
     pub expires_at: Option<DateTime<Utc>>,
 }
 
@@ -63,7 +78,7 @@ struct OidcSessionRow {
     #[allow(dead_code)]
     pub key_id: Uuid,
     pub provider: String,
-    pub refresh_enc: Vec<u8>,
+    pub refresh_enc: Option<Vec<u8>>,
     #[allow(dead_code)]
     pub created_at: chrono::NaiveDateTime,
     pub expires_at: Option<chrono::NaiveDateTime>,
@@ -76,7 +91,7 @@ struct NewOidcSession {
     pub id: Uuid,
     pub key_id: Uuid,
     pub provider: String,
-    pub refresh_enc: Vec<u8>,
+    pub refresh_enc: Option<Vec<u8>>,
     pub expires_at: Option<chrono::NaiveDateTime>,
 }
 
@@ -101,7 +116,7 @@ impl<'a> OidcSessionDAL<'a> {
         enc_key: &[u8],
         expires_at: Option<DateTime<Utc>>,
     ) -> Result<(), ValidationError> {
-        let refresh_enc = encrypt_token(refresh_token, enc_key)?;
+        let refresh_enc = Some(encrypt_token(refresh_token, enc_key)?);
         let row = NewOidcSession {
             id: Uuid::new_v4(),
             key_id,
@@ -152,7 +167,10 @@ impl<'a> OidcSessionDAL<'a> {
         match row {
             None => Ok(None),
             Some(r) => {
-                let refresh_token = decrypt_token(&r.refresh_enc, enc_key)?;
+                let refresh_token = match &r.refresh_enc {
+                    Some(enc) => decrypt_token(enc, enc_key)?,
+                    None => Vec::new(),
+                };
                 Ok(Some(RefreshSession {
                     provider: r.provider,
                     refresh_token,
@@ -160,6 +178,104 @@ impl<'a> OidcSessionDAL<'a> {
                 }))
             }
         }
+    }
+
+    /// Open a login session for a freshly minted key (CLOACI-T-0923).
+    ///
+    /// `expires_at` is the session's **absolute** deadline — refresh extends
+    /// the *key*, never this. No IdP token is stored (`refresh_enc` stays
+    /// NULL); see the module docs for why. Lapsed rows are pruned
+    /// opportunistically first, so the table stays bounded without a dedicated
+    /// sweeper (mirrors the `ws_tickets` hygiene pattern).
+    #[cfg(feature = "postgres")]
+    pub async fn create_session(
+        &self,
+        key_id: Uuid,
+        provider: &str,
+        expires_at: DateTime<Utc>,
+    ) -> Result<(), ValidationError> {
+        use crate::database::schema::postgres::oidc_sessions;
+        let row = NewOidcSession {
+            id: Uuid::new_v4(),
+            key_id,
+            provider: provider.to_string(),
+            refresh_enc: None,
+            expires_at: Some(expires_at.naive_utc()),
+        };
+        let now = Utc::now().naive_utc();
+        let conn = self
+            .dal
+            .database
+            .get_postgres_connection()
+            .await
+            .map_err(|e| ValidationError::ConnectionPool(e.to_string()))?;
+        conn.interact(move |conn| {
+            diesel::delete(oidc_sessions::table.filter(oidc_sessions::expires_at.lt(now)))
+                .execute(conn)?;
+            diesel::insert_into(oidc_sessions::table)
+                .values(&row)
+                .execute(conn)
+        })
+        .await
+        .map_err(|e| ValidationError::ConnectionPool(e.to_string()))??;
+        Ok(())
+    }
+
+    /// Look up the session a minted key belongs to, without touching
+    /// `refresh_enc` (so no encryption key is needed on the refresh path).
+    /// Returns `(provider, absolute_expiry)`.
+    #[cfg(feature = "postgres")]
+    pub async fn get_session(
+        &self,
+        key_id: Uuid,
+    ) -> Result<Option<(String, Option<DateTime<Utc>>)>, ValidationError> {
+        use crate::database::schema::postgres::oidc_sessions;
+        let conn = self
+            .dal
+            .database
+            .get_postgres_connection()
+            .await
+            .map_err(|e| ValidationError::ConnectionPool(e.to_string()))?;
+        let row: Option<(String, Option<chrono::NaiveDateTime>)> = conn
+            .interact(move |conn| {
+                oidc_sessions::table
+                    .filter(oidc_sessions::key_id.eq(key_id))
+                    .select((oidc_sessions::provider, oidc_sessions::expires_at))
+                    .first(conn)
+                    .optional()
+            })
+            .await
+            .map_err(|e| ValidationError::ConnectionPool(e.to_string()))??;
+        Ok(row.map(|(p, e)| (p, e.map(|t| t.and_utc()))))
+    }
+
+    /// Point an existing session at a newly minted key (refresh rotation).
+    ///
+    /// The session's `expires_at` is deliberately **not** extended: the
+    /// absolute deadline is the whole point of the record. Returns true when a
+    /// session was rotated.
+    #[cfg(feature = "postgres")]
+    pub async fn rotate(
+        &self,
+        old_key_id: Uuid,
+        new_key_id: Uuid,
+    ) -> Result<bool, ValidationError> {
+        use crate::database::schema::postgres::oidc_sessions;
+        let conn = self
+            .dal
+            .database
+            .get_postgres_connection()
+            .await
+            .map_err(|e| ValidationError::ConnectionPool(e.to_string()))?;
+        let n: usize = conn
+            .interact(move |conn| {
+                diesel::update(oidc_sessions::table.filter(oidc_sessions::key_id.eq(old_key_id)))
+                    .set(oidc_sessions::key_id.eq(new_key_id))
+                    .execute(conn)
+            })
+            .await
+            .map_err(|e| ValidationError::ConnectionPool(e.to_string()))??;
+        Ok(n > 0)
     }
 
     /// Forget a minted key's refresh session (logout). Returns true if removed.

--- a/crates/cloacina/src/database/migrations/postgres/046_relax_oidc_session_refresh_enc/down.sql
+++ b/crates/cloacina/src/database/migrations/postgres/046_relax_oidc_session_refresh_enc/down.sql
@@ -1,0 +1,4 @@
+DROP INDEX IF EXISTS idx_oidc_sessions_key_id;
+CREATE INDEX idx_oidc_sessions_key_id ON oidc_sessions (key_id);
+DELETE FROM oidc_sessions WHERE refresh_enc IS NULL;
+ALTER TABLE oidc_sessions ALTER COLUMN refresh_enc SET NOT NULL;

--- a/crates/cloacina/src/database/migrations/postgres/046_relax_oidc_session_refresh_enc/up.sql
+++ b/crates/cloacina/src/database/migrations/postgres/046_relax_oidc_session_refresh_enc/up.sql
@@ -1,0 +1,29 @@
+-- CLOACI-T-0923: `oidc_sessions` becomes the OIDC **login-session** record.
+--
+-- T-0793 built this table to hold an encrypted IdP refresh token, but nothing
+-- ever wrote a row (the callback minted keys and stored no session), so
+-- `/v1/auth/refresh` returned 501 for `oidc:` provenance and an SSO session
+-- died hard at the 15-minute key TTL.
+--
+-- T-0923 implements refresh with a **server-side session record** instead of
+-- IdP token custody (see routes/session.rs for the full rationale):
+--   * `expires_at` is now the session's ABSOLUTE deadline — the wall past which
+--     no amount of refreshing keeps you in and a full OIDC re-auth (fresh IdP
+--     check + fresh allowlist resolution) is forced.
+--   * `key_id` is the currently-valid minted key; refresh rotates it onto the
+--     newly-minted key in place, so the row's identity survives key rotation.
+--   * `refresh_enc` therefore holds NOTHING for this design and becomes
+--     NULLable. The column (and its `encrypt_token`/`decrypt_token` helpers)
+--     is kept so a deployment that later wants true IdP-token custody can fill
+--     it without another migration.
+--
+-- No sqlite twin: the whole auth strand (api_keys, local_accounts,
+-- oidc_login_flows, oidc_sessions) is Postgres-only — the API server runs on
+-- Postgres. Cf. migrations 033/034/035, which likewise have no sqlite sibling.
+ALTER TABLE oidc_sessions ALTER COLUMN refresh_enc DROP NOT NULL;
+
+-- Refresh looks the session up by its current key; logout deletes by key.
+-- One live session per minted key, so make that a uniqueness invariant rather
+-- than a convention (the old index was non-unique).
+DROP INDEX IF EXISTS idx_oidc_sessions_key_id;
+CREATE UNIQUE INDEX idx_oidc_sessions_key_id ON oidc_sessions (key_id);

--- a/crates/cloacina/src/database/migrations/postgres/047_create_login_throttle/down.sql
+++ b/crates/cloacina/src/database/migrations/postgres/047_create_login_throttle/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS login_throttle;

--- a/crates/cloacina/src/database/migrations/postgres/047_create_login_throttle/up.sql
+++ b/crates/cloacina/src/database/migrations/postgres/047_create_login_throttle/up.sql
@@ -1,0 +1,38 @@
+-- CLOACI-T-0923: DB-backed brute-force throttle for `/v1/auth/local/login`
+-- (I-0118 OQ-13, "required before production").
+--
+-- Argon2id makes each guess expensive for the SERVER, not for the attacker;
+-- nothing previously stopped sustained guessing against a known username.
+--
+-- State is persisted (NOT a per-replica map) for the T-0916 reason: a counter
+-- held in one replica's memory is trivially evaded by spraying attempts across
+-- replicas behind a load balancer, and a lockout decided on replica A is
+-- invisible to replica B.
+--
+-- DUAL-KEYED, on purpose. Every failed attempt increments TWO independent
+-- counters and a login is refused if EITHER is locked:
+--   * `u:<tenant-or-_>/<username>` — an attacker rotating source IPs still
+--     accumulates against the account they are guessing. IP-only throttling
+--     would miss this entirely.
+--   * `ip:<source>` — one host spraying many usernames is caught even though
+--     no single username crosses its threshold. Username-only throttling would
+--     miss this entirely.
+-- A composite `(username, ip)` key — the obvious third option — is the worst of
+-- the three: it resets for every new source IP, so it stops neither attack.
+-- The IP counter's threshold is deliberately far higher than the username one
+-- so a shared-NAT office does not lock itself out over a handful of typos.
+--
+-- Rows are keyed by that opaque throttle key. Failures for an UNKNOWN username
+-- are counted exactly like failures for a real one, so the 429 a locked key
+-- returns is not a user-enumeration oracle.
+CREATE TABLE login_throttle (
+    throttle_key TEXT PRIMARY KEY,
+    scope TEXT NOT NULL,
+    failure_count INTEGER NOT NULL DEFAULT 0,
+    first_failure_at TIMESTAMP NOT NULL,
+    last_failure_at TIMESTAMP NOT NULL,
+    locked_until TIMESTAMP NULL
+);
+
+-- Prune scan: idle counters are dropped by last-failure age.
+CREATE INDEX idx_login_throttle_last_failure_at ON login_throttle (last_failure_at);

--- a/crates/cloacina/src/database/migrations/sqlite/047_create_login_throttle/down.sql
+++ b/crates/cloacina/src/database/migrations/sqlite/047_create_login_throttle/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS login_throttle;

--- a/crates/cloacina/src/database/migrations/sqlite/047_create_login_throttle/up.sql
+++ b/crates/cloacina/src/database/migrations/sqlite/047_create_login_throttle/up.sql
@@ -1,0 +1,18 @@
+-- CLOACI-T-0923: DB-backed brute-force throttle for local login.
+-- See the sibling postgres migration 047 for the full rationale (dual-keyed
+-- username + source-IP counters, persisted for multi-replica correctness).
+--
+-- The API server is Postgres-only at runtime; this table exists on SQLite
+-- because the throttle DAL is a *unified* (`interact_on_backend!`) DAL — the
+-- same reason `ws_tickets`/`fleet_agents` have sqlite twins — so its
+-- compare-and-set/decay semantics are exercised on both backends.
+CREATE TABLE login_throttle (
+    throttle_key TEXT PRIMARY KEY,
+    scope TEXT NOT NULL,
+    failure_count INTEGER NOT NULL DEFAULT 0,
+    first_failure_at TEXT NOT NULL,
+    last_failure_at TEXT NOT NULL,
+    locked_until TEXT NULL
+);
+
+CREATE INDEX idx_login_throttle_last_failure_at ON login_throttle (last_failure_at);

--- a/crates/cloacina/src/database/schema.rs
+++ b/crates/cloacina/src/database/schema.rs
@@ -172,6 +172,29 @@ mod unified_schema {
         use diesel::sql_types::*;
         use crate::database::universal_types::{DbUuid, DbTimestamp, DbBool, DbBinary};
 
+        /// Failed-login counters for the local-login brute-force throttle
+        /// (CLOACI-T-0923, I-0118 OQ-13). DB-backed so a lockout decided on one
+        /// server replica is enforced by every replica and an attacker cannot
+        /// evade it by spraying attempts across the load balancer.
+        ///
+        /// `throttle_key` is opaque and dual-scoped: `u:<tenant-or-_>/<username>`
+        /// rows catch an attacker rotating source IPs, `ip:<source>` rows catch
+        /// one host spraying many usernames. `locked_until` is NULL until the
+        /// scope's threshold is crossed.
+        login_throttle (throttle_key) {
+            throttle_key -> Text,
+            scope -> Text,
+            failure_count -> Integer,
+            first_failure_at -> DbTimestamp,
+            last_failure_at -> DbTimestamp,
+            locked_until -> Nullable<DbTimestamp>,
+        }
+    }
+
+    diesel::table! {
+        use diesel::sql_types::*;
+        use crate::database::universal_types::{DbUuid, DbTimestamp, DbBool, DbBinary};
+
         /// Execution-agent fleet roster (CLOACI-T-0916). DB-backed so
         /// register/heartbeat state, same-tenant selection, capacity views and
         /// dead-agent reclaim are correct across server replicas. Reads are
@@ -912,12 +935,17 @@ mod postgres_schema {
     }
 
     // CLOACI-T-0793: encrypted refresh-token store (server mode only — Postgres).
+    // CLOACI-T-0923: repurposed as the OIDC *login-session* record — `key_id` is
+    // the currently-valid minted key (rotated in place on refresh) and
+    // `expires_at` is the session's absolute deadline. `refresh_enc` is NULL
+    // under that design (no IdP token custody) and kept only so a deployment
+    // that later wants it needs no migration.
     diesel::table! {
         oidc_sessions (id) {
             id -> Uuid,
             key_id -> Uuid,
             provider -> Text,
-            refresh_enc -> Bytea,
+            refresh_enc -> Nullable<Bytea>,
             created_at -> Timestamptz,
             expires_at -> Nullable<Timestamptz>,
         }

--- a/crates/cloacina/src/security/audit.rs
+++ b/crates/cloacina/src/security/audit.rs
@@ -86,6 +86,12 @@ pub mod events {
     /// trail must mark the graph activity as operator-injected.
     pub const REACTOR_MANUAL_FIRE: &str = "reactor.manual_fire";
 
+    /// CLOACI-T-0923: a login throttle key crossed its failure threshold and
+    /// is now locked. Emitted on the lock **edge** only (not on every attempt
+    /// while locked), so one incident is one audit line. The `scope` field
+    /// distinguishes a username lock from a source-IP lock.
+    pub const AUTH_LOGIN_LOCKOUT: &str = "auth.login.lockout";
+
     /// Operator manually injected an event into an accumulator over REST
     /// (CLOACI-T-0753). Like the reactor manual-fire, this bypasses the real
     /// event source, so the audit trail marks it operator-injected.
@@ -436,6 +442,28 @@ pub fn log_accumulator_manual_inject(
         delivered = delivered,
         operator_injected = true,
         "Operator manually injected an accumulator event"
+    );
+}
+
+/// Log a local-login lockout (CLOACI-T-0923, I-0118 OQ-13).
+///
+/// Emitted once, on the lock edge. `throttle_key` is the opaque throttle key
+/// (`u:<tenant>/<username>` or `ip:<source>`) — it is deliberately the same
+/// value the throttle table stores, so an operator can correlate the audit
+/// line with the row, and it carries no credential material.
+pub fn log_login_lockout(
+    throttle_key: &str,
+    scope: &str,
+    failure_count: i32,
+    locked_for_seconds: i64,
+) {
+    tracing::warn!(
+        event_type = events::AUTH_LOGIN_LOCKOUT,
+        throttle_key = %throttle_key,
+        scope = %scope,
+        failure_count = failure_count,
+        locked_for_seconds = locked_for_seconds,
+        "Local login locked out after repeated failures"
     );
 }
 

--- a/docs/content/service/explanation/security-model.md
+++ b/docs/content/service/explanation/security-model.md
@@ -62,6 +62,22 @@ Every authenticated route under `/v1/*` requires an `Authorization: Bearer <key>
 
 The cache is small and short-lived deliberately: it shaves the per-request DB hit at high throughput, but the 30-second TTL bounds how long a revoked key can keep working. Explicit revocation via `DELETE /v1/auth/keys/{key_id}` clears the *entire* cache (not just the revoked entry) so revocation is immediate at the cost of a brief revalidation spike.
 
+#### The 30-second cross-replica revocation window
+
+The cache is **per replica, and only the replica that served the revocation clears it.** There is no cache-invalidation broadcast between replicas. So in a multi-replica deployment:
+
+> A revoked API key may continue to be accepted by *other* replicas for **up to 30 seconds** after revocation. On the replica that handled the `DELETE`, revocation is immediate.
+
+The same bound applies to every other reason a key stops being valid mid-flight — expiry of a minted login key, the rotation half of `POST /v1/auth/refresh`, and the key revocation performed by `POST /v1/auth/logout`. Each is enforced immediately on the acting replica and within the cache TTL everywhere else.
+
+This is a deliberate trade, not an oversight:
+
+- The window is **short and fixed**. It cannot grow with load, replica count, or clock skew between replicas — the TTL is measured from the moment each replica cached the entry.
+- The alternative — validating every request against the database — puts the auth path on the DB for every call on the hottest code path in the server, for a difference of at most 30 seconds in a scenario (compromised key *and* an attacker actively using it in the same half-minute) where the attacker has already had unbounded time before you noticed.
+- A cross-replica invalidation channel (pub/sub, LISTEN/NOTIFY) would buy a smaller window at the cost of a new failure mode: if the channel breaks, revocation silently stops propagating and the window becomes unbounded rather than 30 seconds. A TTL fails safe; a broadcast fails open.
+
+Operationally: when you revoke a key in response to a *confirmed* compromise and need a hard cut-off, wait 30 seconds before declaring the key dead, or restart the replicas (a fresh process has an empty cache). Do not treat revocation as instantaneous across the fleet.
+
 To create, list, and revoke keys in practice, see [Manage API Keys]({{< ref "/service/how-to/manage-api-keys" >}}).
 
 ### Roles vs the `is_admin` god-mode
@@ -99,10 +115,45 @@ In every case the result is an ordinary bearer key; authorization does not care 
 
 Minted keys (local + OIDC) carry an `expires_at` and an `issued_via` provenance (`local:<account_id>` or `oidc:<issuer>:<sub>`); directly-created API keys have neither and never expire.
 
-- **Refresh** — `POST /v1/auth/refresh` re-checks that the underlying account / identity is still valid, mints a fresh key, and revokes the old one. The UI calls this silently before a key's TTL lapses, so a session survives without storing a long-lived credential in the browser. OIDC refresh-token material, when present, is stored server-side encrypted with AES-256-GCM and never returned to the browser.
-- **Logout** — `POST /v1/auth/logout` revokes the caller's key, deletes any server-side refresh session, and clears the auth-cache entry.
+- **Refresh** — `POST /v1/auth/refresh` re-checks that the underlying account / identity is still valid, mints a fresh key, and revokes the old one. The UI calls this silently before a key's TTL lapses, so a session survives without storing a long-lived credential in the browser. Refresh is *authenticated*: it presents the current, still-valid key. A key that has already lapsed cannot be refreshed — the browser must sign in again, which is why the UI refreshes on a timer rather than on demand.
+- **Logout** — `POST /v1/auth/logout` revokes the caller's key, deletes the server-side login session, and clears the auth cache.
 
-OIDC in-flight login state (the `state` / nonce / PKCE verifier between the redirect and the callback) is persisted in Postgres, so the callback can land on any replica — no sticky sessions.
+A refreshed key is **re-minted with exactly the scope the original login resolved to** — tenant and role are read from the stored key record, not from anything the caller sends — and the mint path takes no `is_admin` argument at all. A refresh therefore cannot broaden a session's authority, and god-mode remains unreachable through any login flow.
+
+#### What bounds an OIDC session
+
+Each OIDC sign-in opens a **server-side login session** with an absolute deadline (`CLOACINA_OIDC_SESSION_MAX_AGE_S`, default 8 hours). Refresh rotates the 15-minute key inside that window; it never extends the deadline. Past it, refreshing fails and the user goes through the full OIDC flow again — which re-checks the identity at the IdP *and* re-resolves the current allowlist.
+
+Cloacina deliberately does **not** spend the IdP's own refresh token on each refresh. Doing so would require `offline_access` (not universally granted), would put the IdP on the hot path of every session in the deployment, and would mean taking custody of a long-lived credential — the very thing short-TTL minted keys exist to avoid. The cost of the simpler design is that a user deactivated *at the IdP* keeps their cloacina session until the absolute deadline expires. Deployments where the IdP is the authority on employment status should lower `CLOACINA_OIDC_SESSION_MAX_AGE_S` accordingly (e.g. `3600` for same-hour offboarding); disabling the corresponding local account or revoking the key cuts a session off immediately, subject to the 30-second cross-replica window above.
+
+The `oidc_sessions` table retains an encrypted (AES-256-GCM) column for IdP refresh material for deployments that later opt into token custody; it is unused — and NULL — by default.
+
+OIDC in-flight login state (the `state` / nonce / PKCE verifier between the redirect and the callback) and the login session itself both live in Postgres, so refresh and the callback can land on any replica — no sticky sessions.
+
+### Brute-force defense on password login
+
+`POST /v1/auth/local/login` is unauthenticated by construction and is the one endpoint where an attacker can guess. Argon2id makes each guess expensive *for the server*; it does nothing to limit how many guesses an attacker gets. Failed attempts are therefore counted and locked out.
+
+Counters are **two independent scopes**, and an attempt is refused if either is locked:
+
+| Scope | What it catches | Default threshold |
+|-------|-----------------|-------------------|
+| Username (per tenant) | an attacker rotating source addresses against one account | 5 consecutive failures |
+| Source address | one host spraying many usernames, none of which alone trips | 50 consecutive failures |
+
+Neither scope alone is sufficient — username-only lets a single host walk an entire user list, address-only is defeated by a proxy pool — and a combined `(username, address)` key is worse than either, because it resets for every new source address. The address threshold is an order of magnitude looser so a shared-NAT office does not lock itself out over a handful of typos.
+
+Once locked, the endpoint returns **`429` with a `Retry-After` header** and refuses the attempt *before* checking the password, so a correct guess during the window does not get in. The window is exponential (30 seconds, doubling per further failure, capped at 15 minutes) and lifts by itself — no operator unlock. A successful login clears the username counter, so a legitimate user who eventually remembers their password does not stay one strike from a lockout. Counters idle for 15 minutes are forgotten.
+
+The response never reveals whether an account exists: failures against unknown usernames are counted exactly like real ones (so the `429` arrives on the same attempt either way), and an unknown username pays the same argon2id cost as a wrong password so the two cannot be told apart by timing.
+
+Lockouts emit the `auth.login.lockout` audit event (once per lock, not once per refused attempt) and increment `cloacina_auth_login_lockouts_total{scope}`; every attempt increments `cloacina_auth_login_attempts_total{outcome=ok|denied|throttled}`.
+
+Counters are stored in Postgres, not in each replica's memory, so a lockout is enforced by every replica — an attacker cannot escape one by reconnecting through the load balancer. If the throttle store itself errors, the request is allowed through to the ordinary password check: the throttle is a mitigation, and a database blip must not become a platform-wide lockout.
+
+Tuning knobs: `CLOACINA_LOGIN_THROTTLE_USER_THRESHOLD`, `CLOACINA_LOGIN_THROTTLE_IP_THRESHOLD` (`0` disables the address scope), `CLOACINA_LOGIN_THROTTLE_BASE_LOCK_S`, `CLOACINA_LOGIN_THROTTLE_MAX_LOCK_S`.
+
+> **Behind a reverse proxy**, the socket peer is the proxy for *every* user, so the address scope collapses into one counter covering the whole deployment. Either set `CLOACINA_TRUST_PROXY_HEADERS=1` — only safe when the proxy *overwrites* `X-Forwarded-For` rather than appending to a client-supplied value — so real client addresses are used, or set `CLOACINA_LOGIN_THROTTLE_IP_THRESHOLD=0` and rely on the username scope. `X-Forwarded-For` is not trusted by default because an unauthenticated caller controls it outright: believing it would let an attacker mint a fresh address identity per request and forge failures against someone else's.
 
 ### Multi-tenant individuals
 

--- a/docs/static/openapi.json
+++ b/docs/static/openapi.json
@@ -327,6 +327,16 @@
               }
             }
           },
+          "429": {
+            "description": "Too many failed attempts — throttled; see Retry-After",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            }
+          },
           "500": {
             "description": "Internal error",
             "content": {
@@ -405,7 +415,7 @@
             }
           },
           "401": {
-            "description": "Invalid key, or the login is no longer valid",
+            "description": "Invalid key, the account is disabled, or the login session has passed its absolute deadline",
             "content": {
               "application/json": {
                 "schema": {


### PR DESCRIPTION
## Summary

The two auth-lifecycle gaps from the deep dive (CLOACI-T-0923), plus a pre-existing oracle found while implementing them.

### Item 1 — OIDC sessions no longer hard-die at 15 minutes

The refresh route's OIDC arm was a flat 501, and the callback stored no session row, so there was nothing to refresh *against* (I-0118 UC2 unfulfilled).

**Design choice: a server-side session record, not custody of the IdP's refresh token.** Taking the token would require `offline_access` (not universally issued), lean on a token endpoint only *recommended* to return a fresh `id_token` on the refresh grant, put the IdP on the hot path (an IdP outage becomes a platform-wide forced logout), and mean holding a long-lived credential — the full token-lifecycle management this ticket explicitly wasn't. Instead the callback opens a session row whose `expires_at` is the **absolute** deadline (default 8h); refresh re-mints within that window, rotates the session onto the new key, revokes the old one, clears the cache.

**Scope can't widen**: it's read from the persisted key row — the durable output of the original allowlist resolution — never from the request, and `mint_for_principal` still takes no `is_admin` parameter at all, so god-mode stays unforgeable by construction. The trade (IdP-side deactivation unnoticed mid-session) is bounded by the deadline and documented. This also revives genuinely dead code: the T-0793 `oidc_sessions` table and DAL had exactly one caller — logout deleting a row nothing ever created.

### Item 2 — local login is throttled (OQ-13, "required before production")

**Dual-keyed, either lock refuses**: a username key (5 strikes) catches IP rotation; an IP key (50) catches one host spraying many usernames. A composite `(username, ip)` key was rejected as *strictly worse* — it resets per source IP and stops neither attack. The IP threshold is 10× looser so shared NAT can't self-lock. 429 + `Retry-After`, 30s→15min backoff, 15min decay; success clears only the username key, since clearing the IP key would let an attacker holding one valid account zero their spray counter. State is persisted so it holds across replicas (the T-0916 lesson). Throttle-store errors **fail open** deliberately — a brute-force mitigation must not become an availability kill-switch.

### Timing oracle closed (pre-existing, found here)

`local_accounts::authenticate` returned immediately for unknown usernames while a wrong password paid full argon2 — a reliable username-enumeration oracle. It now burns an equivalent verify against a per-process decoy hash, and unknown-username failures are throttled identically so the 429 isn't an oracle either. **These must ship together**: unknown usernames now cost real CPU, and the throttle is what bounds that cost.

## Test plan
- 207 server lib tests (9 new: refresh preserves scope and asserts `is_admin=false` via `whoami`, old-key rotation, absolute-deadline stop, expired-key and no-session refresh, lockout blocks a correct password then expires, success clears the counter, two-handle shared state, unknown-username parity, IP spray)
- 738 cloacina lib tests (7 new throttle-DAL, including the two-handle test)
- `openapi.json` re-emitted + TS client regenerated (`check:generated` clean) — login gained a documented 429
- Migrations 046 (postgres-only; the auth strand is postgres-only) and 047 (both backends, since the throttle DAL is unified)

## Also
Documents the 30s cross-replica key-revocation window in the security model — deliberately documentation-only, per the deep dive's judgment that the TTL is a sound trade.

## Residuals
No `oidc_sessions` sweeper (opportunistic prune, same as `ws_tickets`); IP-scope defaults want a soak check; nothing warns at boot if a proxy deployment sets neither `CLOACINA_TRUST_PROXY_HEADERS` nor an IP threshold of 0. Separately noted: `clients/typescript/package-lock.json` has pre-existing version drift (0.7.0 vs 0.10.0) — left alone here, deserves its own ticket.