### PR TITLE
fix(T-0926): persist the cron recovery attempt cap and CAS the recovery claim

### DIFF
--- a/crates/cloacina/src/cron_recovery.rs
+++ b/crates/cloacina/src/cron_recovery.rs
@@ -46,13 +46,30 @@
 //! - The schedule has been deleted
 //! - Too many recovery attempts have been made
 //! - The execution is too old (beyond recovery window)
+//! - Another recovery service already owns the handoff
+//!
+//! # Ownership and accounting (CLOACI-T-0926)
+//!
+//! Both live on the `schedule_executions` row, not in this process:
+//!
+//! * `recovery_attempts` is the attempt cap. It used to be an in-process
+//!   `HashMap`, so a schedule that reliably failed recovery got a fresh budget
+//!   on every restart.
+//! * `recovery_claimed_by` / `recovery_heartbeat_at` are a compare-and-set
+//!   claim. `find_lost_executions` is a plain SELECT, so every replica sees
+//!   the same lost rows; the claim is what makes exactly one of them re-fire.
+//!   Because a re-fire blocks for the workflow's whole (unbounded) duration,
+//!   the owner beats the claim while it works instead of relying on a fixed
+//!   expiry window — a stale beat is then a true death signal, so a crashed
+//!   recovery service's claim is taken over rather than held forever.
 
 use crate::context::Context;
+use crate::dal::unified::{RecoveryClaimResult, RecoveryHeartbeatResult};
 use crate::dal::DAL;
+use crate::database::UniversalUuid;
 use crate::executor::{WorkflowExecutionError, WorkflowExecutor};
 use crate::models::schedule::ScheduleExecution;
 use chrono::Utc;
-use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::watch;
@@ -71,6 +88,13 @@ pub struct CronRecoveryConfig {
     pub max_recovery_attempts: usize,
     /// Whether to recover executions for disabled schedules
     pub recover_disabled_schedules: bool,
+    /// How often the owner of a recovery claim refreshes its heartbeat while
+    /// the re-fire is in flight (CLOACI-T-0926). Must be comfortably smaller
+    /// than `claim_stale_after`.
+    pub claim_heartbeat_interval: Duration,
+    /// How long a recovery claim may go without a heartbeat before another
+    /// recovery service may take it over (CLOACI-T-0926).
+    pub claim_stale_after: Duration,
 }
 
 impl Default for CronRecoveryConfig {
@@ -81,6 +105,8 @@ impl Default for CronRecoveryConfig {
             max_recovery_age: Duration::from_secs(86400), // 24 hours
             max_recovery_attempts: 3,
             recover_disabled_schedules: false,
+            claim_heartbeat_interval: Duration::from_secs(30),
+            claim_stale_after: Duration::from_secs(120),
         }
     }
 }
@@ -95,8 +121,12 @@ pub struct CronRecoveryService {
     executor: Arc<dyn WorkflowExecutor>,
     config: CronRecoveryConfig,
     shutdown: watch::Receiver<bool>,
-    /// Tracks recovery attempts per execution ID
-    recovery_attempts: Arc<tokio::sync::Mutex<HashMap<crate::database::UniversalUuid, usize>>>,
+    /// Identity this service writes into `schedule_executions.recovery_claimed_by`
+    /// when it wins the CAS for a lost handoff (CLOACI-T-0926). Fresh per
+    /// service instance, exactly like a runner id for task claiming — the
+    /// durable state that must survive a restart is the attempt count, which
+    /// lives on the row, not this.
+    owner_id: UniversalUuid,
 }
 
 impl CronRecoveryService {
@@ -118,7 +148,7 @@ impl CronRecoveryService {
             executor,
             config,
             shutdown,
-            recovery_attempts: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+            owner_id: UniversalUuid::new_v4(),
         }
     }
 
@@ -251,7 +281,8 @@ impl CronRecoveryService {
                                 execution.id, e
                             );
                         }
-                        self.recovery_attempts.lock().await.remove(&execution.id);
+                        // No attempt bookkeeping to clear: the count lives on
+                        // the row, and the row just left the lost set for good.
                         return Ok(());
                     }
                     _ => {
@@ -305,18 +336,122 @@ impl CronRecoveryService {
             return Ok(());
         }
 
-        // Check recovery attempts
-        let mut attempts = self.recovery_attempts.lock().await;
-        let attempt_count = attempts.entry(execution.id).or_insert(0);
-        *attempt_count += 1;
+        // CLOACI-T-0926: take exclusive ownership of this handoff before doing
+        // anything that fires a workflow. Without the CAS, every replica's
+        // recovery service saw the same row from `find_lost_executions` and
+        // each one re-fired it.
+        match self
+            .dal
+            .schedule_execution()
+            .claim_for_recovery(execution.id, self.owner_id, self.config.claim_stale_after)
+            .await
+        {
+            Ok(RecoveryClaimResult::Claimed) => {}
+            Ok(RecoveryClaimResult::NotClaimed) => {
+                debug!(
+                    "Execution {} is owned by another recovery service (or already completed); skipping",
+                    execution.id
+                );
+                return Ok(());
+            }
+            Err(e) => {
+                // Fail toward "no duplicate", same as the unreadable-link case
+                // above: if we cannot establish ownership, do not fire.
+                warn!(
+                    "Failed to claim execution {} for recovery; skipping this pass: {}",
+                    execution.id, e
+                );
+                return Ok(());
+            }
+        }
 
-        if *attempt_count > self.config.max_recovery_attempts {
+        // From here on we own the row, so every exit path must release it.
+        let outcome = self.recover_claimed_execution(execution).await;
+
+        if let Err(e) = self
+            .dal
+            .schedule_execution()
+            .release_recovery_claim(execution.id, self.owner_id)
+            .await
+        {
+            // Not fatal: the claim heartbeat stops with this pass, so the claim
+            // goes stale and the next sweep can take it over.
+            warn!(
+                "Failed to release recovery claim on execution {}: {}",
+                execution.id, e
+            );
+        }
+
+        outcome
+    }
+
+    /// Recovery body that runs while this service holds the row's recovery
+    /// claim. Split out so `recover_execution` can release the claim on every
+    /// exit path (CLOACI-T-0926).
+    async fn recover_claimed_execution(
+        &self,
+        execution: &ScheduleExecution,
+    ) -> Result<(), WorkflowExecutionError> {
+        // Re-read under the claim. The row we were handed came from a SELECT
+        // that may predate a concurrent winner's re-fire; if it has since been
+        // linked, that winner already fired and this pass must not.
+        match self.dal.schedule_execution().get_by_id(execution.id).await {
+            Ok(fresh) => {
+                if fresh.workflow_execution_id.is_some() || fresh.completed_at.is_some() {
+                    debug!(
+                        "Execution {} was linked/completed by another recovery pass; skipping",
+                        execution.id
+                    );
+                    return Ok(());
+                }
+            }
+            Err(e) => {
+                warn!(
+                    "Failed to re-read execution {} under its recovery claim; skipping: {}",
+                    execution.id, e
+                );
+                return Ok(());
+            }
+        }
+
+        // CLOACI-T-0926: the attempt count lives on the audit row, so a
+        // schedule that reliably fails recovery cannot earn a fresh budget by
+        // bouncing the process. Increment first, then compare — preserving the
+        // pre-existing semantics where attempts 1..=max fire and the next one
+        // abandons, and where a disabled schedule still consumes an attempt.
+        let attempt_count = match self
+            .dal
+            .schedule_execution()
+            .increment_recovery_attempts(execution.id)
+            .await
+        {
+            Ok(count) => count,
+            Err(e) => {
+                // Fail toward "no duplicate": an unrecorded attempt is an
+                // uncapped attempt.
+                warn!(
+                    "Failed to record a recovery attempt for execution {}; skipping this pass: {}",
+                    execution.id, e
+                );
+                return Ok(());
+            }
+        };
+
+        if attempt_count as usize > self.config.max_recovery_attempts {
             error!(
                 "Execution {} has exceeded max recovery attempts ({}), abandoning",
                 execution.id, self.config.max_recovery_attempts
             );
             return Ok(());
         }
+
+        // `scheduled_time` was already resolved by the caller; recompute here
+        // so the recovery context carries the same value.
+        let scheduled_time = execution
+            .scheduled_time
+            .as_ref()
+            .map(|t| t.0)
+            .unwrap_or(execution.created_at.0);
 
         info!(
             "Attempting recovery of execution {} (schedule: {}, attempt: {}/{})",
@@ -404,6 +539,12 @@ impl CronRecoveryService {
             schedule.workflow_name, execution.id, schedule.id
         );
 
+        // `execute` blocks for the workflow's full duration, which is
+        // unbounded. Beat the claim while we wait so another recovery service
+        // never mistakes a long re-fire for a dead one and steals the row
+        // (CLOACI-T-0926). The guard aborts the beat on every exit path.
+        let _heartbeat = self.spawn_claim_heartbeat(execution.id);
+
         match self
             .executor
             .execute(&schedule.workflow_name, context)
@@ -449,8 +590,21 @@ impl CronRecoveryService {
                     execution.id, workflow_result.execution_id
                 );
 
-                // Clear recovery attempts on success
-                attempts.remove(&execution.id);
+                // Clear recovery attempts on success. Durable equivalent of
+                // the old in-memory `attempts.remove(...)`: the row is complete
+                // so it will not be swept again, but leaving a spent budget on
+                // it would misreport the handoff's history.
+                if let Err(e) = self
+                    .dal
+                    .schedule_execution()
+                    .reset_recovery_attempts(execution.id)
+                    .await
+                {
+                    warn!(
+                        "Failed to reset recovery attempts for execution {}: {}",
+                        execution.id, e
+                    );
+                }
 
                 Ok(())
             }
@@ -464,23 +618,91 @@ impl CronRecoveryService {
         }
     }
 
-    /// Clears the recovery attempts cache.
+    /// Spawns the claim heartbeat for an in-flight re-fire.
     ///
-    /// This can be useful for testing or when you want to retry
-    /// previously abandoned executions.
-    pub async fn clear_recovery_attempts(&self) {
-        let mut attempts = self.recovery_attempts.lock().await;
-        attempts.clear();
-        info!("Cleared recovery attempts cache");
+    /// Returns a guard that aborts the beat when dropped, so the claim starts
+    /// ageing the moment this recovery pass leaves the executor — whether it
+    /// returned, errored, or the whole service was dropped.
+    fn spawn_claim_heartbeat(&self, execution_id: UniversalUuid) -> ClaimHeartbeat {
+        let dal = self.dal.clone();
+        let owner_id = self.owner_id;
+        let interval = self.config.claim_heartbeat_interval;
+
+        ClaimHeartbeat(tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(interval);
+            ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            // The claim was written moments ago; skip the immediate first tick.
+            ticker.tick().await;
+
+            loop {
+                ticker.tick().await;
+                match dal
+                    .schedule_execution()
+                    .recovery_heartbeat(execution_id, owner_id)
+                    .await
+                {
+                    Ok(RecoveryHeartbeatResult::Ok) => {}
+                    Ok(RecoveryHeartbeatResult::ClaimLost) => {
+                        warn!(
+                            "Recovery claim on execution {} was taken over while the re-fire was still running",
+                            execution_id
+                        );
+                        break;
+                    }
+                    Err(e) => {
+                        warn!(
+                            "Failed to beat the recovery claim on execution {}: {}",
+                            execution_id, e
+                        );
+                    }
+                }
+            }
+        }))
     }
 
-    /// Gets the current recovery attempts for an execution.
-    pub async fn get_recovery_attempts(
+    /// Clears the durable recovery attempt count for one execution.
+    ///
+    /// Useful for testing, or for an operator who wants to give a previously
+    /// abandoned handoff a fresh budget. CLOACI-T-0926 moved the count from
+    /// process memory onto the audit row, so this now takes the execution to
+    /// reset rather than wiping a process-local cache.
+    pub async fn clear_recovery_attempts(
         &self,
-        execution_id: crate::database::UniversalUuid,
-    ) -> usize {
-        let attempts = self.recovery_attempts.lock().await;
-        attempts.get(&execution_id).copied().unwrap_or(0)
+        execution_id: UniversalUuid,
+    ) -> Result<(), crate::error::ValidationError> {
+        self.dal
+            .schedule_execution()
+            .reset_recovery_attempts(execution_id)
+            .await?;
+        info!("Cleared recovery attempts for execution {}", execution_id);
+        Ok(())
+    }
+
+    /// Gets the durable recovery attempt count for an execution.
+    ///
+    /// Returns 0 if the row cannot be read; callers use this for reporting,
+    /// never as the cap check (the cap reads the value inside the same
+    /// claimed critical section that increments it).
+    pub async fn get_recovery_attempts(&self, execution_id: UniversalUuid) -> usize {
+        match self.dal.schedule_execution().get_by_id(execution_id).await {
+            Ok(row) => row.recovery_attempts.max(0) as usize,
+            Err(e) => {
+                warn!(
+                    "Failed to read recovery attempts for execution {}: {}",
+                    execution_id, e
+                );
+                0
+            }
+        }
+    }
+}
+
+/// Abort-on-drop handle for a recovery claim heartbeat task (CLOACI-T-0926).
+struct ClaimHeartbeat(tokio::task::JoinHandle<()>);
+
+impl Drop for ClaimHeartbeat {
+    fn drop(&mut self) {
+        self.0.abort();
     }
 }
 
@@ -496,6 +718,11 @@ mod tests {
         assert_eq!(config.max_recovery_age, Duration::from_secs(86400));
         assert_eq!(config.max_recovery_attempts, 3);
         assert!(!config.recover_disabled_schedules);
+        // The heartbeat must beat several times inside the staleness window,
+        // or a healthy owner would look dead (CLOACI-T-0926).
+        assert!(config.claim_heartbeat_interval < config.claim_stale_after);
+        assert_eq!(config.claim_heartbeat_interval, Duration::from_secs(30));
+        assert_eq!(config.claim_stale_after, Duration::from_secs(120));
     }
 
     #[test]
@@ -506,6 +733,8 @@ mod tests {
             max_recovery_age: Duration::from_secs(3600),
             max_recovery_attempts: 5,
             recover_disabled_schedules: true,
+            claim_heartbeat_interval: Duration::from_secs(5),
+            claim_stale_after: Duration::from_secs(20),
         };
 
         assert_eq!(config.check_interval, Duration::from_secs(60));

--- a/crates/cloacina/src/dal/unified/mod.rs
+++ b/crates/cloacina/src/dal/unified/mod.rs
@@ -98,7 +98,9 @@ pub use reactor_subscriptions::{
 };
 pub use recovery_event::RecoveryEventDAL;
 pub use schedule::ScheduleDAL;
-pub use schedule_execution::{ScheduleExecutionDAL, ScheduleExecutionStats};
+pub use schedule_execution::{
+    RecoveryClaimResult, RecoveryHeartbeatResult, ScheduleExecutionDAL, ScheduleExecutionStats,
+};
 pub use task_execution::{RetryStats, TaskExecutionDAL};
 pub use task_execution_metadata::TaskExecutionMetadataDAL;
 pub use workflow_execution::WorkflowExecutionDAL;

--- a/crates/cloacina/src/dal/unified/models.rs
+++ b/crates/cloacina/src/dal/unified/models.rs
@@ -452,6 +452,12 @@ pub struct UnifiedScheduleExecution {
     pub completed_at: Option<UniversalTimestamp>,
     pub created_at: UniversalTimestamp,
     pub updated_at: UniversalTimestamp,
+    /// CLOACI-T-0926: durable recovery attempt count for this handoff.
+    pub recovery_attempts: i32,
+    /// CLOACI-T-0926: recovery service that owns the re-fire of this handoff.
+    pub recovery_claimed_by: Option<UniversalUuid>,
+    /// CLOACI-T-0926: last liveness beat from the claim owner.
+    pub recovery_heartbeat_at: Option<UniversalTimestamp>,
 }
 
 #[derive(Debug, Insertable)]
@@ -1030,6 +1036,9 @@ impl From<UnifiedScheduleExecution> for ScheduleExecution {
             completed_at: u.completed_at,
             created_at: u.created_at,
             updated_at: u.updated_at,
+            recovery_attempts: u.recovery_attempts,
+            recovery_claimed_by: u.recovery_claimed_by,
+            recovery_heartbeat_at: u.recovery_heartbeat_at,
         }
     }
 }

--- a/crates/cloacina/src/dal/unified/schedule_execution/mod.rs
+++ b/crates/cloacina/src/dal/unified/schedule_execution/mod.rs
@@ -44,6 +44,27 @@ pub struct ScheduleExecutionStats {
     pub success_rate: f64,
 }
 
+/// Outcome of a compare-and-set attempt to own the recovery of a lost handoff.
+///
+/// CLOACI-T-0926. Mirrors `RunnerClaimResult` in the task-claiming DAL: the
+/// claim is a single conditional UPDATE and `rows_updated == 1` is the winner.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RecoveryClaimResult {
+    /// This caller now owns the re-fire of the handoff.
+    Claimed,
+    /// Another recovery service owns it (or the row left the lost set).
+    NotClaimed,
+}
+
+/// Outcome of a recovery claim heartbeat.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RecoveryHeartbeatResult {
+    /// The claim is still ours.
+    Ok,
+    /// Another recovery service took the claim over (ours went stale).
+    ClaimLost,
+}
+
 /// Data access layer for unified schedule execution operations with runtime backend selection.
 #[derive(Clone)]
 pub struct ScheduleExecutionDAL<'a> {
@@ -197,6 +218,170 @@ impl<'a> ScheduleExecutionDAL<'a> {
             })?;
 
         Ok(results.into_iter().map(|r| r.into()).collect())
+    }
+
+    // ========================================================================
+    // Recovery ownership + accounting (CLOACI-T-0926)
+    // ========================================================================
+
+    /// Atomically claim a lost handoff for recovery by `owner_id`.
+    ///
+    /// `find_lost_executions` is a plain SELECT, so every replica's recovery
+    /// service sees the same lost rows. This compare-and-set is what makes
+    /// exactly one of them re-fire, in the same shape as
+    /// `TaskExecutionDAL::claim_for_runner`: one conditional UPDATE,
+    /// `rows_updated == 1` wins.
+    ///
+    /// The claim succeeds when the row is still open AND either unclaimed or
+    /// held by an owner whose heartbeat went stale. Two guards matter:
+    ///
+    /// * `completed_at IS NULL` is part of the CAS, not a pre-check. A loser
+    ///   that selected the row before the winner finished still holds a stale
+    ///   snapshot; without this predicate it would claim the (now completed)
+    ///   row after the winner released it and re-fire — the duplicate this is
+    ///   here to prevent.
+    /// * the staleness arm uses the heartbeat, not the claim time. A re-fire
+    ///   blocks for the workflow's full (unbounded) duration, so a fixed
+    ///   claim-age window would expire mid-execution and hand the row to a
+    ///   second service. The owner beats while it works, so a stale beat is a
+    ///   true death signal and a crashed service never locks a handoff
+    ///   permanently.
+    pub async fn claim_for_recovery(
+        &self,
+        id: UniversalUuid,
+        owner_id: UniversalUuid,
+        stale_after: std::time::Duration,
+    ) -> Result<RecoveryClaimResult, ValidationError> {
+        let now = UniversalTimestamp::now();
+        let cutoff = UniversalTimestamp(
+            Utc::now() - Duration::from_std(stale_after).unwrap_or_else(|_| Duration::seconds(120)),
+        );
+
+        let rows_updated: usize = crate::interact_on_backend!(self.dal, |conn| {
+            diesel::update(
+                schedule_executions::table
+                    .find(id)
+                    .filter(schedule_executions::completed_at.is_null())
+                    .filter(
+                        schedule_executions::recovery_claimed_by
+                            .is_null()
+                            .or(schedule_executions::recovery_heartbeat_at.lt(Some(cutoff))),
+                    ),
+            )
+            .set((
+                schedule_executions::recovery_claimed_by.eq(Some(owner_id)),
+                schedule_executions::recovery_heartbeat_at.eq(Some(now)),
+                schedule_executions::updated_at.eq(now),
+            ))
+            .execute(conn)
+        })?;
+
+        Ok(if rows_updated > 0 {
+            RecoveryClaimResult::Claimed
+        } else {
+            RecoveryClaimResult::NotClaimed
+        })
+    }
+
+    /// Refresh the recovery claim heartbeat, only while we still own it.
+    pub async fn recovery_heartbeat(
+        &self,
+        id: UniversalUuid,
+        owner_id: UniversalUuid,
+    ) -> Result<RecoveryHeartbeatResult, ValidationError> {
+        let now = UniversalTimestamp::now();
+        let rows_updated: usize = crate::interact_on_backend!(self.dal, |conn| {
+            diesel::update(
+                schedule_executions::table
+                    .find(id)
+                    .filter(schedule_executions::recovery_claimed_by.eq(Some(owner_id))),
+            )
+            .set((
+                schedule_executions::recovery_heartbeat_at.eq(Some(now)),
+                schedule_executions::updated_at.eq(now),
+            ))
+            .execute(conn)
+        })?;
+
+        Ok(if rows_updated > 0 {
+            RecoveryHeartbeatResult::Ok
+        } else {
+            RecoveryHeartbeatResult::ClaimLost
+        })
+    }
+
+    /// Release a recovery claim we hold. No-op if someone else owns it now.
+    pub async fn release_recovery_claim(
+        &self,
+        id: UniversalUuid,
+        owner_id: UniversalUuid,
+    ) -> Result<(), ValidationError> {
+        let now = UniversalTimestamp::now();
+        crate::interact_on_backend!(self.dal, |conn| {
+            diesel::update(
+                schedule_executions::table
+                    .find(id)
+                    .filter(schedule_executions::recovery_claimed_by.eq(Some(owner_id))),
+            )
+            .set((
+                schedule_executions::recovery_claimed_by.eq(None::<UniversalUuid>),
+                schedule_executions::recovery_heartbeat_at.eq(None::<UniversalTimestamp>),
+                schedule_executions::updated_at.eq(now),
+            ))
+            .execute(conn)
+        })?;
+
+        Ok(())
+    }
+
+    /// Increment the durable recovery attempt count and return the new value.
+    ///
+    /// The count lives on the audit row (not in the recovery service's memory)
+    /// so a schedule that reliably fails recovery cannot earn a fresh budget by
+    /// bouncing the process. Callers hold the recovery claim, so the read-back
+    /// is not racing another attempt; the increment itself is still done
+    /// in-SQL and inside a transaction so the value can never regress.
+    pub async fn increment_recovery_attempts(
+        &self,
+        id: UniversalUuid,
+    ) -> Result<i32, ValidationError> {
+        use diesel::connection::Connection;
+
+        let attempts: i32 = crate::interact_on_backend!(self.dal, |conn| {
+            conn.transaction::<_, diesel::result::Error, _>(|conn| {
+                let now = UniversalTimestamp::now();
+                diesel::update(schedule_executions::table.find(id))
+                    .set((
+                        schedule_executions::recovery_attempts
+                            .eq(schedule_executions::recovery_attempts + 1),
+                        schedule_executions::updated_at.eq(now),
+                    ))
+                    .execute(conn)?;
+
+                schedule_executions::table
+                    .find(id)
+                    .select(schedule_executions::recovery_attempts)
+                    .first(conn)
+            })
+        })?;
+
+        Ok(attempts)
+    }
+
+    /// Reset the durable recovery attempt count (used after a successful
+    /// re-fire, the durable equivalent of clearing the old in-memory entry).
+    pub async fn reset_recovery_attempts(&self, id: UniversalUuid) -> Result<(), ValidationError> {
+        let now = UniversalTimestamp::now();
+        crate::interact_on_backend!(self.dal, |conn| {
+            diesel::update(schedule_executions::table.find(id))
+                .set((
+                    schedule_executions::recovery_attempts.eq(0),
+                    schedule_executions::updated_at.eq(now),
+                ))
+                .execute(conn)
+        })?;
+
+        Ok(())
     }
 
     /// Gets the latest execution for a given schedule.
@@ -616,6 +801,168 @@ mod tests {
             .await
             .unwrap();
         assert!(lost.is_empty());
+    }
+
+    // ── recovery claim + attempt accounting (CLOACI-T-0926) ─────────
+
+    #[cfg(feature = "sqlite")]
+    #[tokio::test]
+    async fn test_recovery_claim_is_exclusive() {
+        let dal = unique_dal().await;
+        let sched_id = create_schedule(&dal).await;
+        let exec = dal
+            .schedule_execution()
+            .create(new_exec(sched_id))
+            .await
+            .unwrap();
+
+        let a = UniversalUuid::new_v4();
+        let b = UniversalUuid::new_v4();
+        let window = std::time::Duration::from_secs(120);
+
+        assert_eq!(
+            dal.schedule_execution()
+                .claim_for_recovery(exec.id, a, window)
+                .await
+                .unwrap(),
+            RecoveryClaimResult::Claimed
+        );
+        // Second service loses while A's claim is fresh.
+        assert_eq!(
+            dal.schedule_execution()
+                .claim_for_recovery(exec.id, b, window)
+                .await
+                .unwrap(),
+            RecoveryClaimResult::NotClaimed
+        );
+
+        let row = dal.schedule_execution().get_by_id(exec.id).await.unwrap();
+        assert_eq!(row.recovery_claimed_by, Some(a));
+        assert!(row.recovery_heartbeat_at.is_some());
+
+        // B may not release a claim it does not hold.
+        dal.schedule_execution()
+            .release_recovery_claim(exec.id, b)
+            .await
+            .unwrap();
+        let row = dal.schedule_execution().get_by_id(exec.id).await.unwrap();
+        assert_eq!(row.recovery_claimed_by, Some(a));
+
+        dal.schedule_execution()
+            .release_recovery_claim(exec.id, a)
+            .await
+            .unwrap();
+        let row = dal.schedule_execution().get_by_id(exec.id).await.unwrap();
+        assert!(row.recovery_claimed_by.is_none());
+        assert!(row.recovery_heartbeat_at.is_none());
+    }
+
+    #[cfg(feature = "sqlite")]
+    #[tokio::test]
+    async fn test_recovery_claim_rejects_completed_row() {
+        let dal = unique_dal().await;
+        let sched_id = create_schedule(&dal).await;
+        let exec = dal
+            .schedule_execution()
+            .create(new_exec(sched_id))
+            .await
+            .unwrap();
+        dal.schedule_execution()
+            .complete(exec.id, Utc::now())
+            .await
+            .unwrap();
+
+        // `completed_at IS NULL` is part of the CAS: a loser holding a stale
+        // snapshot cannot claim (and then re-fire) a finished handoff.
+        assert_eq!(
+            dal.schedule_execution()
+                .claim_for_recovery(
+                    exec.id,
+                    UniversalUuid::new_v4(),
+                    std::time::Duration::from_secs(120)
+                )
+                .await
+                .unwrap(),
+            RecoveryClaimResult::NotClaimed
+        );
+    }
+
+    #[cfg(feature = "sqlite")]
+    #[tokio::test]
+    async fn test_stale_recovery_claim_can_be_taken_over() {
+        let dal = unique_dal().await;
+        let sched_id = create_schedule(&dal).await;
+        let exec = dal
+            .schedule_execution()
+            .create(new_exec(sched_id))
+            .await
+            .unwrap();
+
+        let dead = UniversalUuid::new_v4();
+        let live = UniversalUuid::new_v4();
+        dal.schedule_execution()
+            .claim_for_recovery(exec.id, dead, std::time::Duration::from_secs(120))
+            .await
+            .unwrap();
+
+        // A zero window makes the existing heartbeat stale — what a crashed
+        // owner looks like once `claim_stale_after` has elapsed.
+        assert_eq!(
+            dal.schedule_execution()
+                .claim_for_recovery(exec.id, live, std::time::Duration::ZERO)
+                .await
+                .unwrap(),
+            RecoveryClaimResult::Claimed
+        );
+
+        // The evicted owner's heartbeat no longer lands.
+        assert_eq!(
+            dal.schedule_execution()
+                .recovery_heartbeat(exec.id, dead)
+                .await
+                .unwrap(),
+            RecoveryHeartbeatResult::ClaimLost
+        );
+        assert_eq!(
+            dal.schedule_execution()
+                .recovery_heartbeat(exec.id, live)
+                .await
+                .unwrap(),
+            RecoveryHeartbeatResult::Ok
+        );
+    }
+
+    #[cfg(feature = "sqlite")]
+    #[tokio::test]
+    async fn test_recovery_attempts_are_durable() {
+        let dal = unique_dal().await;
+        let sched_id = create_schedule(&dal).await;
+        let exec = dal
+            .schedule_execution()
+            .create(new_exec(sched_id))
+            .await
+            .unwrap();
+        assert_eq!(exec.recovery_attempts, 0);
+
+        for expected in 1..=3 {
+            assert_eq!(
+                dal.schedule_execution()
+                    .increment_recovery_attempts(exec.id)
+                    .await
+                    .unwrap(),
+                expected
+            );
+        }
+
+        let row = dal.schedule_execution().get_by_id(exec.id).await.unwrap();
+        assert_eq!(row.recovery_attempts, 3);
+
+        dal.schedule_execution()
+            .reset_recovery_attempts(exec.id)
+            .await
+            .unwrap();
+        let row = dal.schedule_execution().get_by_id(exec.id).await.unwrap();
+        assert_eq!(row.recovery_attempts, 0);
     }
 
     // ── get_execution_stats ─────────────────────────────────────────

--- a/crates/cloacina/src/database/migrations/postgres/049_add_recovery_claim_to_schedule_executions/down.sql
+++ b/crates/cloacina/src/database/migrations/postgres/049_add_recovery_claim_to_schedule_executions/down.sql
@@ -1,0 +1,5 @@
+-- Reverse CLOACI-T-0926 durable recovery accounting + CAS claim.
+DROP INDEX IF EXISTS idx_schedule_executions_recovery_claim;
+ALTER TABLE schedule_executions DROP COLUMN recovery_heartbeat_at;
+ALTER TABLE schedule_executions DROP COLUMN recovery_claimed_by;
+ALTER TABLE schedule_executions DROP COLUMN recovery_attempts;

--- a/crates/cloacina/src/database/migrations/postgres/049_add_recovery_claim_to_schedule_executions/up.sql
+++ b/crates/cloacina/src/database/migrations/postgres/049_add_recovery_claim_to_schedule_executions/up.sql
@@ -1,0 +1,36 @@
+-- CLOACI-T-0926: make cron recovery durable and single-owner.
+--
+-- Two residuals from CLOACI-T-0914 (#229), both on the cron recovery path:
+--
+-- 1. The attempt cap lived in `CronRecoveryService.recovery_attempts`, an
+--    in-process HashMap. Every restart handed a reliably-failing schedule a
+--    fresh budget, so "max 3 recovery attempts" was really "max 3 per process
+--    lifetime". `recovery_attempts` persists the count on the audit row
+--    itself. (workflow_executions.recovery_attempts already exists but is
+--    workflow-level — the wrong grain for a schedule handoff.)
+--
+-- 2. `find_lost_executions` is a plain SELECT, so every runner's recovery
+--    service saw the same lost handoff and each one re-fired it. This is the
+--    last duplicate-fire vector after #229 closed the long-running-workflow
+--    case. `recovery_claimed_by` is the CAS claim: exactly one recovery
+--    service flips it from NULL, the losers skip.
+--
+-- The claim carries a HEARTBEAT rather than a fixed expiry window because a
+-- recovery re-fire is NOT short: `WorkflowExecutor::execute` blocks until the
+-- workflow reaches a terminal state, so the claim is held for the workflow's
+-- full duration (unbounded). A static `claimed_at + N minutes` window would
+-- expire mid-execution and let a second service re-fire — reintroducing the
+-- duplicate. `recovery_heartbeat_at` is refreshed while the re-fire runs, so
+-- a stale heartbeat is a true death signal and a crashed recovery service can
+-- never permanently lock a handoff.
+--
+-- ADD COLUMN only; existing rows default to "never attempted, unclaimed".
+ALTER TABLE schedule_executions ADD COLUMN recovery_attempts INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE schedule_executions ADD COLUMN recovery_claimed_by UUID;
+ALTER TABLE schedule_executions ADD COLUMN recovery_heartbeat_at TIMESTAMP;
+
+-- Stale-claim detection during a recovery sweep: open, claimed rows by
+-- heartbeat age.
+CREATE INDEX idx_schedule_executions_recovery_claim
+ON schedule_executions (recovery_heartbeat_at)
+WHERE completed_at IS NULL AND recovery_claimed_by IS NOT NULL;

--- a/crates/cloacina/src/database/migrations/sqlite/049_add_recovery_claim_to_schedule_executions/down.sql
+++ b/crates/cloacina/src/database/migrations/sqlite/049_add_recovery_claim_to_schedule_executions/down.sql
@@ -1,0 +1,5 @@
+-- Reverse CLOACI-T-0926 durable recovery accounting + CAS claim.
+DROP INDEX IF EXISTS idx_schedule_executions_recovery_claim;
+ALTER TABLE schedule_executions DROP COLUMN recovery_heartbeat_at;
+ALTER TABLE schedule_executions DROP COLUMN recovery_claimed_by;
+ALTER TABLE schedule_executions DROP COLUMN recovery_attempts;

--- a/crates/cloacina/src/database/migrations/sqlite/049_add_recovery_claim_to_schedule_executions/up.sql
+++ b/crates/cloacina/src/database/migrations/sqlite/049_add_recovery_claim_to_schedule_executions/up.sql
@@ -1,0 +1,15 @@
+-- CLOACI-T-0926: make cron recovery durable and single-owner.
+-- See the sibling postgres migration 049 for the full rationale.
+--
+-- UUID is stored as BLOB (16 bytes), TIMESTAMP as TEXT (RFC3339) per the
+-- SQLite conventions in 013_unified_schedules.
+--
+-- ADD COLUMN only (constant defaults, so SQLite accepts them in place) — no
+-- table rebuild, per the project's SQLite migration rule.
+ALTER TABLE schedule_executions ADD COLUMN recovery_attempts INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE schedule_executions ADD COLUMN recovery_claimed_by BLOB;
+ALTER TABLE schedule_executions ADD COLUMN recovery_heartbeat_at TEXT;
+
+CREATE INDEX idx_schedule_executions_recovery_claim
+ON schedule_executions (recovery_heartbeat_at)
+WHERE completed_at IS NULL AND recovery_claimed_by IS NOT NULL;

--- a/crates/cloacina/src/database/schema.rs
+++ b/crates/cloacina/src/database/schema.rs
@@ -359,6 +359,14 @@ mod unified_schema {
             completed_at -> Nullable<DbTimestamp>,
             created_at -> DbTimestamp,
             updated_at -> DbTimestamp,
+            /// CLOACI-T-0926 — durable cron-recovery accounting. `recovery_attempts`
+            /// is the per-handoff attempt cap (was an in-process HashMap, so it
+            /// reset on every restart); `recovery_claimed_by` / `recovery_heartbeat_at`
+            /// are the CAS claim that makes exactly one recovery service own a
+            /// given lost handoff.
+            recovery_attempts -> Integer,
+            recovery_claimed_by -> Nullable<DbUuid>,
+            recovery_heartbeat_at -> Nullable<DbTimestamp>,
         }
     }
 

--- a/crates/cloacina/src/models/schedule.rs
+++ b/crates/cloacina/src/models/schedule.rs
@@ -270,6 +270,20 @@ pub struct ScheduleExecution {
     pub completed_at: Option<UniversalTimestamp>,
     pub created_at: UniversalTimestamp,
     pub updated_at: UniversalTimestamp,
+
+    // Recovery accounting (CLOACI-T-0926). These live on the audit row rather
+    // than in the recovery service's process memory so the attempt cap survives
+    // a restart, and so replicas can CAS for ownership of a lost handoff.
+    // `serde(default)` keeps older serialized payloads readable.
+    /// Number of recovery re-fire attempts already spent on this handoff.
+    #[serde(default)]
+    pub recovery_attempts: i32,
+    /// Recovery service instance that currently owns the re-fire, if any.
+    #[serde(default)]
+    pub recovery_claimed_by: Option<UniversalUuid>,
+    /// Last liveness beat from the claim owner; a stale beat frees the claim.
+    #[serde(default)]
+    pub recovery_heartbeat_at: Option<UniversalTimestamp>,
 }
 
 /// Structure for creating new schedule execution records.

--- a/crates/cloacina/src/runner/default_runner/services.rs
+++ b/crates/cloacina/src/runner/default_runner/services.rs
@@ -163,6 +163,11 @@ impl DefaultRunner {
             max_recovery_age: self.config.cron_max_recovery_age(),
             max_recovery_attempts: self.config.cron_max_recovery_attempts(),
             recover_disabled_schedules: false,
+            // CLOACI-T-0926 claim liveness. Not runner-configurable: these are
+            // internal to how the recovery service proves it is still alive
+            // while a re-fire runs, not a scheduling knob.
+            claim_heartbeat_interval: crate::CronRecoveryConfig::default().claim_heartbeat_interval,
+            claim_stale_after: crate::CronRecoveryConfig::default().claim_stale_after,
         };
 
         let dal = DAL::new(self.database.clone());

--- a/crates/cloacina/tests/integration/scheduler/cron_recovery.rs
+++ b/crates/cloacina/tests/integration/scheduler/cron_recovery.rs
@@ -51,17 +51,48 @@ use uuid::Uuid;
 /// fire and creates a REAL `workflow_executions` row (status Completed) so
 /// the recovery service's audit-link write satisfies the FK constraint.
 /// The remaining trait methods are never called by `CronRecoveryService`.
+///
+/// The counter is shared (`Arc`) so two recovery services can be pointed at
+/// one tally — that is how the CLOACI-T-0926 concurrency test proves a lost
+/// handoff is re-fired exactly once across replicas.
 struct CountingExecutor {
     dal: cloacina::dal::DAL,
-    execute_calls: AtomicUsize,
+    execute_calls: Arc<AtomicUsize>,
+    /// Held inside `execute` so a second recovery service gets a turn while
+    /// the first is mid-re-fire — the window the claim has to close.
+    delay: Duration,
+    /// When true, `execute` counts the fire and then fails, leaving the audit
+    /// row lost so the next sweep spends another recovery attempt.
+    fail: bool,
 }
 
 impl CountingExecutor {
     fn new(dal: cloacina::dal::DAL) -> Self {
         Self {
             dal,
-            execute_calls: AtomicUsize::new(0),
+            execute_calls: Arc::new(AtomicUsize::new(0)),
+            delay: Duration::ZERO,
+            fail: false,
         }
+    }
+
+    fn with_counter(dal: cloacina::dal::DAL, counter: Arc<AtomicUsize>) -> Self {
+        Self {
+            execute_calls: counter,
+            ..Self::new(dal)
+        }
+    }
+
+    fn failing(dal: cloacina::dal::DAL) -> Self {
+        Self {
+            fail: true,
+            ..Self::new(dal)
+        }
+    }
+
+    fn delayed(mut self, delay: Duration) -> Self {
+        self.delay = delay;
+        self
     }
 
     fn fires(&self) -> usize {
@@ -83,6 +114,16 @@ impl WorkflowExecutor for CountingExecutor {
         _context: Context<serde_json::Value>,
     ) -> Result<WorkflowExecutionResult, WorkflowExecutionError> {
         self.execute_calls.fetch_add(1, Ordering::SeqCst);
+
+        if !self.delay.is_zero() {
+            tokio::time::sleep(self.delay).await;
+        }
+
+        if self.fail {
+            return Err(WorkflowExecutionError::ExecutionFailed {
+                message: "mock execute: deliberate recovery failure".to_string(),
+            });
+        }
 
         let row = self
             .dal
@@ -180,6 +221,9 @@ fn aged_past_threshold_config() -> CronRecoveryConfig {
         max_recovery_age: Duration::from_secs(86400),
         max_recovery_attempts: 3,
         recover_disabled_schedules: false,
+        // Long enough that no test ever mistakes a live claim for a dead one.
+        claim_heartbeat_interval: Duration::from_secs(30),
+        claim_stale_after: Duration::from_secs(120),
     }
 }
 
@@ -383,5 +427,321 @@ async fn test_genuinely_lost_cron_handoff_is_refired() {
         executor.fires(),
         1,
         "a recovered execution must not be re-fired on subsequent sweeps"
+    );
+}
+
+/// Helper: a lost cron handoff — claimed audit row, never linked, never
+/// completed — for a freshly created schedule. Returns (schedule id, audit id).
+async fn lost_handoff(
+    dal: &cloacina::dal::DAL,
+    workflow_name: &str,
+) -> (
+    cloacina::database::universal_types::UniversalUuid,
+    cloacina::database::universal_types::UniversalUuid,
+) {
+    let schedule = dal
+        .schedule()
+        .create(NewSchedule::cron(
+            workflow_name,
+            "*/15 * * * *",
+            UniversalTimestamp(Utc::now()),
+        ))
+        .await
+        .expect("create schedule");
+
+    let audit = dal
+        .schedule_execution()
+        .create(NewScheduleExecution {
+            schedule_id: schedule.id,
+            workflow_execution_id: None,
+            scheduled_time: Some(UniversalTimestamp(Utc::now())),
+            claimed_at: Some(UniversalTimestamp(Utc::now())),
+            context_hash: None,
+        })
+        .await
+        .expect("create schedule_execution");
+
+    (schedule.id, audit.id)
+}
+
+/// CLOACI-T-0926 item 1: the recovery attempt cap must survive a restart.
+///
+/// The cap used to be an `Arc<Mutex<HashMap<..>>>` on `CronRecoveryService`,
+/// so a schedule that reliably failed recovery got a fresh budget every time
+/// the process bounced — "max 3 attempts" was really "max 3 per process".
+/// The count now lives on the audit row: a brand-new service instance against
+/// the same database sees the spent budget and abandons instead of re-firing.
+#[tokio::test]
+#[serial]
+async fn test_recovery_attempt_cap_survives_restart() {
+    let fixture = get_or_init_fixture().await;
+    let mut fixture = fixture.lock().unwrap_or_else(|e| e.into_inner());
+    fixture.reset_database().await;
+    fixture.initialize().await;
+    let dal = fixture.get_dal();
+
+    let (_schedule_id, audit_id) = lost_handoff(&dal, "t0926-cap-survives-restart").await;
+
+    let config = aged_past_threshold_config();
+    let max_attempts = config.max_recovery_attempts;
+
+    // ── Process 1: burn the whole budget on a re-fire that keeps failing.
+    let executor1 = Arc::new(CountingExecutor::failing(fixture.get_dal()));
+    let (_tx1, rx1) = watch::channel(false);
+    let recovery1 = CronRecoveryService::new(
+        Arc::new(fixture.get_dal()),
+        executor1.clone(),
+        config.clone(),
+        rx1,
+    );
+
+    for _ in 0..max_attempts {
+        // The failing executor makes each pass return Err from
+        // `recover_execution`; `check_and_recover_lost_executions` logs and
+        // keeps going, so the pass itself still succeeds.
+        recovery1
+            .recover_lost_executions_once()
+            .await
+            .expect("recovery pass");
+    }
+
+    assert_eq!(
+        executor1.fires(),
+        max_attempts,
+        "the first process should spend exactly the configured budget"
+    );
+
+    let row = dal
+        .schedule_execution()
+        .get_by_id(audit_id)
+        .await
+        .expect("re-read audit row");
+    assert_eq!(
+        row.recovery_attempts, max_attempts as i32,
+        "the attempt count must be persisted on the audit row, not in process memory"
+    );
+    assert!(
+        row.recovery_claimed_by.is_none(),
+        "a finished recovery pass must leave the claim released"
+    );
+    assert!(
+        row.completed_at.is_none() && row.workflow_execution_id.is_none(),
+        "a failed re-fire leaves the handoff lost — this is what makes it eligible again"
+    );
+
+    // ── Restart: a brand-new service instance, same database. Before
+    // CLOACI-T-0926 this reset the budget to zero and re-fired.
+    let executor2 = Arc::new(CountingExecutor::failing(fixture.get_dal()));
+    let (_tx2, rx2) = watch::channel(false);
+    let recovery2 = CronRecoveryService::new(
+        Arc::new(fixture.get_dal()),
+        executor2.clone(),
+        config.clone(),
+        rx2,
+    );
+
+    recovery2
+        .recover_lost_executions_once()
+        .await
+        .expect("post-restart recovery pass");
+
+    assert_eq!(
+        executor2.fires(),
+        0,
+        "a restarted recovery service must not get a fresh attempt budget"
+    );
+
+    // The abandoned pass still records that it looked, so the budget can only
+    // move in one direction.
+    let row = dal
+        .schedule_execution()
+        .get_by_id(audit_id)
+        .await
+        .expect("re-read audit row after restart");
+    assert!(
+        row.recovery_attempts > max_attempts as i32,
+        "the persisted count must keep climbing past the cap, never reset"
+    );
+
+    assert_eq!(
+        recovery2.get_recovery_attempts(audit_id).await,
+        row.recovery_attempts as usize,
+        "the service must report the durable count, not a process-local one"
+    );
+}
+
+/// CLOACI-T-0926 item 2: two recovery services against one database must
+/// re-fire a lost handoff exactly once.
+///
+/// `find_lost_executions` is a plain SELECT, so both services see the same
+/// row. The CAS claim on `schedule_executions.recovery_claimed_by` is what
+/// decides ownership — mirroring `claim_for_runner` for task claiming and the
+/// per-row CAS sweep in CLOACI-T-0916. The mock holds `execute` open long
+/// enough that the loser is guaranteed to reach its claim attempt while the
+/// winner is still mid-re-fire.
+#[tokio::test]
+#[serial]
+async fn test_two_recovery_services_refire_lost_handoff_exactly_once() {
+    let fixture = get_or_init_fixture().await;
+    let mut fixture = fixture.lock().unwrap_or_else(|e| e.into_inner());
+    fixture.reset_database().await;
+    fixture.initialize().await;
+    let dal = fixture.get_dal();
+
+    let (schedule_id, audit_id) = lost_handoff(&dal, "t0926-concurrent-recovery").await;
+
+    // One tally, two services — exactly as if two runners were sweeping.
+    let fires = Arc::new(AtomicUsize::new(0));
+
+    let executor_a = Arc::new(
+        CountingExecutor::with_counter(fixture.get_dal(), fires.clone())
+            .delayed(Duration::from_millis(250)),
+    );
+    let executor_b = Arc::new(
+        CountingExecutor::with_counter(fixture.get_dal(), fires.clone())
+            .delayed(Duration::from_millis(250)),
+    );
+
+    let (_tx_a, rx_a) = watch::channel(false);
+    let (_tx_b, rx_b) = watch::channel(false);
+    let recovery_a = CronRecoveryService::new(
+        Arc::new(fixture.get_dal()),
+        executor_a.clone(),
+        aged_past_threshold_config(),
+        rx_a,
+    );
+    let recovery_b = CronRecoveryService::new(
+        Arc::new(fixture.get_dal()),
+        executor_b.clone(),
+        aged_past_threshold_config(),
+        rx_b,
+    );
+
+    let (a, b) = tokio::join!(
+        recovery_a.recover_lost_executions_once(),
+        recovery_b.recover_lost_executions_once(),
+    );
+    a.expect("recovery pass A");
+    b.expect("recovery pass B");
+
+    assert_eq!(
+        fires.load(Ordering::SeqCst),
+        1,
+        "two concurrent recovery services must re-fire a lost handoff exactly once"
+    );
+
+    let executions = dal
+        .schedule_execution()
+        .list_by_schedule(schedule_id, 100, 0)
+        .await
+        .expect("list schedule executions");
+    assert_eq!(executions.len(), 1, "no second audit row may be created");
+
+    let row = dal
+        .schedule_execution()
+        .get_by_id(audit_id)
+        .await
+        .expect("re-read audit row");
+    assert!(
+        row.workflow_execution_id.is_some(),
+        "the winning service must link the audit row"
+    );
+    assert!(
+        row.completed_at.is_some(),
+        "the winning service must complete the audit row"
+    );
+    assert!(
+        row.recovery_claimed_by.is_none(),
+        "the winner must release its claim when the pass ends"
+    );
+    assert_eq!(
+        row.recovery_attempts, 0,
+        "a successful re-fire resets the durable attempt budget"
+    );
+
+    // A further sweep by either service must not fire again.
+    recovery_b
+        .recover_lost_executions_once()
+        .await
+        .expect("follow-up recovery pass");
+    assert_eq!(
+        fires.load(Ordering::SeqCst),
+        1,
+        "a recovered handoff must not be re-fired on subsequent sweeps"
+    );
+}
+
+/// A crashed recovery service must not lock a handoff forever. Its claim is
+/// only as good as its heartbeat: once the beat goes stale, the next sweep
+/// takes the row over. Simulated by writing a claim with an ancient heartbeat
+/// (what a crashed owner leaves behind) and running a service whose staleness
+/// window has already elapsed.
+#[tokio::test]
+#[serial]
+async fn test_stale_recovery_claim_is_taken_over() {
+    let fixture = get_or_init_fixture().await;
+    let mut fixture = fixture.lock().unwrap_or_else(|e| e.into_inner());
+    fixture.reset_database().await;
+    fixture.initialize().await;
+    let dal = fixture.get_dal();
+
+    let (_schedule_id, audit_id) = lost_handoff(&dal, "t0926-stale-claim-takeover").await;
+
+    // A dead owner's claim: written, then never beaten again.
+    let dead_owner = cloacina::database::universal_types::UniversalUuid::new_v4();
+    assert!(
+        matches!(
+            dal.schedule_execution()
+                .claim_for_recovery(audit_id, dead_owner, Duration::from_secs(120))
+                .await
+                .expect("dead owner claims"),
+            cloacina::dal::unified::RecoveryClaimResult::Claimed
+        ),
+        "the first claimant wins"
+    );
+
+    // A live service with the same staleness window must NOT steal a fresh
+    // claim — that is the guarantee that keeps a long re-fire safe.
+    let executor = Arc::new(CountingExecutor::new(fixture.get_dal()));
+    let (_tx, rx) = watch::channel(false);
+    let recovery = CronRecoveryService::new(
+        Arc::new(fixture.get_dal()),
+        executor.clone(),
+        aged_past_threshold_config(),
+        rx,
+    );
+    recovery
+        .recover_lost_executions_once()
+        .await
+        .expect("recovery pass against a live claim");
+    assert_eq!(
+        executor.fires(),
+        0,
+        "a live (recently beaten) claim must not be stolen"
+    );
+
+    // Now age the claim past the window: zero staleness makes any existing
+    // heartbeat older than the cutoff, which is what a crashed owner looks
+    // like after `claim_stale_after` has elapsed.
+    let mut takeover_config = aged_past_threshold_config();
+    takeover_config.claim_stale_after = Duration::ZERO;
+
+    let executor2 = Arc::new(CountingExecutor::new(fixture.get_dal()));
+    let (_tx2, rx2) = watch::channel(false);
+    let recovery2 = CronRecoveryService::new(
+        Arc::new(fixture.get_dal()),
+        executor2.clone(),
+        takeover_config,
+        rx2,
+    );
+    recovery2
+        .recover_lost_executions_once()
+        .await
+        .expect("recovery pass against a stale claim");
+
+    assert_eq!(
+        executor2.fires(),
+        1,
+        "a stale claim must be taken over so a crashed service cannot lock a handoff forever"
     );
 }


### PR DESCRIPTION
## Summary

The two residuals left open when #229 fixed cron duplicate-fires (CLOACI-T-0926).

**Attempt cap is now durable.** It was an in-memory `HashMap` on `CronRecoveryService`, reset on every restart, so a schedule that reliably fails recovery got a fresh budget after each bounce. The counter now lives only on the row (`schedule_executions.recovery_attempts`, migration 049, ADD COLUMN, both backends). The in-memory map is **deleted outright** rather than kept as a cache — a cache would need invalidating by the other replica's writes and buys nothing, since the increment is a single UPDATE already inside the claimed critical section.

**Recovery claims are now CAS'd.** `find_lost_executions` is a plain `completed_at IS NULL AND started_at < cutoff` SELECT, so every replica got an identical row set and two services could both re-fire the same handoff. Added `recovery_claimed_by` + `recovery_heartbeat_at` with a claim in the shape of task claiming's `claim_for_runner` (`rows_updated == 1` wins).

### Two design points worth reviewing

- **`completed_at IS NULL` is part of the CAS predicate, not a pre-check.** A loser holding a row snapshot from before the winner finished would otherwise claim the now-completed row after the winner released it — and re-fire it, which is exactly the duplicate this closes.

- **Expiry is a heartbeat, not a fixed window — and this contradicts the ticket's own suggestion.** The ticket (and my brief) supposed "a recovery pass is short, so a simple claim+release or a staleness window is likely enough." That's wrong: `DefaultRunner`'s `WorkflowExecutor::execute` **blocks** until the workflow is terminal, so a re-fire lasts as long as the workflow. A static `claimed_at + N` window would expire mid-execution and hand the row to a second service, recreating the duplicate. The owner spawns an abort-on-drop beat task while it waits, so a stale beat is a true death signal and a crashed service's claim gets taken over rather than held forever.

`recover_execution` was also split so claim release is unconditional on every post-claim exit path, and it re-reads the row under the claim as a second guard against a stale snapshot. #229's semantics are untouched and both its regression tests stay green.

**Public API**: `clear_recovery_attempts()` now takes an execution id and returns `Result` — there's no process-local cache left to wipe. No in-repo callers besides the service; semver-relevant for external crate consumers.

## Test plan
- New integration tests: attempt cap survives a simulated restart (fresh service instance against the same DB doesn't re-fire); two concurrent services re-fire a lost handoff exactly once; a stale claim is taken over
- 4 new sqlite DAL unit tests: claim exclusivity, the completed-row CAS guard, stale takeover, durable increment/reset
- 21 cron integration tests pass against postgres, including both #229 regression tests
- `cargo check` clean both backends; `fmt --check` clean

## Residual (separate ticket material)
`scheduler::cron_basic::test_workflow_instance_register_roundtrip` builds a `DefaultRunner` from the fixture's base URL (public schema) rather than the per-test schema, so `schedules` rows leak between runs and it can fail on a duplicate `idx_schedules_instance_name`. Pre-existing and unrelated to this change.