### PR TITLE
fix(T-0925): scope provider resolution per load instead of a process-global path

### DIFF
--- a/crates/cloacina-python/src/loader.rs
+++ b/crates/cloacina-python/src/loader.rs
@@ -35,6 +35,26 @@ use std::sync::Arc;
 use crate::import_guard::{import_timeout, supervise_import, ImportThreadIdent};
 use crate::runtime_scope::{current_runtime, ScopedRuntime};
 
+/// The provider scope installed on the CALLING thread (CLOACI-T-0925).
+///
+/// The reconciler installs it around a package load — it says which staged
+/// `providers/` tree this package's `cloaca.constructor(from = ..)` calls resolve
+/// against. Imports run on a thread we spawn, and a thread-local does not follow
+/// a thread hop, so we capture it here and re-install it there — the same
+/// treatment `ScopedRuntime` and `ScopedRegistration` already get.
+fn provider_scope_of_caller() -> Option<cloacina::registry::loader::ProviderScope> {
+    cloacina::registry::loader::current_provider_scope()
+}
+
+/// Re-install a captured provider scope on this thread for the import's
+/// duration. `None` (embedded / direct import / tests) leaves resolution on the
+/// process-wide path, exactly as before CLOACI-T-0925.
+fn enter_provider_scope(
+    scope: Option<cloacina::registry::loader::ProviderScope>,
+) -> cloacina::registry::loader::ScopedProviderSearch {
+    cloacina::registry::loader::ScopedProviderSearch::enter_opt(scope)
+}
+
 /// Python stdlib module names that must never appear in extracted packages.
 /// A malicious package could shadow these to hijack execution.
 const STDLIB_DENY_LIST: &[&str] = &[
@@ -217,6 +237,12 @@ pub fn import_and_register_python_workflow_named(
 
     // PyO3 operations must happen on a thread that can acquire the GIL.
     // Wrap in a timeout to catch infinite loops during import.
+    // CLOACI-T-0925: the loader installs the package's provider scope on the
+    // calling thread; capture it here so the import thread we are about to spawn
+    // resolves `cloaca.constructor(from = ..)` against THIS package's staged
+    // providers (a thread-local does not follow a thread hop).
+    let provider_scope = provider_scope_of_caller();
+
     let handle = std::thread::spawn(move || -> Result<Vec<TaskNamespace>, PythonLoaderError> {
         // Install the scoped runtime on this worker thread so every
         // @task/@trigger/@workflow_builder registration triggered by the
@@ -229,6 +255,8 @@ pub fn import_and_register_python_workflow_named(
             Some(tenant_id.as_str()),
             Some(package_name.as_str()),
         );
+        // CLOACI-T-0925: whose providers this import resolves against.
+        let _provider_scope = enter_provider_scope(provider_scope);
         Python::with_gil(|py| {
             // 0. Publish this thread's Python ident BEFORE any user code runs,
             //    so a module-scope hang is interruptible (CLOACI-T-0919).
@@ -465,10 +493,14 @@ pub fn import_python_computation_graph(
     let thread_ident = ident.clone();
     let supervise_label = graph_name.clone();
 
+    // CLOACI-T-0925: carry the caller's provider scope onto the import thread.
+    let provider_scope = provider_scope_of_caller();
+
     let handle = std::thread::spawn(move || -> Result<String, PythonLoaderError> {
         let _scope =
             ScopedRuntime::new(runtime.clone()).map_err(PythonLoaderError::RuntimeError)?;
         let _registration = crate::registration_scope::ScopedRegistration::new(registration_scope);
+        let _provider_scope = enter_provider_scope(provider_scope);
         Python::with_gil(|py| {
             thread_ident.record(py);
             ensure_cloaca_module(py)?;

--- a/crates/cloacina/src/computation_graph/packaging_bridge.rs
+++ b/crates/cloacina/src/computation_graph/packaging_bridge.rs
@@ -187,6 +187,19 @@ pub fn build_declaration_from_ffi(
     graph_meta: &GraphPackageMetadata,
     library_data: Vec<u8>,
 ) -> ComputationGraphDeclaration {
+    build_declaration_from_ffi_in(graph_meta, library_data, None)
+}
+
+/// [`build_declaration_from_ffi`] binding an EXPLICIT provider tree
+/// (CLOACI-T-0925): `provider_root` is where the reconciler staged this
+/// package's bundled providers, and every provider-backed accumulator in the
+/// resulting declaration resolves there rather than against ambient state that
+/// another tenant's concurrent load can re-point.
+pub fn build_declaration_from_ffi_in(
+    graph_meta: &GraphPackageMetadata,
+    library_data: Vec<u8>,
+    provider_root: Option<&std::path::Path>,
+) -> ComputationGraphDeclaration {
     let criteria = match graph_meta.reaction_mode.as_str() {
         "when_all" => ReactionCriteria::WhenAll,
         _ => ReactionCriteria::WhenAny,
@@ -223,7 +236,11 @@ pub fn build_declaration_from_ffi(
         .accumulators
         .iter()
         .map(|acc_entry| {
-            let factory = accumulator_factory_for(&acc_entry.accumulator_type, &acc_entry.config);
+            let factory = accumulator_factory_for(
+                &acc_entry.accumulator_type,
+                &acc_entry.config,
+                provider_root,
+            );
             AccumulatorDeclaration {
                 name: acc_entry.name.clone(),
                 factory,
@@ -427,11 +444,40 @@ pub struct ProviderStreamAccumulatorFactory {
     /// Full accumulator config; `provider`/`constructor` are routing keys, the
     /// rest are the member's `#[config]` values (may be `{{ VAR }}` templates).
     config: std::collections::HashMap<String, String>,
+    /// The provider tree this accumulator resolves in, CAPTURED when the
+    /// declaration was built (CLOACI-T-0925). The source loads from a spawned
+    /// task that can run long after the load finished — and, in a shared server
+    /// process, after another tenant's load re-pointed any ambient path. Binding
+    /// the directory at declaration time is what keeps the resolution the owning
+    /// package's own.
+    provider_root: Option<std::path::PathBuf>,
 }
 
 impl ProviderStreamAccumulatorFactory {
+    /// Capture the CURRENTLY-EFFECTIVE provider search path (the ambient scope
+    /// installed for a package import, else the process/env/default path) as this
+    /// accumulator's resolution root.
     pub fn new(config: std::collections::HashMap<String, String>) -> Self {
-        Self { config }
+        #[cfg(feature = "constructors-wasm")]
+        let provider_root = Some(crate::registry::loader::provider_search_path());
+        #[cfg(not(feature = "constructors-wasm"))]
+        let provider_root = None;
+        Self {
+            config,
+            provider_root,
+        }
+    }
+
+    /// Bind an EXPLICIT provider tree — what the reconciler staged for the package
+    /// that declared this accumulator.
+    pub fn new_in(
+        config: std::collections::HashMap<String, String>,
+        provider_root: std::path::PathBuf,
+    ) -> Self {
+        Self {
+            config,
+            provider_root: Some(provider_root),
+        }
     }
 }
 
@@ -474,6 +520,10 @@ impl AccumulatorFactory for ProviderStreamAccumulatorFactory {
             .filter(|(k, _)| !["provider", "constructor", "backend"].contains(&k.as_str()))
             .map(|(k, v)| (k.clone(), v.clone()))
             .collect();
+        // CLOACI-T-0925: the root bound at declaration time, moved into the
+        // spawned task so the resolution below reads no shared state.
+        #[cfg_attr(not(feature = "constructors-wasm"), allow(unused_variables))]
+        let provider_root = self.provider_root.clone();
 
         #[cfg(feature = "constructors-wasm")]
         let handle = tokio::spawn(async move {
@@ -521,7 +571,10 @@ impl AccumulatorFactory for ProviderStreamAccumulatorFactory {
                 }
             }
 
-            match crate::registry::loader::constructor_loader::load_stream_accumulator_source_from_config(
+            let search_path =
+                provider_root.unwrap_or_else(crate::registry::loader::provider_search_path);
+            match crate::registry::loader::constructor_loader::load_stream_accumulator_source_from_config_in(
+                &search_path,
                 &provider,
                 &constructor,
                 &resolved,
@@ -885,9 +938,15 @@ fn polling_interval_from_config(
         .unwrap_or_else(|| std::time::Duration::from_secs(5))
 }
 
+/// `provider_root` (CLOACI-T-0925) is the tree a provider-backed `stream`
+/// accumulator resolves in — the directory the reconciler staged for the package
+/// that declared it. `None` = no staged tree known (embedded, tests, or a Python
+/// import that already has the scope installed), in which case the factory
+/// captures the ambient search path at construction.
 fn accumulator_factory_for(
     acc_type: &str,
     config: &std::collections::HashMap<String, String>,
+    provider_root: Option<&std::path::Path>,
 ) -> Arc<dyn AccumulatorFactory> {
     match acc_type {
         // CLOACI-T-0898/T-0907: a stream accumulator's source ALWAYS comes from
@@ -895,7 +954,13 @@ fn accumulator_factory_for(
         // e.g. cloacina-provider-kafka). The host-compiled kafka backend is
         // gone; a declaration without a `provider` key fails LOUDLY at spawn
         // (ERROR + health Disconnected), never a silent passthrough.
-        "stream" => Arc::new(ProviderStreamAccumulatorFactory::new(config.clone())),
+        "stream" => match provider_root {
+            Some(root) => Arc::new(ProviderStreamAccumulatorFactory::new_in(
+                config.clone(),
+                root.to_path_buf(),
+            )),
+            None => Arc::new(ProviderStreamAccumulatorFactory::new(config.clone())),
+        },
         "state" => Arc::new(StateAccumulatorFactory::new(state_capacity_from_config(
             config,
         ))),
@@ -946,6 +1011,27 @@ pub async fn dispatch_runtime_reactors_into_scheduler(
     accumulator_overrides: &[cloacina_workflow_plugin::types::AccumulatorConfig],
     tenant_id: Option<String>,
 ) -> Result<Vec<String>, String> {
+    dispatch_runtime_reactors_into_scheduler_in(
+        runtime,
+        scheduler,
+        accumulator_overrides,
+        tenant_id,
+        None,
+    )
+    .await
+}
+
+/// [`dispatch_runtime_reactors_into_scheduler`] binding an EXPLICIT provider tree
+/// (CLOACI-T-0925) — the directory the reconciler staged for this package. Both
+/// the reactor's own `#[reactor(from = ..)]` constructor and its provider-backed
+/// accumulators resolve there.
+pub async fn dispatch_runtime_reactors_into_scheduler_in(
+    runtime: &crate::Runtime,
+    scheduler: &super::scheduler::ComputationGraphScheduler,
+    accumulator_overrides: &[cloacina_workflow_plugin::types::AccumulatorConfig],
+    tenant_id: Option<String>,
+    provider_root: Option<&std::path::Path>,
+) -> Result<Vec<String>, String> {
     let mut dispatched = Vec::new();
     for name in runtime.reactor_names() {
         let registration = match runtime.get_reactor(&name) {
@@ -976,7 +1062,7 @@ pub async fn dispatch_runtime_reactors_into_scheduler(
                         None => ("passthrough".to_string(), Default::default()),
                     },
                 };
-                let factory = accumulator_factory_for(&acc_type, &acc_config);
+                let factory = accumulator_factory_for(&acc_type, &acc_config, provider_root);
                 AccumulatorDeclaration {
                     name: acc_name.clone(),
                     factory,
@@ -988,7 +1074,7 @@ pub async fn dispatch_runtime_reactors_into_scheduler(
         let strategy = InputStrategy::Latest;
 
         scheduler
-            .load_reactor(
+            .load_reactor_in(
                 name.clone(),
                 accumulators,
                 criteria,
@@ -1000,6 +1086,7 @@ pub async fn dispatch_runtime_reactors_into_scheduler(
                 // into the scheduler, which resolves + installs the WASM
                 // `evaluate` as the reactor's firing decider.
                 registration.constructor.clone(),
+                provider_root,
             )
             .await?;
 
@@ -1028,6 +1115,25 @@ pub async fn dispatch_package_reactors_into_scheduler(
     accumulator_overrides: &[cloacina_workflow_plugin::types::AccumulatorConfig],
     tenant_id: Option<String>,
 ) -> Result<Vec<String>, String> {
+    dispatch_package_reactors_into_scheduler_in(
+        reactor_metadata,
+        scheduler,
+        accumulator_overrides,
+        tenant_id,
+        None,
+    )
+    .await
+}
+
+/// [`dispatch_package_reactors_into_scheduler`] binding an EXPLICIT provider tree
+/// (CLOACI-T-0925) — see [`dispatch_runtime_reactors_into_scheduler_in`].
+pub async fn dispatch_package_reactors_into_scheduler_in(
+    reactor_metadata: &[cloacina_workflow_plugin::ReactorPackageMetadata],
+    scheduler: &super::scheduler::ComputationGraphScheduler,
+    accumulator_overrides: &[cloacina_workflow_plugin::types::AccumulatorConfig],
+    tenant_id: Option<String>,
+    provider_root: Option<&std::path::Path>,
+) -> Result<Vec<String>, String> {
     use cloacina_computation_graph::ReactionMode;
 
     let mut dispatched = Vec::new();
@@ -1043,8 +1149,11 @@ pub async fn dispatch_package_reactors_into_scheduler(
                     Some(override_cfg) => accumulator_factory_for(
                         &override_cfg.accumulator_type,
                         &override_cfg.config,
+                        provider_root,
                     ),
-                    None => accumulator_factory_for(&acc.accumulator_type, &acc.config),
+                    None => {
+                        accumulator_factory_for(&acc.accumulator_type, &acc.config, provider_root)
+                    }
                 };
                 AccumulatorDeclaration {
                     name: acc.name.clone(),

--- a/crates/cloacina/src/computation_graph/scheduler.rs
+++ b/crates/cloacina/src/computation_graph/scheduler.rs
@@ -238,16 +238,26 @@ fn dummy_graph_fn() -> CompiledGraphFn {
 /// Behind the default-OFF `constructors-wasm` feature: a ref present in a build that
 /// lacks the feature fails closed with a clear error rather than silently ignoring the
 /// author's firing logic.
+/// `provider_root` (CLOACI-T-0925) is the provider tree the owning package's
+/// bundled providers were staged into. `None` falls back to the ambient
+/// [`crate::registry::loader::provider_search_path`] — the embedded/test path.
+/// A multi-tenant host MUST pass `Some(..)`: this resolution runs on a
+/// `spawn_blocking` thread, so an ambient read can observe whatever another
+/// tenant's concurrent load left behind.
 async fn resolve_reactor_evaluator(
     constructor: &Option<cloacina_computation_graph::ReactorConstructorRef>,
+    provider_root: Option<std::path::PathBuf>,
 ) -> Result<Option<Arc<dyn ReactorFireDecider>>, String> {
     let Some(cref) = constructor else {
         return Ok(None);
     };
+    let _ = &provider_root;
 
     #[cfg(feature = "constructors-wasm")]
     {
         let cref = cref.clone();
+        let search_path =
+            provider_root.unwrap_or_else(crate::registry::loader::provider_search_path);
         let decider = tokio::task::spawn_blocking(move || {
             let grants = crate::registry::loader::grants::GrantSpec::from_pairs(cref.grants);
             // CLOACI-T-0920: re-parse the author's `runtime = ".."` pin fail-closed
@@ -262,7 +272,8 @@ async fn resolve_reactor_evaluator(
                     )
                 })
                 .transpose()?;
-            crate::registry::loader::constructor_loader::load_reactor_constructor_node_pinned(
+            crate::registry::loader::constructor_loader::load_reactor_constructor_node_pinned_in(
+                &search_path,
                 &cref.from,
                 &cref.constructor,
                 cref.config,
@@ -571,6 +582,36 @@ impl ComputationGraphScheduler {
         // the `criteria`. Resolved once here and reused across restarts.
         constructor: Option<cloacina_computation_graph::ReactorConstructorRef>,
     ) -> Result<(), String> {
+        self.load_reactor_in(
+            reactor_name,
+            accumulators,
+            criteria,
+            strategy,
+            tenant_id,
+            register_aliases,
+            constructor,
+            None,
+        )
+        .await
+    }
+
+    /// [`load_reactor`](Self::load_reactor) resolving the reactor's constructor
+    /// ref against an EXPLICIT provider tree (CLOACI-T-0925): `provider_root` is
+    /// where the owning package's bundled providers were staged. `None` keeps the
+    /// ambient behavior for embedded/test callers.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn load_reactor_in(
+        &self,
+        reactor_name: String,
+        accumulators: Vec<AccumulatorDeclaration>,
+        criteria: ReactionCriteria,
+        strategy: InputStrategy,
+        tenant_id: Option<String>,
+        register_aliases: Vec<String>,
+        constructor: Option<cloacina_computation_graph::ReactorConstructorRef>,
+        provider_root: Option<&std::path::Path>,
+    ) -> Result<(), String> {
+        let provider_root = provider_root.map(|p| p.to_path_buf());
         // Idempotent path: matching contract → no-op.
         {
             let reactors = self.reactors.read().await;
@@ -602,7 +643,7 @@ impl ComputationGraphScheduler {
         // live firing decider BEFORE we spawn anything, so a bad constructor ref
         // fails the load cleanly instead of leaving a half-wired reactor running.
         // The resolved decider is reused on restart (stored on `RunningGraph`).
-        let evaluator = resolve_reactor_evaluator(&constructor).await?;
+        let evaluator = resolve_reactor_evaluator(&constructor, provider_root).await?;
 
         // CLOACI-T-0921: every endpoint this reactor registers is keyed by
         // `(tenant, name)` and stamped with this owner, so a same-named
@@ -904,6 +945,17 @@ impl ComputationGraphScheduler {
     /// lifecycle and the graph's subscription. Independent-reactor consumers
     /// (the reconciler post-T-0545) call the explicit pair directly.
     pub async fn load_graph(&self, decl: ComputationGraphDeclaration) -> Result<(), String> {
+        self.load_graph_in(decl, None).await
+    }
+
+    /// [`load_graph`](Self::load_graph) resolving the declaration's reactor
+    /// constructor against an EXPLICIT provider tree (CLOACI-T-0925) — the
+    /// directory the reconciler staged for the package that declared the graph.
+    pub async fn load_graph_in(
+        &self,
+        decl: ComputationGraphDeclaration,
+        provider_root: Option<&std::path::Path>,
+    ) -> Result<(), String> {
         let name = decl.name.clone();
         // Resolve the reactor identity. `Some(...)` from a split-form caller
         // (T-0544 M2: cross-package fan-out) lets multiple graphs share a
@@ -962,7 +1014,7 @@ impl ComputationGraphScheduler {
         // alias so `cloacinactl reactor force-fire <graph>` keeps working
         // for bundled-form callers and for the first graph that names a
         // shared reactor (T-0544 M2 surface promise).
-        self.load_reactor(
+        self.load_reactor_in(
             reactor_name.clone(),
             decl.accumulators.clone(),
             decl.reactor.criteria.clone(),
@@ -970,6 +1022,7 @@ impl ComputationGraphScheduler {
             decl.tenant_id.clone(),
             vec![name.clone()],
             decl.reactor.constructor.clone(),
+            provider_root,
         )
         .await?;
 

--- a/crates/cloacina/src/registry/loader/constructor_loader.rs
+++ b/crates/cloacina/src/registry/loader/constructor_loader.rs
@@ -1314,14 +1314,37 @@ pub async fn load_stream_accumulator_source<C: Serialize>(
 /// declaration order. String values coerce per the declared field type (`"5"` for
 /// an `i64` field parses; kafka's fields are all `String`).
 ///
-/// The provider resolves from the process-wide [`provider_search_path`] — the same
+/// The provider resolves from the ambient [`provider_search_path`] — the same
 /// `providers/` tree the reconciler unpacks a package's bundled providers into.
+/// A host that knows which package it is loading should call
+/// [`load_stream_accumulator_source_from_config_in`] instead: this resolution runs
+/// from a spawned accumulator task, so an ambient read can land long after the
+/// load that staged the providers finished (CLOACI-T-0925).
 pub async fn load_stream_accumulator_source_from_config(
     provider_name: &str,
     constructor_name: &str,
     config: &std::collections::HashMap<String, String>,
 ) -> Result<ProviderStreamSource, LoaderError> {
-    let search_path = provider_search_path();
+    load_stream_accumulator_source_from_config_in(
+        &provider_search_path(),
+        provider_name,
+        constructor_name,
+        config,
+    )
+    .await
+}
+
+/// [`load_stream_accumulator_source_from_config`] against an EXPLICIT provider
+/// directory (CLOACI-T-0925) — the root captured when the accumulator's
+/// declaration was built, not whatever the process global holds when the spawned
+/// stream task happens to run.
+pub async fn load_stream_accumulator_source_from_config_in(
+    search_path: &Path,
+    provider_name: &str,
+    constructor_name: &str,
+    config: &std::collections::HashMap<String, String>,
+) -> Result<ProviderStreamSource, LoaderError> {
+    let search_path = search_path.to_path_buf();
 
     // Member manifest first — bind_config_by_name needs its config_fields.
     let (_dir, provider) =
@@ -1646,6 +1669,10 @@ pub fn load_reactor_constructor<C: Serialize>(
 /// form resolves `from = "..."` against. `None` falls back to
 /// [`PROVIDER_PATH_ENV`] then [`DEFAULT_PROVIDER_DIR`]. Set it once at startup
 /// (e.g. from a deployment's config) via [`set_provider_search_path`].
+///
+/// This is the EMBEDDED / single-tenant convenience knob. It is the LOWEST-
+/// precedence source: a per-load [`ProviderScope`] (what the reconciler installs
+/// around one package's load) always wins over it — see [`provider_search_path`].
 static PROVIDER_SEARCH_PATH: std::sync::RwLock<Option<std::path::PathBuf>> =
     std::sync::RwLock::new(None);
 
@@ -1659,6 +1686,12 @@ pub const DEFAULT_PROVIDER_DIR: &str = "providers";
 
 /// Set the process-wide provider search path used to resolve `constructor!`
 /// `from = "..."` references. Takes precedence over [`PROVIDER_PATH_ENV`].
+///
+/// Embedded / single-tenant use only. A multi-tenant host (the server's
+/// reconciler) must NOT set this — it scopes each package load instead
+/// ([`ScopedProviderSearch`] / the `*_in` loader entry points), because one
+/// process-wide directory makes every tenant's staged providers visible to
+/// every other tenant's resolution (CLOACI-T-0925).
 pub fn set_provider_search_path(path: impl Into<std::path::PathBuf>) {
     *PROVIDER_SEARCH_PATH.write().unwrap() = Some(path.into());
 }
@@ -1668,19 +1701,162 @@ pub fn clear_provider_search_path() {
     *PROVIDER_SEARCH_PATH.write().unwrap() = None;
 }
 
-/// The directory `constructor!(from = ...)` resolves provider packages in:
-/// the [`set_provider_search_path`] override, else [`PROVIDER_PATH_ENV`], else
-/// [`DEFAULT_PROVIDER_DIR`].
-pub fn provider_search_path() -> std::path::PathBuf {
-    if let Some(p) = PROVIDER_SEARCH_PATH.read().unwrap().clone() {
-        return p;
+// ===========================================================================
+// Per-load provider scope (CLOACI-T-0925)
+// ===========================================================================
+//
+// TENANT IS THE ISOLATION BOUNDARY. A shared server process runs one reconciler
+// PER TENANT, each on its own tokio task (`DefaultRunner` →
+// `RegistryReconcilerService::start`), so package loads are serialized only
+// WITHIN a tenant, never across tenants. A single process-wide search directory
+// therefore means tenant A's staged providers are visible to — and racily
+// overwritten by — tenant B's resolution.
+//
+// The fix has two halves:
+//
+//   1. Every HOST-SIDE resolution site takes the directory as an explicit
+//      argument (`load_constructor_node_in`, `load_reactor_constructor_node_*_in`,
+//      `load_stream_accumulator_source_from_config_in`). The reconciler passes the
+//      root it just staged for THAT package; nothing is read from shared state,
+//      so nothing can race — including the deferred sites that resolve from a
+//      spawned task long after the load returned.
+//
+//   2. Call sites that cannot take an argument — the Python `cloaca.constructor(…)`
+//      bridge, which runs inside a package's module import — read the AMBIENT
+//      scope installed for the duration of that import ([`ScopedProviderSearch`]).
+//      The scope is thread-local and RAII, mirroring cloacina-python's
+//      `registration_scope` (CLOACI-T-0921); the Python loader carries it onto the
+//      import thread it spawns exactly as it already carries `ScopedRuntime` and
+//      `ScopedRegistration`.
+//
+// The embedded/single-tenant experience is untouched: with no scope installed,
+// [`provider_search_path`] resolves exactly as it always has (process override →
+// env → `providers`).
+
+/// The provider tree ONE package load resolves `from = ".."` against
+/// (CLOACI-T-0925).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProviderScope {
+    /// The package's OWN bundled providers, unpacked into this directory by the
+    /// reconciler. Highest precedence — it is this package's hermetic world.
+    Staged(std::path::PathBuf),
+    /// The package bundles NO providers. Its `from = ".."` refs must not fall
+    /// back to whatever another tenant's load staged, so the process-wide
+    /// override is SKIPPED and resolution falls through to
+    /// [`PROVIDER_PATH_ENV`] / [`DEFAULT_PROVIDER_DIR`] — the same directory the
+    /// pre-T-0925 `clear_provider_search_path()` call left behind, but scoped to
+    /// this load instead of stomping the process.
+    Unbundled,
+}
+
+impl ProviderScope {
+    /// `Some(root)` → [`ProviderScope::Staged`]; `None` → [`ProviderScope::Unbundled`].
+    pub fn from_staged_root(root: Option<std::path::PathBuf>) -> Self {
+        match root {
+            Some(root) => ProviderScope::Staged(root),
+            None => ProviderScope::Unbundled,
+        }
     }
+
+    /// The directory this scope resolves in.
+    pub fn search_path(&self) -> std::path::PathBuf {
+        match self {
+            ProviderScope::Staged(root) => root.clone(),
+            ProviderScope::Unbundled => provider_search_path_from_env(),
+        }
+    }
+}
+
+thread_local! {
+    /// The provider scope installed on THIS thread, if any. `None` = unscoped
+    /// (embedded, tests, direct library use) → the pre-T-0925 global behavior.
+    static CURRENT_PROVIDER_SCOPE: std::cell::RefCell<Option<ProviderScope>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+/// The provider scope installed on this thread (`None` when unscoped).
+///
+/// Capture this before spawning a thread that will resolve constructors on the
+/// caller's behalf (the Python loader does exactly that) and re-install it there
+/// with [`ScopedProviderSearch::enter_opt`] — a thread-local does not follow a
+/// `std::thread::spawn` / `spawn_blocking` hop on its own.
+pub fn current_provider_scope() -> Option<ProviderScope> {
+    CURRENT_PROVIDER_SCOPE.with(|slot| slot.borrow().clone())
+}
+
+/// RAII guard installing a [`ProviderScope`] on the current thread for the
+/// duration of one package load (CLOACI-T-0925).
+///
+/// Nests: the previous scope is saved and restored on drop, so a load that
+/// transitively triggers another scoped load cannot strand the outer scope.
+///
+/// **Threads, not futures.** Hold it across synchronous work only (a Python
+/// module import, a `spawn_blocking` closure). A guard held across an `.await`
+/// would follow the THREAD, not the task, once the executor moves the future —
+/// async resolution sites take the directory as an explicit argument instead.
+#[must_use = "the scope is uninstalled when the guard drops"]
+pub struct ScopedProviderSearch {
+    previous: Option<ProviderScope>,
+}
+
+impl ScopedProviderSearch {
+    /// Install `scope` on this thread until the guard drops.
+    pub fn enter(scope: ProviderScope) -> Self {
+        Self::enter_opt(Some(scope))
+    }
+
+    /// Install `scope` (or uninstall any scope, for `None`) on this thread until
+    /// the guard drops. `None` is what an unscoped caller propagates.
+    pub fn enter_opt(scope: Option<ProviderScope>) -> Self {
+        let previous = CURRENT_PROVIDER_SCOPE.with(|slot| slot.replace(scope));
+        Self { previous }
+    }
+
+    /// Install the scope for a package whose bundled providers were staged into
+    /// `root` (`None` = the package bundles none).
+    pub fn for_staged_root(root: Option<std::path::PathBuf>) -> Self {
+        Self::enter(ProviderScope::from_staged_root(root))
+    }
+}
+
+impl Drop for ScopedProviderSearch {
+    fn drop(&mut self) {
+        let previous = self.previous.take();
+        CURRENT_PROVIDER_SCOPE.with(|slot| *slot.borrow_mut() = previous);
+    }
+}
+
+/// [`PROVIDER_PATH_ENV`] else [`DEFAULT_PROVIDER_DIR`] — the deployment-level
+/// directory, with no process override and no per-load scope applied.
+fn provider_search_path_from_env() -> std::path::PathBuf {
     if let Ok(p) = std::env::var(PROVIDER_PATH_ENV) {
         if !p.is_empty() {
             return std::path::PathBuf::from(p);
         }
     }
     std::path::PathBuf::from(DEFAULT_PROVIDER_DIR)
+}
+
+/// The directory `constructor!(from = ...)` resolves provider packages in.
+///
+/// Precedence (highest first, CLOACI-T-0925):
+///
+///   1. the per-load [`ProviderScope`] installed on this thread
+///      ([`ScopedProviderSearch`]) — the tenant/package-scoped world;
+///   2. the process-wide [`set_provider_search_path`] override — the
+///      embedded/single-tenant convenience knob;
+///   3. [`PROVIDER_PATH_ENV`];
+///   4. [`DEFAULT_PROVIDER_DIR`].
+///
+/// With no scope installed this is byte-for-byte the pre-T-0925 behavior.
+pub fn provider_search_path() -> std::path::PathBuf {
+    if let Some(scope) = current_provider_scope() {
+        return scope.search_path();
+    }
+    if let Some(p) = PROVIDER_SEARCH_PATH.read().unwrap().clone() {
+        return p;
+    }
+    provider_search_path_from_env()
 }
 
 /// Strip an optional `@version` suffix from a `from = "name[@version]"` reference,
@@ -2178,7 +2354,62 @@ pub fn load_constructor_node_pinned(
     grants: GrantSpec,
     runtime_pin: Option<ProviderRuntime>,
 ) -> Result<Arc<dyn Task>, LoaderError> {
-    let search_path = provider_search_path();
+    load_constructor_node_pinned_in(
+        &provider_search_path(),
+        node_id,
+        from,
+        constructor_name,
+        config,
+        dependencies,
+        grants,
+        runtime_pin,
+    )
+}
+
+/// [`load_constructor_node`] against an EXPLICIT provider directory
+/// (CLOACI-T-0925) — no shared state is read, so a multi-tenant host resolves
+/// each package against the tree it staged for that package and nothing else.
+///
+/// This is the primitive; the ambient-path forms above are thin wrappers that
+/// supply [`provider_search_path`]. Host-side callers that know which package
+/// they are loading (the reconciler, the CG scheduler, provider-backed stream
+/// accumulators) MUST use this form: they resolve from spawned tasks that can
+/// outlive any process-global the load set.
+pub fn load_constructor_node_in(
+    search_path: &Path,
+    node_id: &str,
+    from: &str,
+    constructor_name: &str,
+    config: Vec<(String, serde_json::Value)>,
+    dependencies: Vec<TaskNamespace>,
+    grants: GrantSpec,
+) -> Result<Arc<dyn Task>, LoaderError> {
+    load_constructor_node_pinned_in(
+        search_path,
+        node_id,
+        from,
+        constructor_name,
+        config,
+        dependencies,
+        grants,
+        None,
+    )
+}
+
+/// [`load_constructor_node_pinned`] against an EXPLICIT provider directory
+/// (CLOACI-T-0925). See [`load_constructor_node_in`].
+#[allow(clippy::too_many_arguments)]
+pub fn load_constructor_node_pinned_in(
+    search_path: &Path,
+    node_id: &str,
+    from: &str,
+    constructor_name: &str,
+    config: Vec<(String, serde_json::Value)>,
+    dependencies: Vec<TaskNamespace>,
+    grants: GrantSpec,
+    runtime_pin: Option<ProviderRuntime>,
+) -> Result<Arc<dyn Task>, LoaderError> {
+    let search_path = search_path.to_path_buf();
     let package_name = provider_package_name(from);
 
     // CLOACI-T-0920: settle the trust tier BEFORE any load work — both because a
@@ -2320,7 +2551,30 @@ pub fn load_reactor_constructor_node_pinned(
     grants: GrantSpec,
     runtime_pin: Option<ProviderRuntime>,
 ) -> Result<Arc<dyn ReactorFireDecider>, LoaderError> {
-    let search_path = provider_search_path();
+    load_reactor_constructor_node_pinned_in(
+        &provider_search_path(),
+        from,
+        constructor_name,
+        config,
+        grants,
+        runtime_pin,
+    )
+}
+
+/// [`load_reactor_constructor_node_pinned`] against an EXPLICIT provider
+/// directory (CLOACI-T-0925). The CG scheduler resolves a reactor constructor on
+/// a `spawn_blocking` thread, i.e. off the load's task — it must carry the
+/// package's staged root rather than read process-global state that another
+/// tenant's load may already have re-pointed.
+pub fn load_reactor_constructor_node_pinned_in(
+    search_path: &Path,
+    from: &str,
+    constructor_name: &str,
+    config: Vec<(String, serde_json::Value)>,
+    grants: GrantSpec,
+    runtime_pin: Option<ProviderRuntime>,
+) -> Result<Arc<dyn ReactorFireDecider>, LoaderError> {
+    let search_path = search_path.to_path_buf();
     let package_name = provider_package_name(from);
 
     // CLOACI-T-0920: settle the trust tier before any load work (see
@@ -2398,6 +2652,97 @@ pub fn load_reactor_constructor_node_pinned(
     })?;
 
     Ok(Arc::new(reactor_constructor) as Arc<dyn ReactorFireDecider>)
+}
+
+/// CLOACI-T-0925: the precedence contract between the per-load scope and the
+/// embedded process-wide override. These pin the two properties the fix rests on:
+/// a scope ALWAYS wins (so no tenant can be resolved against another's tree), and
+/// with no scope the resolution is byte-for-byte the pre-T-0925 embedded behavior.
+#[cfg(test)]
+mod provider_scope_tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    // These mutate the PROCESS-WIDE override, so they serialize against each
+    // other (and against any other test touching it). The scope itself is
+    // thread-local and needs no serialization — that is the point.
+    #[test]
+    #[serial_test::serial(provider_search_path)]
+    fn scope_wins_over_the_process_override() {
+        let host = PathBuf::from("/tmp/t0925-host-configured");
+        let tenant_a = PathBuf::from("/tmp/t0925-tenant-a");
+        set_provider_search_path(&host);
+        assert_eq!(provider_search_path(), host, "unscoped = the process knob");
+
+        {
+            let _scope = ScopedProviderSearch::enter(ProviderScope::Staged(tenant_a.clone()));
+            assert_eq!(
+                provider_search_path(),
+                tenant_a,
+                "a staged scope must win over the process-wide override"
+            );
+        }
+        assert_eq!(
+            provider_search_path(),
+            host,
+            "the override is visible again once the scope drops"
+        );
+        clear_provider_search_path();
+    }
+
+    #[test]
+    #[serial_test::serial(provider_search_path)]
+    fn unbundled_scope_skips_the_process_override() {
+        let host = PathBuf::from("/tmp/t0925-host-configured-2");
+        set_provider_search_path(&host);
+        {
+            let _scope = ScopedProviderSearch::enter(ProviderScope::Unbundled);
+            assert_eq!(
+                provider_search_path(),
+                provider_search_path_from_env(),
+                "a package that bundles nothing must not inherit the host/other-tenant \
+                 override — it falls through to env/default"
+            );
+        }
+        clear_provider_search_path();
+    }
+
+    #[test]
+    fn scopes_nest_and_restore() {
+        let outer = PathBuf::from("/tmp/t0925-outer");
+        let inner = PathBuf::from("/tmp/t0925-inner");
+        assert_eq!(current_provider_scope(), None);
+        let _o = ScopedProviderSearch::enter(ProviderScope::Staged(outer.clone()));
+        {
+            let _i = ScopedProviderSearch::enter(ProviderScope::Staged(inner.clone()));
+            assert_eq!(provider_search_path(), inner);
+        }
+        assert_eq!(
+            provider_search_path(),
+            outer,
+            "an inner scope must not strand the outer one"
+        );
+    }
+
+    #[test]
+    fn capture_and_reinstall_carries_a_scope_across_threads() {
+        // What the Python loader does: a thread-local does not follow a thread
+        // hop, so the scope is captured and re-entered on the import thread.
+        let staged = PathBuf::from("/tmp/t0925-staged-for-import");
+        let _scope = ScopedProviderSearch::enter(ProviderScope::Staged(staged.clone()));
+        let captured = current_provider_scope();
+
+        let seen = std::thread::spawn(move || {
+            let unscoped = current_provider_scope();
+            let _s = ScopedProviderSearch::enter_opt(captured);
+            (unscoped, provider_search_path())
+        })
+        .join()
+        .unwrap();
+
+        assert_eq!(seen.0, None, "a fresh thread starts unscoped");
+        assert_eq!(seen.1, staged, "the captured scope resolves on that thread");
+    }
 }
 
 #[cfg(test)]

--- a/crates/cloacina/src/registry/loader/mod.rs
+++ b/crates/cloacina/src/registry/loader/mod.rs
@@ -38,13 +38,14 @@ pub use task_registrar::TaskRegistrar;
 
 #[cfg(feature = "constructors-wasm")]
 pub use constructor_loader::{
-    clear_provider_search_path, load_constructor, load_constructor_node,
-    load_constructor_node_pinned, load_reactor_constructor_node,
-    load_reactor_constructor_node_pinned, load_task_constructor,
+    clear_provider_search_path, current_provider_scope, load_constructor, load_constructor_node,
+    load_constructor_node_in, load_constructor_node_pinned, load_constructor_node_pinned_in,
+    load_reactor_constructor_node, load_reactor_constructor_node_pinned,
+    load_reactor_constructor_node_pinned_in, load_task_constructor,
     load_task_constructor_from_package, load_trigger_constructor, parse_runtime_pin,
     provider_search_path, set_provider_search_path, unpack_provider_archive, ConstructorBinding,
-    ConstructorNode, TriggerBinding, WasmTaskConstructor, WasmTriggerConstructor,
-    DEFAULT_PROVIDER_DIR, PROVIDER_PATH_ENV,
+    ConstructorNode, ProviderScope, ScopedProviderSearch, TriggerBinding, WasmTaskConstructor,
+    WasmTriggerConstructor, DEFAULT_PROVIDER_DIR, PROVIDER_PATH_ENV,
 };
 
 /// CLOACI-T-0920: the trust tier a consumer can PIN with

--- a/crates/cloacina/src/registry/reconciler/loading.rs
+++ b/crates/cloacina/src/registry/reconciler/loading.rs
@@ -434,9 +434,12 @@ impl RegistryReconciler {
             // packages with `constructor!` NODES) — but a provider-backed STREAM
             // accumulator (`[[metadata.accumulators]] provider = ..`) consumes a
             // bundled provider from step 3's reactor spawn, with no constructor
-            // node in sight. Packages that bundle nothing stage nothing (and
-            // clear the search path — hermetic fail-closed, unchanged).
-            self.stage_bundled_providers(&metadata).await?;
+            // node in sight. Packages that bundle nothing stage nothing.
+            //
+            // CLOACI-T-0925: the staged root is a VALUE now, handed to each step
+            // that resolves against it, instead of a process-global the next
+            // tenant's concurrent load overwrites.
+            let provider_root = self.stage_bundled_providers(&metadata).await?;
 
             // Step 1: cron triggers — registered through the attached
             // CronWorkflowRegistrar (no-op when none is wired).
@@ -448,8 +451,13 @@ impl RegistryReconciler {
             let trigger_names =
                 self.step_load_custom_triggers(&metadata, &view, Some(&library_data))?;
             // Step 3: reactors → graph scheduler.
-            self.step_load_reactors(&metadata, &view, &cloacina_manifest.metadata)
-                .await?;
+            self.step_load_reactors(
+                &metadata,
+                &view,
+                &cloacina_manifest.metadata,
+                provider_root.as_deref(),
+            )
+            .await?;
             // Step 4: trigger-less CGs — register FFI adapters for any
             // declared by the cdylib (cross-cdylib inventory doesn't
             // reach the host runtime; close that gap with FFI dispatch
@@ -468,6 +476,7 @@ impl RegistryReconciler {
                     &view,
                     &cloacina_manifest.metadata,
                     &library_data,
+                    provider_root.as_deref(),
                 )
                 .await?;
             // Step 5b: packaged `constructor!` nodes (CLOACI-T-0832/T-0836).
@@ -476,7 +485,7 @@ impl RegistryReconciler {
             // BEFORE step 6 builds the workflow — the DAG builder
             // (`create_workflow_from_host_registry_static`) enumerates the
             // registry, so resolved nodes join the topology automatically.
-            self.step_load_constructor_nodes(&metadata, &library_data)
+            self.step_load_constructor_nodes(&metadata, &library_data, provider_root.clone())
                 .await?;
             // Step 6: workflows (tasks + workflow + trigger-subscription
             // validation).
@@ -527,14 +536,27 @@ impl RegistryReconciler {
             // CLOACI-T-0831: stage the package's bundled constructor providers
             // BEFORE the module import — `cloaca.constructor(...)` calls resolve
             // against the provider search path DURING import. Packages that
-            // bundle none stage nothing (Ok(0)).
-            self.stage_bundled_providers(&metadata).await?;
+            // bundle none stage nothing (`None`).
+            let provider_root = self.stage_bundled_providers(&metadata).await?;
 
             let loaded = {
                 let archive_data = loaded_workflow.package_data.clone();
                 let runtime = runtime.clone();
                 let cloacina_runtime = cloacina_runtime.clone();
+                let import_provider_root = provider_root.clone();
                 tokio::task::spawn_blocking(move || {
+                    // CLOACI-T-0925: `cloaca.constructor(..)` runs INSIDE the
+                    // module import and cannot take the directory as an argument,
+                    // so install it as the ambient scope for the import. The
+                    // Python loader carries it onto the import thread it spawns
+                    // (the same way it carries ScopedRuntime/ScopedRegistration).
+                    #[cfg(feature = "constructors-wasm")]
+                    let _provider_scope =
+                        crate::registry::loader::ScopedProviderSearch::for_staged_root(
+                            import_provider_root,
+                        );
+                    #[cfg(not(feature = "constructors-wasm"))]
+                    let _ = import_provider_root;
                     runtime
                         .load_workflow_package(
                             &archive_data,
@@ -574,8 +596,13 @@ impl RegistryReconciler {
             // dispatches each into the scheduler via the same idempotent
             // path the Rust pipeline uses. Replaces the old inline
             // `dispatch_runtime_reactors_into_scheduler` call.
-            self.step_load_reactors(&metadata, &py_view, &cloacina_manifest.metadata)
-                .await?;
+            self.step_load_reactors(
+                &metadata,
+                &py_view,
+                &cloacina_manifest.metadata,
+                provider_root.as_deref(),
+            )
+            .await?;
 
             info!(
                 "Python package loaded: {} v{} — {} tasks, workflow '{}'",
@@ -679,6 +706,13 @@ impl RegistryReconciler {
                                 metadata.package_name
                             ),
                             })?;
+                    // CLOACI-T-0925: this branch previously staged NOTHING, so a
+                    // Python CG package's provider-backed accumulators resolved
+                    // against whatever directory the last load left in the
+                    // process global — another tenant's tree in a shared server.
+                    // Stage its own bundle and scope the import to it, exactly
+                    // like the Python workflow branch above.
+                    let cg_provider_root = self.stage_bundled_providers(&metadata).await?;
                     let maybe_decl = {
                         let archive_data = loaded_workflow.package_data.clone();
                         let gn_inner = gn.clone();
@@ -686,7 +720,15 @@ impl RegistryReconciler {
                         let tenant_inner = tenant.clone();
                         let runtime = runtime.clone();
                         let cloacina_runtime = cloacina_runtime.clone();
+                        let import_provider_root = cg_provider_root.clone();
                         tokio::task::spawn_blocking(move || {
+                            #[cfg(feature = "constructors-wasm")]
+                            let _provider_scope =
+                                crate::registry::loader::ScopedProviderSearch::for_staged_root(
+                                    import_provider_root,
+                                );
+                            #[cfg(not(feature = "constructors-wasm"))]
+                            let _ = import_provider_root;
                             runtime
                                 .load_cg_package(
                                     &archive_data,
@@ -736,8 +778,13 @@ impl RegistryReconciler {
                             .await?,
                     );
                     let _ = self.step_load_custom_triggers(&metadata, &cg_view, None)?;
-                    self.step_load_reactors(&metadata, &cg_view, &cloacina_manifest.metadata)
-                        .await?;
+                    self.step_load_reactors(
+                        &metadata,
+                        &cg_view,
+                        &cloacina_manifest.metadata,
+                        cg_provider_root.as_deref(),
+                    )
+                    .await?;
                     if let Some(graph_meta) = cg_view.graph.as_ref() {
                         if let Some(upstream_reactor_name) = graph_meta.trigger_reactor.as_deref() {
                             let publisher_in_same_package = cg_view
@@ -780,7 +827,10 @@ impl RegistryReconciler {
                     if let Some(decl) = maybe_decl {
                         let scheduler_guard = self.graph_scheduler.read().await;
                         if let Some(ref scheduler) = *scheduler_guard {
-                            if let Err(e) = scheduler.load_graph(decl).await {
+                            if let Err(e) = scheduler
+                                .load_graph_in(decl, cg_provider_root.as_deref())
+                                .await
+                            {
                                 warn!(
                                     "Failed to load Python CG '{}' into ComputationGraphScheduler: {}",
                                     gn, e
@@ -1933,6 +1983,10 @@ impl RegistryReconciler {
         metadata: &WorkflowMetadata,
         view: &PackageLoadView,
         manifest: &cloacina_workflow_plugin::CloacinaMetadata,
+        // CLOACI-T-0925: where THIS package's bundled providers were staged. The
+        // reactor's constructor ref and its provider-backed stream accumulators
+        // resolve there — never against process-wide state another tenant shares.
+        provider_root: Option<&std::path::Path>,
     ) -> Result<(), RegistryError> {
         if view.reactors.is_empty() {
             return Ok(());
@@ -1946,11 +2000,12 @@ impl RegistryReconciler {
             return Ok(());
         };
         if let Err(e) =
-            crate::computation_graph::packaging_bridge::dispatch_package_reactors_into_scheduler(
+            crate::computation_graph::packaging_bridge::dispatch_package_reactors_into_scheduler_in(
                 &view.reactors,
                 scheduler,
                 &manifest.accumulators,
                 Some(self.config.default_tenant_id.clone()),
+                provider_root,
             )
             .await
         {
@@ -2072,6 +2127,9 @@ impl RegistryReconciler {
         view: &PackageLoadView,
         manifest: &cloacina_workflow_plugin::CloacinaMetadata,
         library_data: &[u8],
+        // CLOACI-T-0925: this package's staged provider tree (see
+        // `step_load_reactors`).
+        provider_root: Option<&std::path::Path>,
     ) -> Result<Option<String>, RegistryError> {
         let Some(graph_meta) = view.graph.clone() else {
             return Ok(None);
@@ -2166,9 +2224,10 @@ impl RegistryReconciler {
             }
         }
 
-        let mut decl = crate::computation_graph::packaging_bridge::build_declaration_from_ffi(
+        let mut decl = crate::computation_graph::packaging_bridge::build_declaration_from_ffi_in(
             &graph_meta,
             library_data.to_vec(),
+            provider_root,
         );
         decl.tenant_id = Some(self.config.default_tenant_id.clone());
 
@@ -2189,7 +2248,7 @@ impl RegistryReconciler {
             });
         }
 
-        if let Err(e) = scheduler.load_graph(decl).await {
+        if let Err(e) = scheduler.load_graph_in(decl, provider_root).await {
             warn!(
                 "Failed to load computation graph '{}' for package {}: {}",
                 graph_meta.graph_name, metadata.package_name, e
@@ -2222,18 +2281,26 @@ impl RegistryReconciler {
     /// Fails closed: a package that declares constructor nodes but has no bundled
     /// providers (or an unresolvable member/grant/config) does not load.
     ///
-    /// Known v1 caveats (documented in CLOACI-T-0836): the provider search path is
-    /// process-global (fine under today's sequential reconciler; concurrent loads
-    /// of different packages would race it), and constructor nodes registered here
-    /// are dropped with the runtime rather than per-package unload.
+    /// Known v1 caveat (documented in CLOACI-T-0836): constructor nodes registered
+    /// here are dropped with the runtime rather than per-package unload.
     /// Stage a package's bundled constructor providers (CLOACI-T-0836/T-0831):
-    /// fetch the `package_providers` rows, unpack each archive into a fresh
-    /// `providers/` tree, and point the loader's provider search path at it.
-    /// Returns how many providers were staged (0 = the package bundles none).
+    /// fetch the `package_providers` rows and unpack each archive into a fresh
+    /// `providers/` tree. Returns the staged root — `None` when the package
+    /// bundles no providers.
     ///
-    /// Shared by BOTH load paths: the Rust branch's Step 5b (before resolving FFI
+    /// Shared by BOTH load paths: the Rust branch's Step 0/5b (before resolving FFI
     /// constructor declarations) and the Python branch (BEFORE the module import,
     /// so `cloaca.constructor(...)` calls resolve against the bundle during load).
+    ///
+    /// CLOACI-T-0925: staging NO LONGER points a process-global search path at the
+    /// result. Tenant is the isolation boundary and every tenant's reconciler runs
+    /// its own concurrent loop in this process, so a shared directory made one
+    /// tenant's staged providers visible to (and racily overwritten by) another's
+    /// resolution. The caller now owns the root: it passes it explicitly to every
+    /// host-side resolution site and installs it as a
+    /// [`crate::registry::loader::ScopedProviderSearch`] around the module import
+    /// for the call sites (Python's `cloaca.constructor`) that cannot take it as an
+    /// argument.
     ///
     /// The unpacked dir must outlive the process' use of the search path (wasm
     /// components are re-read on every node load), so it is deliberately leaked —
@@ -2246,21 +2313,20 @@ impl RegistryReconciler {
     pub(super) async fn stage_bundled_providers(
         &self,
         metadata: &WorkflowMetadata,
-    ) -> Result<usize, RegistryError> {
+    ) -> Result<Option<std::path::PathBuf>, RegistryError> {
         let providers = self
             .registry
             .get_package_providers(&metadata.package_name, &metadata.version)
             .await?;
         if providers.is_empty() {
-            // Hermeticity: the search path is process-global, so without this a
-            // package that bundles NOTHING would silently resolve constructor
-            // refs against whatever bundle the PREVIOUS load staged
-            // (load-order-dependent imports). Clear it so undeclared refs fail
-            // closed for the current package. Already-loaded nodes are
-            // unaffected — they hold their wasm handles.
-            #[cfg(feature = "constructors-wasm")]
-            crate::registry::loader::clear_provider_search_path();
-            return Ok(0);
+            // Hermeticity: a package that bundles NOTHING must not resolve its
+            // constructor refs against whatever bundle another load staged. The
+            // `None` root becomes a `ProviderScope::Unbundled` at the call site,
+            // which skips the process-wide override for THIS load only (the
+            // pre-T-0925 code cleared that override process-wide, which fixed the
+            // load-order dependence but stomped every other tenant in flight).
+            // Already-loaded nodes are unaffected — they hold their wasm handles.
+            return Ok(None);
         }
 
         #[cfg(not(feature = "constructors-wasm"))]
@@ -2279,7 +2345,7 @@ impl RegistryReconciler {
 
         #[cfg(feature = "constructors-wasm")]
         {
-            use crate::registry::loader::{set_provider_search_path, unpack_provider_archive};
+            use crate::registry::loader::unpack_provider_archive;
 
             let providers_root = tempfile::TempDir::new()
                 .map_err(|e| RegistryError::RegistrationFailed {
@@ -2299,7 +2365,6 @@ impl RegistryReconciler {
                     }
                 })?;
             }
-            set_provider_search_path(&providers_root);
             info!(
                 "Unpacked {} bundled provider(s) for {} v{} into {}",
                 providers.len(),
@@ -2307,14 +2372,20 @@ impl RegistryReconciler {
                 metadata.version,
                 providers_root.display()
             );
-            Ok(providers.len())
+            Ok(Some(providers_root))
         }
     }
 
+    /// `provider_root` is the tree this package's bundled providers were staged
+    /// into by [`Self::stage_bundled_providers`] (`None` = it bundles none). Every
+    /// node resolves against THAT directory explicitly (CLOACI-T-0925) — the
+    /// resolution runs on a `spawn_blocking` thread, so reading a process-global
+    /// there would race every other tenant's concurrent load.
     pub(super) async fn step_load_constructor_nodes(
         &self,
         metadata: &WorkflowMetadata,
         library_data: &[u8],
+        provider_root: Option<std::path::PathBuf>,
     ) -> Result<(), RegistryError> {
         let declarations = self
             .package_loader
@@ -2327,6 +2398,7 @@ impl RegistryReconciler {
 
         #[cfg(not(feature = "constructors-wasm"))]
         {
+            let _ = provider_root;
             return Err(RegistryError::RegistrationFailed {
                 message: format!(
                     "package {} v{} declares {} constructor node(s), but this host was built \
@@ -2342,12 +2414,16 @@ impl RegistryReconciler {
         #[cfg(feature = "constructors-wasm")]
         {
             use crate::registry::loader::grants::GrantSpec;
-            use crate::registry::loader::load_constructor_node;
+            use crate::registry::loader::load_constructor_node_in;
 
-            // Stage this package's bundled providers (fail closed: decls with no
-            // bundle refuse to load — the hermetic guarantee).
-            let staged = self.stage_bundled_providers(metadata).await?;
-            if staged == 0 {
+            // Fail closed: decls with no bundle refuse to load — the hermetic
+            // guarantee. Step 0 already staged; re-stage only if the caller had
+            // nothing to hand us (keeps the direct-call test seam working).
+            let providers_root = match provider_root {
+                Some(root) => Some(root),
+                None => self.stage_bundled_providers(metadata).await?,
+            };
+            let Some(providers_root) = providers_root else {
                 return Err(RegistryError::RegistrationFailed {
                     message: format!(
                         "package {} v{} declares {} constructor node(s) but has NO bundled \
@@ -2358,7 +2434,7 @@ impl RegistryReconciler {
                         declarations.len()
                     ),
                 });
-            }
+            };
 
             let runtime =
                 self.runtime
@@ -2405,8 +2481,10 @@ impl RegistryReconciler {
                             })
                     })
                     .collect::<Result<_, _>>()?;
+                let search_path = providers_root.clone();
                 let node = tokio::task::spawn_blocking(move || {
-                    load_constructor_node(
+                    load_constructor_node_in(
+                        &search_path,
                         &node_id,
                         &from,
                         &constructor,
@@ -3011,7 +3089,7 @@ mod tests {
         let manifest = make_cloacina_metadata();
 
         let err = reconciler
-            .step_load_reactor_bound_cgs(&metadata, &view, &manifest, b"")
+            .step_load_reactor_bound_cgs(&metadata, &view, &manifest, b"", None)
             .await
             .expect_err("subscriber declaring accumulator outside upstream contract must error");
         let msg = format!("{:?}", err);
@@ -3051,7 +3129,7 @@ mod tests {
         let manifest = make_cloacina_metadata();
 
         let err = reconciler
-            .step_load_reactor_bound_cgs(&metadata, &view, &manifest, b"")
+            .step_load_reactor_bound_cgs(&metadata, &view, &manifest, b"", None)
             .await
             .expect_err("subscriber-before-publisher must error fast, no pending bindings");
         let msg = format!("{:?}", err);
@@ -3123,7 +3201,7 @@ mod tests {
         // appears in view.reactors. The downstream `load_graph` call
         // will spin its own reactor instance via the bundled-form path.
         let result = reconciler
-            .step_load_reactor_bound_cgs(&metadata, &view, &manifest, b"")
+            .step_load_reactor_bound_cgs(&metadata, &view, &manifest, b"", None)
             .await;
         assert!(
             result.is_ok(),
@@ -3441,7 +3519,7 @@ mod tests {
         };
 
         reconciler
-            .step_load_reactor_bound_cgs(&metadata, &view, &manifest, b"")
+            .step_load_reactor_bound_cgs(&metadata, &view, &manifest, b"", None)
             .await
             .expect("bundled-form graph load should succeed");
 
@@ -3616,7 +3694,7 @@ mod tests {
             let metadata = consumer_metadata();
 
             reconciler
-                .step_load_constructor_nodes(&metadata, consumer_cdylib())
+                .step_load_constructor_nodes(&metadata, consumer_cdylib(), None)
                 .await
                 .expect("Step 5b resolves the declared constructor node");
 
@@ -3671,7 +3749,7 @@ mod tests {
             let metadata = consumer_metadata();
 
             let err = reconciler
-                .step_load_constructor_nodes(&metadata, consumer_cdylib())
+                .step_load_constructor_nodes(&metadata, consumer_cdylib(), None)
                 .await
                 .expect_err("decls without bundled providers must fail closed");
             let msg = format!("{err:?}");

--- a/crates/cloacina/tests/constructor_provider_tenant_scope_wasm.rs
+++ b/crates/cloacina/tests/constructor_provider_tenant_scope_wasm.rs
@@ -1,0 +1,198 @@
+/*
+ *  Copyright 2026 Colliery Software
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+//! CLOACI-T-0925 — constructor/provider resolution respects the TENANT boundary.
+//!
+//! The bug: `constructor!(from = "provider@version")` resolved against ONE
+//! process-wide directory. A shared server process runs one reconciler per tenant,
+//! each on its own task, so tenant A's staged providers were visible to (and
+//! racily overwritten by) tenant B's resolution — a doctrine breach, since tenant
+//! is THE isolation boundary.
+//!
+//! What these tests pin:
+//!   * a provider staged for tenant A is NOT resolvable by tenant B's constructor
+//!     node in the SAME process — with both the explicit-directory entry point and
+//!     an installed per-load scope;
+//!   * a leftover process-wide override (what another tenant's load used to leave
+//!     behind) cannot leak into a scoped load;
+//!   * the embedded/untenanted path — `set_provider_search_path` + a plain
+//!     `load_constructor_node` — resolves exactly as it always did.
+//!
+//! Feature-gated (`constructors-wasm`); needs the `wasm32-wasip2` target to build
+//! the fixture provider.
+#![cfg(feature = "constructors-wasm")]
+
+use std::path::PathBuf;
+use std::sync::OnceLock;
+
+use cloacina::packaging::constructor_provider::{
+    package_constructor_provider, ProviderPackageOptions,
+};
+use cloacina::registry::loader::grants::GrantSpec;
+use cloacina::registry::loader::{
+    clear_provider_search_path, load_constructor_node, load_constructor_node_in,
+    set_provider_search_path, unpack_provider_archive, ProviderScope, ScopedProviderSearch,
+};
+use serde_json::json;
+
+fn fixture_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../examples/constructor-contract/task-constructor-macro-fixture")
+}
+
+/// Build the `prefix` provider ONCE and unpack it into a directory that stands in
+/// for ONE tenant's staged bundle. Tenant B deliberately gets nothing.
+struct Tenants {
+    _work: tempfile::TempDir,
+    /// Tenant A's staged providers — holds the `prefix` provider.
+    a: PathBuf,
+    /// Tenant B's staged providers — exists, but stages nothing.
+    b: PathBuf,
+}
+
+fn tenants() -> &'static Tenants {
+    static TENANTS: OnceLock<Tenants> = OnceLock::new();
+    TENANTS.get_or_init(|| {
+        let work = tempfile::TempDir::new().unwrap();
+        let a = work.path().join("tenant-a-providers");
+        let b = work.path().join("tenant-b-providers");
+        std::fs::create_dir_all(&a).unwrap();
+        std::fs::create_dir_all(&b).unwrap();
+
+        let archive = work.path().join("prefix.cloacina");
+        let opts = ProviderPackageOptions {
+            crate_dir: fixture_dir(),
+            output: Some(archive.clone()),
+            sign_key: None,
+            manifest_bin: "emit_manifest".to_string(),
+            runtime: cloacina_constructor_contract::ProviderRuntime::Wasm,
+            release: true,
+        };
+        package_constructor_provider(&opts).expect("package_constructor_provider");
+        unpack_provider_archive(&archive, &a, &[]).expect("unpack provider archive");
+
+        Tenants { _work: work, a, b }
+    })
+}
+
+fn node_config() -> Vec<(String, serde_json::Value)> {
+    vec![("prefix".to_string(), json!("hello, "))]
+}
+
+/// The heart of the ticket: same process, same `from`, two tenants — only the
+/// tenant that staged the provider resolves it.
+#[test]
+fn provider_staged_for_tenant_a_is_not_resolvable_by_tenant_b() {
+    let t = tenants();
+
+    load_constructor_node_in(
+        &t.a,
+        "greet",
+        "prefix@0.1.0",
+        "prefix",
+        node_config(),
+        vec![],
+        GrantSpec::default(),
+    )
+    .expect("tenant A staged this provider — its own node must resolve");
+
+    let err = load_constructor_node_in(
+        &t.b,
+        "greet",
+        "prefix@0.1.0",
+        "prefix",
+        node_config(),
+        vec![],
+        GrantSpec::default(),
+    )
+    .err()
+    .expect("tenant B staged NO providers — it must not see tenant A's tree");
+    let msg = err.to_string();
+    assert!(
+        msg.contains(&t.b.display().to_string()),
+        "the failure must name the tenant's OWN search path, got: {msg}"
+    );
+    assert!(
+        !msg.contains(&t.a.display().to_string()),
+        "tenant A's directory must never appear in tenant B's resolution: {msg}"
+    );
+}
+
+/// A scoped load ignores a process-wide override — which is exactly what another
+/// tenant's load used to leave behind when it pointed the global at its own tree.
+#[test]
+#[serial_test::serial(provider_search_path)]
+fn a_leftover_process_override_cannot_leak_into_a_scoped_load() {
+    let t = tenants();
+    // Stand in for "some other tenant's load set the global to its staged tree".
+    set_provider_search_path(&t.a);
+
+    {
+        let _scope = ScopedProviderSearch::enter(ProviderScope::Staged(t.b.clone()));
+        let scoped = load_constructor_node(
+            "greet",
+            "prefix@0.1.0",
+            "prefix",
+            node_config(),
+            vec![],
+            GrantSpec::default(),
+        );
+        assert!(
+            scoped.is_err(),
+            "a tenant-B-scoped load must not resolve tenant A's provider"
+        );
+    }
+
+    {
+        // A package that bundles NOTHING must not inherit the leftover either.
+        let _scope = ScopedProviderSearch::enter(ProviderScope::Unbundled);
+        let unbundled = load_constructor_node(
+            "greet",
+            "prefix@0.1.0",
+            "prefix",
+            node_config(),
+            vec![],
+            GrantSpec::default(),
+        );
+        assert!(
+            unbundled.is_err(),
+            "an unbundled package must not inherit the process-wide override"
+        );
+    }
+
+    clear_provider_search_path();
+}
+
+/// Embedded/untenanted parity: no scope in play, `set_provider_search_path` +
+/// `load_constructor_node` behave exactly as before T-0925.
+#[test]
+#[serial_test::serial(provider_search_path)]
+fn embedded_untenanted_path_is_unchanged() {
+    let t = tenants();
+    set_provider_search_path(&t.a);
+
+    load_constructor_node(
+        "greet",
+        "prefix@0.1.0",
+        "prefix",
+        node_config(),
+        vec![],
+        GrantSpec::default(),
+    )
+    .expect("with no scope installed, the process-wide override still resolves");
+
+    clear_provider_search_path();
+}

--- a/crates/cloacina/tests/constructor_reactor_scheduler_wasm.rs
+++ b/crates/cloacina/tests/constructor_reactor_scheduler_wasm.rs
@@ -54,9 +54,6 @@ use cloacina::computation_graph::scheduler::{
 };
 use cloacina::computation_graph::types::{GraphResult, InputCache, SourceName};
 use cloacina::computation_graph::Accumulator;
-use cloacina::registry::loader::constructor_loader::{
-    clear_provider_search_path, set_provider_search_path,
-};
 
 // ---------------------------------------------------------------------------
 // Fixture build + staging (mirrors constructor_reactor_wasm.rs)
@@ -174,12 +171,15 @@ impl AccumulatorFactory for PassthroughFactory {
 /// Drive a graph whose reactor is a WASM `#[constructor(kind = reactor)]` gate,
 /// loaded + fired entirely through the scheduler. `gate` is bound BY NAME via the
 /// declaration's `config`; the graph fires only when the guest's `evaluate` says so.
+// CLOACI-T-0925: both tests below used to carry
+// `#[serial_test::serial(provider_search_path)]` because they had to mutate the
+// PROCESS-WIDE provider search path (and clear it again on the way out). They now
+// hand the scheduler this test's own provider directory via `load_graph_in`,
+// touch no shared state, and need no serialization.
 #[tokio::test]
-#[serial_test::serial(provider_search_path)]
 async fn reactor_constructor_fires_via_scheduler() {
     let tmp = tempfile::TempDir::new().unwrap();
     stage(tmp.path());
-    set_provider_search_path(tmp.path());
 
     let registry = EndpointRegistry::new();
     let scheduler = ComputationGraphScheduler::new(registry.clone());
@@ -220,7 +220,7 @@ async fn reactor_constructor_fires_via_scheduler() {
     };
 
     scheduler
-        .load_graph(decl)
+        .load_graph_in(decl, Some(tmp.path()))
         .await
         .expect("load_graph with reactor constructor should resolve + install the WASM evaluator");
 
@@ -262,19 +262,15 @@ async fn reactor_constructor_fires_via_scheduler() {
         fired,
         "above-gate boundary should fire the graph via the scheduler-installed WASM evaluator"
     );
-
-    clear_provider_search_path();
 }
 
 /// A reactor constructor whose declared name doesn't match the provider's
 /// `constructor.json` name fails the load closed — the author asked for a
 /// constructor the provider does not carry.
 #[tokio::test]
-#[serial_test::serial(provider_search_path)]
 async fn reactor_constructor_name_mismatch_fails_closed() {
     let tmp = tempfile::TempDir::new().unwrap();
     stage(tmp.path());
-    set_provider_search_path(tmp.path());
 
     let registry = EndpointRegistry::new();
     let scheduler = ComputationGraphScheduler::new(registry.clone());
@@ -306,13 +302,11 @@ async fn reactor_constructor_name_mismatch_fails_closed() {
     };
 
     let err = scheduler
-        .load_graph(decl)
+        .load_graph_in(decl, Some(tmp.path()))
         .await
         .expect_err("a constructor-name mismatch must fail the load closed");
     assert!(
         err.contains("not_the_gate") || err.contains("gate"),
         "error should name the requested/resolved constructor, got: {err}"
     );
-
-    clear_provider_search_path();
 }

--- a/docs/content/engine/constructors/consume-a-provider.md
+++ b/docs/content/engine/constructors/consume-a-provider.md
@@ -183,3 +183,21 @@ bundle: the process-wide override (`set_provider_search_path`), else
 `CLOACINA_PROVIDER_PATH`, else `./providers`. Stage provider packages there
 (e.g. via `cloacinactl constructor package` + unpack). The runnable
 `examples/constructor-contract/fs-grant-demo` shows the full embedded flow.
+
+Full precedence, highest first:
+
+1. the **per-load scope** — the directory a host staged for the package being
+   loaded. This is what the server's reconciler installs, and it is per package
+   (and therefore per tenant), never shared;
+2. the process-wide `set_provider_search_path` override;
+3. `CLOACINA_PROVIDER_PATH`;
+4. `./providers`.
+
+`set_provider_search_path` is the **embedded/single-tenant** knob. A multi-tenant
+host must not use it: every tenant would resolve `from` against one directory, so
+one tenant's staged providers would be visible to another's constructor nodes.
+Hosts scope each load instead (the loader's `*_in` entry points take the directory
+explicitly, and `ScopedProviderSearch` installs it for call sites like Python's
+`cloaca.constructor(...)` that cannot take an argument). A package that bundles no
+providers gets a scope that deliberately skips level 2, so it can never inherit
+another load's staged tree.


### PR DESCRIPTION
## Summary

**The exposure was worse than the ticket assumed, not narrower.** The ticket supposed the reconciler's hermetic per-package staging might already isolate packaged loads, leaving only the embedded knob exposed — I asked the implementation to verify that before building anything. Phase-1 verification found a **live cross-tenant race**:

- **Staging was set-only.** `stage_bundled_providers` called `set_provider_search_path` and never restored the previous value; an empty bundle called `clear_provider_search_path`, which falls *through* to env/`providers` rather than failing closed.
- **Loads are not serialized across tenants.** Serialization holds only within one reconciler — but each tenant gets its own `DefaultRunner`, and every runner spawns its own reconciliation loop as an independent tokio task. No process-wide load lock exists, and the load path yields at many awaits between staging and resolution, so tenant B's `set_provider_search_path` lands inside tenant A's window.
- **Two resolution sites read the global from a different task entirely**, outside any staging window: the provider-backed stream accumulator (spawned) and the reactor evaluator (`spawn_blocking`).
- **The Python computation-graph branch never staged its own bundle at all** — it resolved against whatever the previous load left behind.

## Design — explicit parameter first, ambient scope only where a parameter can't reach

New `ProviderScope` / `ScopedProviderSearch` (thread-local, nestable RAII, mirroring T-0921's `registration_scope`) plus `*_in` variants of the load primitives taking the root explicitly. Precedence is now **scope → process override → `CLOACINA_PROVIDER_PATH` → `providers`**; unscoped behavior is byte-for-byte unchanged.

`stage_bundled_providers` returns the root instead of mutating the global, and the reconciler threads it into the reactor / reactor-bound-CG / constructor-node steps. Deferred sites bind their root at declaration-build time rather than reading a global from a spawned task. The Python path installs the scope inside `spawn_blocking` and re-installs it on the import thread — the same treatment `ScopedRuntime` and `ScopedRegistration` already get.

Tenant identity **couldn't** simply be threaded everywhere: the macro and the Python bridge can't supply one at authoring call sites, which is why the scope is ambient there rather than a parameter.

The global survives as the documented lowest-precedence embedded/single-tenant knob, with its docs now stating a multi-tenant host must not use it.

## Test plan
- New `constructor_provider_tenant_scope_wasm.rs` (3): tenant A's provider isn't resolvable by tenant B and B's error names only B's directory; a leftover process override can't leak into a scoped load; embedded behavior unchanged
- New lib `provider_scope_tests` (4): precedence, nesting/restore, capture-reinstall across a thread hop
- Green across tenant-scope 3, reactor-scheduler 2, workflow-node 4, runtime-pin 7, packaged-e2e 3, provider-bundle 7, lib scope 4, reconciler 29 (wasm32-wasip2 present, so the gated suites actually ran)
- `cargo check` clean for cloacina (both backends), constructors-wasm --tests, cloacina-python --tests, -agent, -server

**Serial-annotation cleanup**: both tests in `constructor_reactor_scheduler_wasm.rs` dropped `#[serial_test::serial(provider_search_path)]` — they pass their own directory via `load_graph_in` now, so the shared-global serialization they existed to work around is gone. That annotation's existence was itself evidence for this fix.

## Deliberately left
`cloacina-agent` still uses the global (single-tenant process — that's the knob's purpose); embedded macro-emitted loads still resolve ambiently (packaged builds emit declarations instead); pre-existing T-0836 caveats untouched.