### PR TITLE
fix(T-0924): key Runtime and CG scheduler registries by tenant

### DIFF
--- a/crates/cloacina-python/tests/cross_language_fan_out.rs
+++ b/crates/cloacina-python/tests/cross_language_fan_out.rs
@@ -44,6 +44,7 @@ use cloacina::computation_graph::scheduler::{
     AccumulatorDeclaration, AccumulatorFactory, AccumulatorSpawnConfig, ComputationGraphScheduler,
 };
 use cloacina::computation_graph::types::{GraphResult, InputCache, SourceName};
+use cloacina::tenant_scope::TenantScope;
 use cloacina_workflow_plugin::{AccumulatorDeclarationEntry, GraphPackageMetadata};
 
 use cloacina_python::computation_graph::{
@@ -268,7 +269,16 @@ with ComputationGraphBuilder("py_g", reactor=SharedRx, graph={
 
     // Cleanup — explicit unbind + unload_reactor, exercising the M4 lifecycle
     // primitives.
-    scheduler.unbind_graph_from_reactor("rust_g").await.unwrap();
-    scheduler.unbind_graph_from_reactor("py_g").await.unwrap();
-    scheduler.unload_reactor("shared_rx").await.unwrap();
+    scheduler
+        .unbind_graph_from_reactor("rust_g", TenantScope::untenanted())
+        .await
+        .unwrap();
+    scheduler
+        .unbind_graph_from_reactor("py_g", TenantScope::untenanted())
+        .await
+        .unwrap();
+    scheduler
+        .unload_reactor("shared_rx", TenantScope::untenanted())
+        .await
+        .unwrap();
 }

--- a/crates/cloacina-python/tests/python_reactor_library.rs
+++ b/crates/cloacina-python/tests/python_reactor_library.rs
@@ -36,6 +36,7 @@ use pyo3::prelude::*;
 
 use cloacina::computation_graph::registry::{EndpointRegistry, EndpointScope};
 use cloacina::computation_graph::scheduler::ComputationGraphScheduler;
+use cloacina::tenant_scope::TenantScope;
 
 use cloacina_python::reactor as py_reactor;
 use cloacina_python::runtime_scope::ScopedRuntime;
@@ -127,8 +128,14 @@ class LibRxB: pass
         .expect("idempotent re-dispatch should succeed");
 
     // ---- Cleanup ----
-    scheduler.unload_reactor("lib_rx_a").await.unwrap();
-    scheduler.unload_reactor("lib_rx_b").await.unwrap();
+    scheduler
+        .unload_reactor("lib_rx_a", TenantScope::untenanted())
+        .await
+        .unwrap();
+    scheduler
+        .unload_reactor("lib_rx_b", TenantScope::untenanted())
+        .await
+        .unwrap();
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -184,7 +191,12 @@ class CrossPkgRx: pass
         })
     });
     scheduler
-        .bind_graph_to_reactor("late_g".to_string(), "cross_pkg_rx".to_string(), graph_fn)
+        .bind_graph_to_reactor(
+            "late_g".to_string(),
+            "cross_pkg_rx".to_string(),
+            TenantScope::untenanted(),
+            graph_fn,
+        )
         .await
         .expect("bind should succeed against the Python-declared reactor");
 
@@ -207,8 +219,14 @@ class CrossPkgRx: pass
         "late-bound graph should fire"
     );
 
-    scheduler.unbind_graph_from_reactor("late_g").await.unwrap();
-    scheduler.unload_reactor("cross_pkg_rx").await.unwrap();
+    scheduler
+        .unbind_graph_from_reactor("late_g", TenantScope::untenanted())
+        .await
+        .unwrap();
+    scheduler
+        .unload_reactor("cross_pkg_rx", TenantScope::untenanted())
+        .await
+        .unwrap();
 }
 
 /// T-0545 M3a end-to-end: a Python *workflow* package that registers only

--- a/crates/cloacina-server/src/lib.rs
+++ b/crates/cloacina-server/src/lib.rs
@@ -4932,21 +4932,35 @@ mod tests {
             .await
             .expect("runner B");
 
-        // The cache's `shared_runtime` accessor should match what each
-        // runner reports via its `runtime()` accessor.
+        // Each runner's `Runtime` handle must be a VIEW over the cache's
+        // shared registries — same allocation underneath, so inventory is not
+        // duplicated per tenant. CLOACI-T-0924: it is no longer the same
+        // `Arc<Runtime>`, because each runner binds the handle to its own
+        // tenant; `shares_registries_with` is the honest identity check.
         let cache_rt = state.tenant_runners.shared_runtime();
         assert!(
-            std::sync::Arc::ptr_eq(&cache_rt, &runner_a.runtime()),
-            "runner A's Runtime Arc should match the cache's shared_runtime"
+            cache_rt.shares_registries_with(&runner_a.runtime()),
+            "runner A's Runtime must share the cache's shared_runtime registries"
         );
         assert!(
-            std::sync::Arc::ptr_eq(&cache_rt, &runner_b.runtime()),
-            "runner B's Runtime Arc should match the cache's shared_runtime"
+            cache_rt.shares_registries_with(&runner_b.runtime()),
+            "runner B's Runtime must share the cache's shared_runtime registries"
         );
-        // Transitively, both runners share the same Arc.
+        // Transitively, both runners share one registry allocation…
         assert!(
-            std::sync::Arc::ptr_eq(&runner_a.runtime(), &runner_b.runtime()),
-            "two tenant runners must share the same Runtime Arc (inventory not duplicated)"
+            runner_a
+                .runtime()
+                .shares_registries_with(&runner_b.runtime()),
+            "two tenant runners must share the same Runtime registries (inventory not duplicated)"
+        );
+        // …but are scoped to DIFFERENT tenants, which is what stops two
+        // tenants' same-named workflows/graphs/reactors colliding in-process
+        // (CLOACI-T-0924).
+        assert_eq!(runner_a.runtime().tenant_id(), Some(schema_a.as_str()));
+        assert_eq!(runner_b.runtime().tenant_id(), Some(schema_b.as_str()));
+        assert_ne!(
+            runner_a.runtime().tenant_id(),
+            runner_b.runtime().tenant_id()
         );
 
         // Clean up: drop both tenants.

--- a/crates/cloacina/src/computation_graph/scheduler.rs
+++ b/crates/cloacina/src/computation_graph/scheduler.rs
@@ -34,6 +34,7 @@ use super::reactor::{
 };
 use super::registry::{AccumulatorAuthPolicy, EndpointRegistry, ReactorAuthPolicy};
 use super::types::{GraphResult, InputCache, SourceName};
+use crate::tenant_scope::{resolve_tenant_key, TenantKey, TenantScope};
 
 /// Declaration of a computation graph to be loaded by the [`ComputationGraphScheduler`].
 #[derive(Clone)]
@@ -469,7 +470,9 @@ enum PlannedRestart {
     /// The reactor task exited — full-graph restart (new channels,
     /// re-spawned accumulators + reactor).
     Reactor {
-        reactor_name: String,
+        /// Full `(tenant, name)` key of the reactor to restart
+        /// (CLOACI-T-0924).
+        reactor_key: TenantKey,
         /// `"{reactor}::reactor"` — recovery-event component key.
         component_key: String,
         /// Failure count at detection time (drives the recovery event).
@@ -481,7 +484,7 @@ enum PlannedRestart {
     },
     /// An accumulator task exited — in-place respawn.
     Accumulator {
-        reactor_name: String,
+        reactor_key: TenantKey,
         acc_name: String,
         component_key: String,
         attempt: u32,
@@ -499,18 +502,27 @@ pub struct ComputationGraphScheduler {
     /// the server swaps in its fleet executor under `--default-executor
     /// fleet`. Applied to every reactor spawned (and re-spawned) after set.
     graph_executor: Arc<RwLock<Arc<dyn super::graph_executor::GraphExecutor>>>,
-    /// Running reactors, keyed by reactor name. Each reactor owns a subscriber
-    /// map that may contain one or more graphs sharing this reactor instance.
-    reactors: Arc<RwLock<HashMap<String, RunningGraph>>>,
-    /// Maps graph_name → reactor_name so external operations that take a
+    /// Running reactors, keyed by `(tenant, reactor name)`. Each reactor owns a
+    /// subscriber map that may contain one or more graphs sharing this reactor
+    /// instance.
+    ///
+    /// CLOACI-T-0924: ONE scheduler `Arc` serves every tenant
+    /// (`cloacina-server`'s `TenantRunnerCache` installs the same instance on
+    /// every per-tenant runner), so the tenant has to be in the key — bare
+    /// names let two tenants' same-named reactors collide in-process.
+    /// `tenant_id: None` is the embedded/untenanted entry.
+    reactors: Arc<RwLock<HashMap<TenantKey, RunningGraph>>>,
+    /// Maps graph key → reactor key so external operations that take a
     /// graph_name (`unload_graph`, `list_graphs`) can find the reactor that
-    /// hosts it.
-    graph_to_reactor: Arc<RwLock<HashMap<String, String>>>,
-    /// Maps graph_name → serialized node/edge topology JSON, captured from the
+    /// hosts it. The *value* is a full key, not a name, so a subscriber in one
+    /// tenant that bound to an untenanted upstream reactor still points at the
+    /// exact reactor entry it bound to.
+    graph_to_reactor: Arc<RwLock<HashMap<TenantKey, TenantKey>>>,
+    /// Maps graph key → serialized node/edge topology JSON, captured from the
     /// declaration at load so the health API can surface the CG DAG without
     /// digging through the synthetic per-reactor anchor declaration.
     /// (CLOACI-T-0673)
-    graph_topologies: Arc<RwLock<HashMap<String, String>>>,
+    graph_topologies: Arc<RwLock<HashMap<TenantKey, String>>>,
     /// DAL handle for persistence. None in embedded/test mode.
     dal: Option<crate::dal::unified::DAL>,
 }
@@ -612,10 +624,18 @@ impl ComputationGraphScheduler {
         provider_root: Option<&std::path::Path>,
     ) -> Result<(), String> {
         let provider_root = provider_root.map(|p| p.to_path_buf());
+
+        // CLOACI-T-0924: a load is a CLAIM, so it addresses the caller's own
+        // `(tenant, name)` key exactly — never the untenanted fallback. A
+        // tenant loading `R` gets its own `R` even if an untenanted `R` is
+        // already running; with `tenant_id: None` (embedded) the key IS the
+        // bare name, so this path is byte-for-byte what it was.
+        let reactor_key = TenantKey::new(tenant_id.as_deref(), &reactor_name);
+
         // Idempotent path: matching contract → no-op.
         {
             let reactors = self.reactors.read().await;
-            if let Some(existing) = reactors.get(&reactor_name) {
+            if let Some(existing) = reactors.get(&reactor_key) {
                 let probe = ComputationGraphDeclaration {
                     name: reactor_name.clone(),
                     accumulators: accumulators.clone(),
@@ -889,7 +909,7 @@ impl ComputationGraphScheduler {
             evaluator,
         };
 
-        self.reactors.write().await.insert(reactor_name, running);
+        self.reactors.write().await.insert(reactor_key, running);
         Ok(())
     }
 
@@ -899,38 +919,61 @@ impl ComputationGraphScheduler {
     /// transitively via [`load_graph`]); this entry point doesn't spawn
     /// reactors. Returns an error if the reactor isn't loaded or if a graph
     /// with the same name is already bound somewhere.
+    ///
+    /// CLOACI-T-0924: `scope` is the *binding tenant*. The graph is claimed
+    /// under `scope`'s own key, while the upstream reactor is **resolved**
+    /// within `scope` — own tenant first, then the untenanted (embedded /
+    /// pre-multi-tenancy) reactor. A tenant can therefore subscribe to an
+    /// untenanted upstream, but never to another tenant's.
     pub async fn bind_graph_to_reactor(
         &self,
         graph_name: String,
         reactor_name: String,
+        scope: TenantScope<'_>,
         graph_fn: CompiledGraphFn,
     ) -> Result<(), String> {
+        let graph_key = scope.own_key(&graph_name);
         {
             let g2r = self.graph_to_reactor.read().await;
-            if g2r.contains_key(&graph_name) {
+            if g2r.contains_key(&graph_key) {
                 return Err(format!("graph '{}' already loaded", graph_name));
             }
         }
 
-        {
+        let reactor_key = {
             let reactors = self.reactors.read().await;
+            let reactor_key = resolve_tenant_key(&*reactors, scope, &reactor_name)
+                .map_err(|_| format!("reactor '{}' is not loaded", reactor_name))?;
             let existing = reactors
-                .get(&reactor_name)
+                .get(&reactor_key)
                 .ok_or_else(|| format!("reactor '{}' is not loaded", reactor_name))?;
-            existing
-                .subscribers
-                .write()
-                .await
-                .insert(graph_name.clone(), graph_fn);
-        }
+            let mut subs = existing.subscribers.write().await;
+            // The per-reactor subscriber map is keyed by bare graph name (the
+            // dispatcher labels results with it). The `graph_to_reactor`
+            // pre-check above already rejects a same-tenant duplicate, so a
+            // name that is still present here means a DIFFERENT tenant bound a
+            // same-named graph to this same (necessarily untenanted) reactor.
+            // Refuse loudly rather than silently replacing their graph_fn.
+            if subs.contains_key(&graph_name) {
+                return Err(format!(
+                    "graph '{}' is already bound to reactor '{}' by another tenant; \
+                     rename the graph or load a tenant-scoped reactor",
+                    graph_name, reactor_name
+                ));
+            }
+            subs.insert(graph_name.clone(), graph_fn);
+            drop(subs);
+            reactor_key
+        };
         self.graph_to_reactor
             .write()
             .await
-            .insert(graph_name.clone(), reactor_name.clone());
+            .insert(graph_key, reactor_key);
 
         info!(
             graph = %graph_name,
             reactor = %reactor_name,
+            tenant = %scope.tenant_id.unwrap_or("<untenanted>"),
             "graph bound to reactor"
         );
         Ok(())
@@ -966,14 +1009,20 @@ impl ComputationGraphScheduler {
             .reactor_name
             .clone()
             .unwrap_or_else(|| format!("__Reactor_{}", name));
+        // CLOACI-T-0924: the declaration's tenant is the scope for everything
+        // this load claims. `None` (embedded / bundled-form tests) keeps the
+        // untenanted keys the pre-T-0924 code used.
+        let scope = TenantScope::of(decl.tenant_id.as_deref());
+        let graph_key = scope.own_key(&name);
 
         // Pre-check: reject re-loading the same graph regardless of which
         // reactor it was bound to. (load_reactor + bind_graph_to_reactor
         // would catch this too, but doing it here keeps the error message
-        // precise.)
+        // precise.) Scoped to this tenant — another tenant's same-named graph
+        // is a different entry entirely.
         {
             let g2r = self.graph_to_reactor.read().await;
-            if g2r.contains_key(&name) {
+            if g2r.contains_key(&graph_key) {
                 return Err(format!("graph '{}' already loaded", name));
             }
         }
@@ -987,7 +1036,7 @@ impl ComputationGraphScheduler {
             self.graph_topologies
                 .write()
                 .await
-                .insert(name.clone(), topology);
+                .insert(graph_key.clone(), topology);
         }
 
         // Cross-package subscriber path: when the named reactor is
@@ -1001,11 +1050,11 @@ impl ComputationGraphScheduler {
         if decl.reactor_name.is_some() && decl.accumulators.is_empty() {
             let already_loaded = {
                 let reactors = self.reactors.read().await;
-                reactors.contains_key(&reactor_name)
+                resolve_tenant_key(&*reactors, scope, &reactor_name).is_ok()
             };
             if already_loaded {
                 return self
-                    .bind_graph_to_reactor(name, reactor_name, decl.reactor.graph_fn)
+                    .bind_graph_to_reactor(name, reactor_name, scope, decl.reactor.graph_fn)
                     .await;
             }
         }
@@ -1026,7 +1075,7 @@ impl ComputationGraphScheduler {
         )
         .await?;
 
-        self.bind_graph_to_reactor(name, reactor_name, decl.reactor.graph_fn)
+        self.bind_graph_to_reactor(name, reactor_name, scope, decl.reactor.graph_fn)
             .await
     }
 
@@ -1096,18 +1145,28 @@ impl ComputationGraphScheduler {
     /// accumulators) keeps running, ready for new subscribers. This is the
     /// honest lifecycle primitive — reactors are independent units; binding
     /// and unbinding subscribers is decoupled from reactor teardown.
-    pub async fn unbind_graph_from_reactor(&self, name: &str) -> Result<String, String> {
-        let reactor_name = {
+    ///
+    /// CLOACI-T-0924: `name` is resolved within `scope` (own tenant, then the
+    /// untenanted entry), so a caller can only unbind a graph it can see.
+    /// Returns the full [`TenantKey`] of the reactor the graph was bound to.
+    pub async fn unbind_graph_from_reactor(
+        &self,
+        name: &str,
+        scope: TenantScope<'_>,
+    ) -> Result<TenantKey, String> {
+        let reactor_key = {
             let mut g2r = self.graph_to_reactor.write().await;
-            g2r.remove(name)
+            let graph_key = resolve_tenant_key(&*g2r, scope, name)
+                .map_err(|_| format!("graph '{}' not loaded", name))?;
+            // Drop the cached topology for this graph. (CLOACI-T-0673)
+            self.graph_topologies.write().await.remove(&graph_key);
+            g2r.remove(&graph_key)
                 .ok_or_else(|| format!("graph '{}' not loaded", name))?
         };
-        // Drop the cached topology for this graph. (CLOACI-T-0673)
-        self.graph_topologies.write().await.remove(name);
 
         let remaining = {
             let reactors = self.reactors.read().await;
-            if let Some(running) = reactors.get(&reactor_name) {
+            if let Some(running) = reactors.get(&reactor_key) {
                 let mut subs = running.subscribers.write().await;
                 subs.remove(name);
                 subs.len()
@@ -1116,18 +1175,18 @@ impl ComputationGraphScheduler {
                 // an error rather than silently no-oping.
                 return Err(format!(
                     "graph '{}' was bound to reactor '{}' but the reactor is not loaded",
-                    name, reactor_name
+                    name, reactor_key.name
                 ));
             }
         };
 
         info!(
             graph = %name,
-            reactor = %reactor_name,
+            reactor = %reactor_key,
             remaining_subscribers = remaining,
             "graph unbound from reactor"
         );
-        Ok(reactor_name)
+        Ok(reactor_key)
     }
 
     /// Tear down a reactor and its accumulators. Rejects if the reactor has
@@ -1135,12 +1194,25 @@ impl ComputationGraphScheduler {
     /// is the lifecycle guard that makes "reactors as independent units"
     /// safe: a reactor never disappears out from under a graph that's still
     /// declaring it as an upstream.
-    pub async fn unload_reactor(&self, reactor_name: &str) -> Result<(), String> {
+    ///
+    /// CLOACI-T-0924: `reactor_name` is resolved within `scope`. A tenant can
+    /// only tear down its own reactor (or an untenanted one it can already
+    /// address); another tenant's same-named reactor is simply "not loaded".
+    pub async fn unload_reactor(
+        &self,
+        reactor_name: &str,
+        scope: TenantScope<'_>,
+    ) -> Result<(), String> {
         // Snapshot subscribers under read lock so we can build a precise
         // error message if any remain.
+        let reactor_key = {
+            let reactors = self.reactors.read().await;
+            resolve_tenant_key(&*reactors, scope, reactor_name)
+                .map_err(|_| format!("reactor '{}' not loaded", reactor_name))?
+        };
         let subscriber_names: Vec<String> = {
             let reactors = self.reactors.read().await;
-            match reactors.get(reactor_name) {
+            match reactors.get(&reactor_key) {
                 Some(running) => running.subscribers.read().await.keys().cloned().collect(),
                 None => return Err(format!("reactor '{}' not loaded", reactor_name)),
             }
@@ -1157,7 +1229,7 @@ impl ComputationGraphScheduler {
         let running = {
             let mut reactors = self.reactors.write().await;
             reactors
-                .remove(reactor_name)
+                .remove(&reactor_key)
                 .ok_or_else(|| format!("reactor '{}' not loaded", reactor_name))?
         };
 
@@ -1202,22 +1274,29 @@ impl ComputationGraphScheduler {
     /// `unload_graph(name)` removes everything the matching `load_graph`
     /// brought in). For independent reactor lifecycles, prefer
     /// [`unbind_graph_from_reactor`] + explicit [`unload_reactor`].
-    pub async fn unload_graph(&self, name: &str) -> Result<(), String> {
-        let reactor_name = self.unbind_graph_from_reactor(name).await?;
+    pub async fn unload_graph(&self, name: &str, scope: TenantScope<'_>) -> Result<(), String> {
+        let reactor_key = self.unbind_graph_from_reactor(name, scope).await?;
 
         // If subscribers are now empty, tear down the reactor for back-compat
         // with bundled-form callers.
         let now_empty = {
             let reactors = self.reactors.read().await;
-            match reactors.get(&reactor_name) {
+            match reactors.get(&reactor_key) {
                 Some(running) => running.subscribers.read().await.is_empty(),
                 None => false,
             }
         };
         if now_empty {
-            self.unload_reactor(&reactor_name).await?;
+            // Address the reactor in ITS own scope — a tenant graph bound to
+            // an untenanted upstream must still resolve back to that exact
+            // entry, not to a same-named one in the caller's tenant.
+            self.unload_reactor(
+                &reactor_key.name,
+                TenantScope::of(reactor_key.tenant_id.as_deref()),
+            )
+            .await?;
         }
-        info!(graph = %name, reactor = %reactor_name, "computation graph unloaded");
+        info!(graph = %name, reactor = %reactor_key, "computation graph unloaded");
         Ok(())
     }
 
@@ -1225,9 +1304,14 @@ impl ComputationGraphScheduler {
     /// order. Returns `None` if the reactor isn't loaded. Used by the
     /// reconciler to pre-validate cross-package subscriber bindings against
     /// the upstream reactor's contract before calling [`load_graph`].
-    pub async fn reactor_accumulator_names(&self, reactor_name: &str) -> Option<Vec<String>> {
+    pub async fn reactor_accumulator_names(
+        &self,
+        reactor_name: &str,
+        scope: TenantScope<'_>,
+    ) -> Option<Vec<String>> {
         let reactors = self.reactors.read().await;
-        reactors.get(reactor_name).map(|running| {
+        let key = resolve_tenant_key(&*reactors, scope, reactor_name).ok()?;
+        reactors.get(&key).map(|running| {
             running
                 .accumulator_handles
                 .iter()
@@ -1244,9 +1328,9 @@ impl ComputationGraphScheduler {
         let reactors = self.reactors.read().await;
         let topologies = self.graph_topologies.read().await;
         g2r.iter()
-            .filter_map(|(graph_name, reactor_name)| {
-                reactors.get(reactor_name).map(|running| GraphStatus {
-                    name: graph_name.clone(),
+            .filter_map(|(graph_key, reactor_key)| {
+                reactors.get(reactor_key).map(|running| GraphStatus {
+                    name: graph_key.name.clone(),
                     accumulators: running
                         .accumulator_handles
                         .iter()
@@ -1258,8 +1342,11 @@ impl ComputationGraphScheduler {
                         .reactor_health_rx
                         .as_ref()
                         .map(|rx| rx.borrow().clone()),
-                    tenant_id: running.declaration.tenant_id.clone(),
-                    topology: topologies.get(graph_name).cloned(),
+                    // CLOACI-T-0924: the key is now the authority on tenancy —
+                    // it is what isolation is enforced on. (It matches the
+                    // declaration's `tenant_id`, which set it at load.)
+                    tenant_id: graph_key.tenant_id.clone(),
+                    topology: topologies.get(graph_key).cloned(),
                     reactor: running.declaration.reactor_name.clone(),
                     reaction_mode: match running.declaration.reactor.criteria {
                         ReactionCriteria::WhenAny => "when_any".to_string(),
@@ -1285,15 +1372,15 @@ impl ComputationGraphScheduler {
         let g2r = self.graph_to_reactor.read().await;
         reactors
             .iter()
-            .map(|(reactor_name, running)| {
+            .map(|(reactor_key, running)| {
                 let bound_graphs: Vec<String> = g2r
                     .iter()
-                    .filter(|(_, r)| *r == reactor_name)
-                    .map(|(g, _)| g.clone())
+                    .filter(|(_, r)| *r == reactor_key)
+                    .map(|(g, _)| g.name.clone())
                     .collect();
                 let (fires, last_fire_unix_ms) = running.reactor_shared.stats();
                 ReactorStatus {
-                    name: reactor_name.clone(),
+                    name: reactor_key.name.clone(),
                     accumulators: running
                         .accumulator_handles
                         .iter()
@@ -1314,7 +1401,8 @@ impl ComputationGraphScheduler {
                         .reactor_health_rx
                         .as_ref()
                         .map(|rx| rx.borrow().clone()),
-                    tenant_id: running.declaration.tenant_id.clone(),
+                    // CLOACI-T-0924: tenancy comes from the key.
+                    tenant_id: reactor_key.tenant_id.clone(),
                     fires,
                     last_fire_unix_ms,
                 }
@@ -1346,7 +1434,12 @@ impl ComputationGraphScheduler {
             let mut graphs = self.reactors.write().await;
             let mut plans = Vec::new();
 
-            for (graph_name, running) in graphs.iter_mut() {
+            for (reactor_key, running) in graphs.iter_mut() {
+                // Metric/log labels stay bare names (CLOACI-T-0924 keeps the
+                // `cloacina_component_health` label vocabulary unchanged); the
+                // restart plan carries the full key so phase 3 re-finds the
+                // exact entry.
+                let graph_name = reactor_key.name.as_str();
                 // Reset failure counts for components that have been running successfully
                 let success_threshold = std::time::Duration::from_secs(SUCCESS_RESET_SECS);
                 let names_to_reset: Vec<String> = running
@@ -1362,10 +1455,10 @@ impl ComputationGraphScheduler {
 
                 // Check reactor
                 if running.reactor_handle.is_finished() {
-                    let reactor_key = format!("{}::reactor", graph_name);
+                    let component_key = format!("{}::reactor", graph_name);
                     let failures = running
                         .failure_counts
-                        .entry(reactor_key.clone())
+                        .entry(component_key.clone())
                         .or_insert(0);
                     *failures += 1;
 
@@ -1397,8 +1490,8 @@ impl ComputationGraphScheduler {
                     );
 
                     plans.push(PlannedRestart::Reactor {
-                        reactor_name: graph_name.clone(),
-                        component_key: reactor_key,
+                        reactor_key: reactor_key.clone(),
+                        component_key,
                         attempt: *failures,
                         backoff_secs,
                         dead,
@@ -1449,7 +1542,7 @@ impl ComputationGraphScheduler {
                             tokio::spawn(async {}),
                         );
                         plans.push(PlannedRestart::Accumulator {
-                            reactor_name: graph_name.clone(),
+                            reactor_key: reactor_key.clone(),
                             acc_name,
                             component_key: acc_key,
                             attempt: *failures,
@@ -1471,7 +1564,7 @@ impl ComputationGraphScheduler {
         for plan in plans {
             match plan {
                 PlannedRestart::Reactor {
-                    reactor_name,
+                    reactor_key,
                     component_key,
                     attempt,
                     backoff_secs,
@@ -1483,14 +1576,14 @@ impl ComputationGraphScheduler {
                         .await;
                     tokio::time::sleep(std::time::Duration::from_secs(backoff_secs)).await;
                     if self
-                        .restart_reactor_after_backoff(&reactor_name, reason, now)
+                        .restart_reactor_after_backoff(&reactor_key, reason, now)
                         .await
                     {
                         restarted += 1;
                     }
                 }
                 PlannedRestart::Accumulator {
-                    reactor_name,
+                    reactor_key,
                     acc_name,
                     component_key,
                     attempt,
@@ -1502,7 +1595,7 @@ impl ComputationGraphScheduler {
                         .await;
                     tokio::time::sleep(std::time::Duration::from_secs(backoff_secs)).await;
                     if self
-                        .restart_accumulator_after_backoff(&reactor_name, &acc_name, reason, now)
+                        .restart_accumulator_after_backoff(&reactor_key, &acc_name, reason, now)
                         .await
                     {
                         restarted += 1;
@@ -1522,12 +1615,14 @@ impl ComputationGraphScheduler {
     /// (e.g. unload + reload). Returns whether a restart actually happened.
     async fn restart_reactor_after_backoff(
         &self,
-        reactor_name: &str,
+        reactor_key: &TenantKey,
         reason: &'static str,
         now: std::time::Instant,
     ) -> bool {
+        // Labels/log fields stay bare names; the lookup uses the full key.
+        let reactor_name = reactor_key.name.as_str();
         let mut graphs = self.reactors.write().await;
-        let Some(running) = graphs.get_mut(reactor_name) else {
+        let Some(running) = graphs.get_mut(reactor_key) else {
             info!(
                 graph = %reactor_name,
                 "reactor unloaded during restart backoff — skipping restart"
@@ -1726,13 +1821,14 @@ impl ComputationGraphScheduler {
     /// Returns whether a restart actually happened.
     async fn restart_accumulator_after_backoff(
         &self,
-        reactor_name: &str,
+        reactor_key: &TenantKey,
         acc_name: &str,
         reason: &'static str,
         now: std::time::Instant,
     ) -> bool {
+        let reactor_name = reactor_key.name.as_str();
         let mut graphs = self.reactors.write().await;
-        let Some(running) = graphs.get_mut(reactor_name) else {
+        let Some(running) = graphs.get_mut(reactor_key) else {
             info!(
                 graph = %reactor_name,
                 accumulator = %acc_name,
@@ -1890,9 +1986,9 @@ impl ComputationGraphScheduler {
     /// site.
     pub async fn emit_health_metrics(&self) {
         let reactors = self.reactors.read().await;
-        for (reactor_name, running) in reactors.iter() {
+        for (reactor_key, running) in reactors.iter() {
             let graph_labels = if running.endpoint_registry_keys.is_empty() {
-                vec![reactor_name.clone()]
+                vec![reactor_key.name.clone()]
             } else {
                 running.endpoint_registry_keys.clone()
             };
@@ -1955,14 +2051,19 @@ impl ComputationGraphScheduler {
 
     /// Graceful shutdown of all graphs.
     pub async fn shutdown_all(&self) {
-        let graph_names: Vec<String> = {
+        let graph_keys: Vec<TenantKey> = {
             let g2r = self.graph_to_reactor.read().await;
             g2r.keys().cloned().collect()
         };
 
-        for name in graph_names {
-            if let Err(e) = self.unload_graph(&name).await {
-                warn!(graph = %name, error = %e, "failed to unload graph during shutdown");
+        for key in graph_keys {
+            // Address each graph in its OWN tenant scope so shutdown reaches
+            // every tenant's graphs, not just the untenanted ones.
+            if let Err(e) = self
+                .unload_graph(&key.name, TenantScope::of(key.tenant_id.as_deref()))
+                .await
+            {
+                warn!(graph = %key, error = %e, "failed to unload graph during shutdown");
             }
         }
     }
@@ -2138,7 +2239,10 @@ mod tests {
             .contains(&"test_graph".to_string()));
 
         // Unload
-        scheduler.unload_graph("test_graph").await.unwrap();
+        scheduler
+            .unload_graph("test_graph", TenantScope::untenanted())
+            .await
+            .unwrap();
 
         // Verify deregistered
         assert_eq!(
@@ -2178,6 +2282,261 @@ mod tests {
         scheduler.load_graph(decl.clone()).await.unwrap();
         let err = scheduler.load_graph(decl).await.unwrap_err();
         assert!(err.contains("already loaded"));
+
+        scheduler.shutdown_all().await;
+    }
+
+    // -----------------------------------------------------------------------
+    // CLOACI-T-0924: tenant keying of reactors / graph_to_reactor / topologies
+    // -----------------------------------------------------------------------
+
+    fn nop_graph_fn() -> CompiledGraphFn {
+        Arc::new(|_cache: InputCache| Box::pin(async { GraphResult::completed(vec![]) }))
+    }
+
+    fn tenant_decl(
+        graph: &str,
+        reactor: &str,
+        tenant: Option<&str>,
+    ) -> ComputationGraphDeclaration {
+        ComputationGraphDeclaration {
+            name: graph.to_string(),
+            accumulators: vec![AccumulatorDeclaration {
+                name: format!("{}_acc", graph),
+                factory: Arc::new(TestAccumulatorFactory),
+            }],
+            reactor: ReactorDeclaration {
+                criteria: ReactionCriteria::WhenAny,
+                strategy: InputStrategy::Latest,
+                graph_fn: nop_graph_fn(),
+                constructor: None,
+            },
+            tenant_id: tenant.map(|t| t.to_string()),
+            reactor_name: Some(reactor.to_string()),
+            topology: Some(format!("{{\"graph\":\"{}\"}}", graph)),
+        }
+    }
+
+    /// Two tenants load a graph AND a reactor under the SAME names on ONE
+    /// shared scheduler. Both survive; neither is overwritten.
+    #[tokio::test]
+    async fn two_tenants_same_graph_and_reactor_names_coexist() {
+        let registry = EndpointRegistry::new();
+        let scheduler = ComputationGraphScheduler::new(registry.clone());
+
+        for tenant in ["acme", "globex"] {
+            scheduler
+                .load_graph(tenant_decl("pipeline", "rx", Some(tenant)))
+                .await
+                .unwrap_or_else(|e| panic!("tenant {tenant} should load its own graph: {e}"));
+        }
+
+        assert_eq!(scheduler.reactors.read().await.len(), 2);
+        assert_eq!(scheduler.graph_to_reactor.read().await.len(), 2);
+        assert_eq!(scheduler.graph_topologies.read().await.len(), 2);
+
+        let graphs = scheduler.list_graphs().await;
+        assert_eq!(graphs.len(), 2);
+        let mut tenants: Vec<Option<String>> = graphs.iter().map(|g| g.tenant_id.clone()).collect();
+        tenants.sort();
+        assert_eq!(
+            tenants,
+            vec![Some("acme".to_string()), Some("globex".to_string())]
+        );
+        assert!(graphs.iter().all(|g| g.name == "pipeline"));
+
+        let reactors = scheduler.list_reactors().await;
+        assert_eq!(reactors.len(), 2);
+        assert!(reactors.iter().all(|r| r.name == "rx"));
+
+        scheduler.shutdown_all().await;
+    }
+
+    /// Unloading one tenant's graph leaves the other tenant's graph and
+    /// reactor running.
+    #[tokio::test]
+    async fn unload_graph_is_tenant_scoped() {
+        let registry = EndpointRegistry::new();
+        let scheduler = ComputationGraphScheduler::new(registry.clone());
+
+        for tenant in ["acme", "globex"] {
+            scheduler
+                .load_graph(tenant_decl("pipeline", "rx", Some(tenant)))
+                .await
+                .unwrap();
+        }
+
+        scheduler
+            .unload_graph("pipeline", TenantScope::tenant("acme"))
+            .await
+            .expect("acme unloads its own graph");
+
+        // Only globex's entries remain — and they are globex's.
+        let reactors = scheduler.list_reactors().await;
+        assert_eq!(reactors.len(), 1);
+        assert_eq!(reactors[0].tenant_id.as_deref(), Some("globex"));
+        let graphs = scheduler.list_graphs().await;
+        assert_eq!(graphs.len(), 1);
+        assert_eq!(graphs[0].tenant_id.as_deref(), Some("globex"));
+        assert_eq!(scheduler.graph_topologies.read().await.len(), 1);
+
+        scheduler.shutdown_all().await;
+    }
+
+    /// A tenant cannot see, unbind, or tear down another tenant's reactor.
+    #[tokio::test]
+    async fn other_tenants_reactors_are_unreachable() {
+        let registry = EndpointRegistry::new();
+        let scheduler = ComputationGraphScheduler::new(registry.clone());
+
+        scheduler
+            .load_graph(tenant_decl("pipeline", "rx", Some("acme")))
+            .await
+            .unwrap();
+
+        let outsider = TenantScope::tenant("globex");
+        assert!(scheduler
+            .reactor_accumulator_names("rx", outsider)
+            .await
+            .is_none());
+        assert!(scheduler.unload_reactor("rx", outsider).await.is_err());
+        assert!(scheduler
+            .unbind_graph_from_reactor("pipeline", outsider)
+            .await
+            .is_err());
+        assert!(scheduler
+            .bind_graph_to_reactor(
+                "intruder".to_string(),
+                "rx".to_string(),
+                outsider,
+                nop_graph_fn(),
+            )
+            .await
+            .is_err());
+
+        // The owner's entries are untouched.
+        assert!(scheduler
+            .reactor_accumulator_names("rx", TenantScope::tenant("acme"))
+            .await
+            .is_some());
+        assert_eq!(scheduler.reactors.read().await.len(), 1);
+
+        scheduler.shutdown_all().await;
+    }
+
+    /// EMBEDDED COMPATIBILITY: with `tenant_id: None` everywhere, keys are bare
+    /// names and the whole lifecycle behaves exactly as it did pre-T-0924 —
+    /// including a tenant view resolving the untenanted reactor via fallback.
+    #[tokio::test]
+    async fn untenanted_lifecycle_is_unchanged_and_globally_addressable() {
+        let registry = EndpointRegistry::new();
+        let scheduler = ComputationGraphScheduler::new(registry.clone());
+
+        scheduler
+            .load_graph(tenant_decl("pipeline", "rx", None))
+            .await
+            .unwrap();
+
+        let key = scheduler
+            .reactors
+            .read()
+            .await
+            .keys()
+            .next()
+            .unwrap()
+            .clone();
+        assert_eq!(key, TenantKey::new(None, "rx"));
+
+        // Untenanted callers address it by bare name, as always…
+        assert!(scheduler
+            .reactor_accumulator_names("rx", TenantScope::untenanted())
+            .await
+            .is_some());
+        // …and a tenant-scoped caller reaches it through the untenanted
+        // fallback, which is how an embedded/inventory reactor stays usable
+        // once a deployment grows tenants.
+        assert!(scheduler
+            .reactor_accumulator_names("rx", TenantScope::tenant("acme"))
+            .await
+            .is_some());
+
+        scheduler
+            .unload_graph("pipeline", TenantScope::untenanted())
+            .await
+            .unwrap();
+        assert!(scheduler.reactors.read().await.is_empty());
+        assert!(scheduler.graph_to_reactor.read().await.is_empty());
+        assert!(scheduler.graph_topologies.read().await.is_empty());
+    }
+
+    /// A tenant may subscribe to an untenanted (embedded) upstream reactor,
+    /// and `unload_graph` follows the binding back to that exact entry rather
+    /// than looking for a same-named reactor in the subscriber's own tenant.
+    #[tokio::test]
+    async fn tenant_graph_can_bind_untenanted_upstream() {
+        let registry = EndpointRegistry::new();
+        let scheduler = ComputationGraphScheduler::new(registry.clone());
+
+        scheduler
+            .load_reactor(
+                "upstream".to_string(),
+                vec![AccumulatorDeclaration {
+                    name: "alpha".to_string(),
+                    factory: Arc::new(TestAccumulatorFactory),
+                }],
+                ReactionCriteria::WhenAny,
+                InputStrategy::Latest,
+                None,
+                vec![],
+                None,
+            )
+            .await
+            .unwrap();
+
+        scheduler
+            .bind_graph_to_reactor(
+                "subscriber".to_string(),
+                "upstream".to_string(),
+                TenantScope::tenant("acme"),
+                nop_graph_fn(),
+            )
+            .await
+            .expect("a tenant may subscribe to an untenanted upstream");
+
+        // The binding records the UNTENANTED reactor key…
+        let bound = scheduler
+            .graph_to_reactor
+            .read()
+            .await
+            .get(&TenantKey::new(Some("acme"), "subscriber"))
+            .cloned();
+        assert_eq!(bound, Some(TenantKey::new(None, "upstream")));
+
+        // …and unloading the subscriber (its last subscriber) tears down that
+        // exact reactor.
+        scheduler
+            .unload_graph("subscriber", TenantScope::tenant("acme"))
+            .await
+            .unwrap();
+        assert!(scheduler.reactors.read().await.is_empty());
+    }
+
+    /// Same tenant, same graph name from two packages is still "already
+    /// loaded" — the loud same-tenant collision the ticket asks for.
+    #[tokio::test]
+    async fn same_tenant_duplicate_graph_is_rejected() {
+        let registry = EndpointRegistry::new();
+        let scheduler = ComputationGraphScheduler::new(registry.clone());
+
+        scheduler
+            .load_graph(tenant_decl("pipeline", "rx_a", Some("acme")))
+            .await
+            .unwrap();
+        let err = scheduler
+            .load_graph(tenant_decl("pipeline", "rx_b", Some("acme")))
+            .await
+            .expect_err("a second package in the same tenant must not silently replace");
+        assert!(err.contains("already loaded"), "{err}");
 
         scheduler.shutdown_all().await;
     }

--- a/crates/cloacina/src/lib.rs
+++ b/crates/cloacina/src/lib.rs
@@ -546,6 +546,7 @@ pub use inventory;
 pub use serde_json;
 pub mod security;
 pub mod task;
+pub mod tenant_scope;
 pub mod trigger;
 pub mod var;
 pub mod workflow;
@@ -607,6 +608,7 @@ pub use runner::{DefaultRunner, DefaultRunnerConfig};
 pub use runtime::Runtime;
 pub use task::namespace::parse_namespace;
 pub use task::{Task, TaskNamespace, TaskRegistry, TaskState};
+pub use tenant_scope::{TenantKey, TenantOwner, TenantResolveMiss, TenantScope};
 pub use trigger::{Trigger, TriggerConfig, TriggerError, TriggerResult};
 pub use workflow::{DependencyGraph, Workflow, WorkflowBuilder, WorkflowMetadata};
 

--- a/crates/cloacina/src/registry/reconciler/loading.rs
+++ b/crates/cloacina/src/registry/reconciler/loading.rs
@@ -795,7 +795,10 @@ impl RegistryReconciler {
                                 let scheduler_guard = self.graph_scheduler.read().await;
                                 if let Some(ref scheduler) = *scheduler_guard {
                                     if let Some(upstream_acc_names) = scheduler
-                                        .reactor_accumulator_names(upstream_reactor_name)
+                                        .reactor_accumulator_names(
+                                            upstream_reactor_name,
+                                            self.tenant_scope(),
+                                        )
                                         .await
                                     {
                                         let upstream_set: std::collections::HashSet<&str> =
@@ -978,7 +981,10 @@ impl RegistryReconciler {
             }
             let scheduler_guard = self.graph_scheduler.read().await;
             if let Some(ref scheduler) = *scheduler_guard {
-                if let Err(e) = scheduler.unload_graph(graph_name).await {
+                if let Err(e) = scheduler
+                    .unload_graph(graph_name, self.tenant_scope())
+                    .await
+                {
                     warn!("Failed to unload computation graph '{}': {}", graph_name, e);
                 }
             }
@@ -1003,7 +1009,10 @@ impl RegistryReconciler {
             let scheduler_guard = self.graph_scheduler.read().await;
             if let Some(ref scheduler) = *scheduler_guard {
                 for reactor_name in &package_state.reactor_names {
-                    match scheduler.unload_reactor(reactor_name).await {
+                    match scheduler
+                        .unload_reactor(reactor_name, self.tenant_scope())
+                        .await
+                    {
                         Ok(()) => {
                             debug!(
                                 "Reactor '{}' unloaded for package {}",
@@ -1312,27 +1321,37 @@ impl RegistryReconciler {
             let tenant_id_for_closure = self.config.default_tenant_id.clone();
             let runtime_for_closure: Arc<Runtime> = runtime.clone();
 
-            runtime.register_workflow(workflow_name.clone(), move || {
-                debug!(
-                    "Creating workflow instance for {} using runtime registry",
-                    workflow_name_for_closure
-                );
+            // CLOACI-T-0924: attribute the registration to this package so a
+            // SECOND package claiming the same workflow name inside the same
+            // tenant is a loud load-time rejection instead of a silent
+            // overwrite. (Same package re-registering still replaces — the
+            // package-reload path depends on it.)
+            let owner = crate::tenant_scope::TenantOwner::package(&metadata.package_name);
+            runtime
+                .try_register_workflow(&owner, workflow_name.clone(), move || {
+                    debug!(
+                        "Creating workflow instance for {} using runtime registry",
+                        workflow_name_for_closure
+                    );
 
-                // Recreate the workflow from the runtime task registry each time
-                match Self::create_workflow_from_host_registry_static(
-                    &runtime_for_closure,
-                    &package_name_for_closure,
-                    &workflow_name_for_closure_static,
-                    &tenant_id_for_closure,
-                ) {
-                    Ok(workflow) => workflow,
-                    Err(e) => {
-                        error!("Failed to create workflow from runtime registry: {}", e);
-                        // Fallback to empty workflow
-                        crate::workflow::Workflow::new(&workflow_name_for_closure)
+                    // Recreate the workflow from the runtime task registry each time
+                    match Self::create_workflow_from_host_registry_static(
+                        &runtime_for_closure,
+                        &package_name_for_closure,
+                        &workflow_name_for_closure_static,
+                        &tenant_id_for_closure,
+                    ) {
+                        Ok(workflow) => workflow,
+                        Err(e) => {
+                            error!("Failed to create workflow from runtime registry: {}", e);
+                            // Fallback to empty workflow
+                            crate::workflow::Workflow::new(&workflow_name_for_closure)
+                        }
                     }
-                }
-            });
+                })
+                .map_err(|e| RegistryError::RegistrationFailed {
+                    message: e.to_string(),
+                })?;
 
             info!(
                 "Registered workflow '{}' for package {} v{}",
@@ -1939,9 +1958,21 @@ impl RegistryReconciler {
             None
         };
 
+        // CLOACI-T-0924: the "already in the runtime, reuse it" fast path below
+        // is what lets an inventory/self-registered trigger satisfy this
+        // package. Ask first whether this package is *allowed* to claim the
+        // name: an entry owned by a DIFFERENT package in the same tenant is a
+        // loud load-time rejection, not a silent adoption (which would also let
+        // this package's unload tear down the other package's trigger).
+        let owner = crate::tenant_scope::TenantOwner::package(&metadata.package_name);
         let mut tracked = Vec::new();
         for t in &custom {
-            if runtime.get_trigger(&t.name).is_some() {
+            let free = runtime.may_claim_trigger(&owner, &t.name).map_err(|e| {
+                RegistryError::RegistrationFailed {
+                    message: e.to_string(),
+                }
+            })?;
+            if !free {
                 tracked.push(t.name.clone());
                 continue;
             }
@@ -1952,15 +1983,21 @@ impl RegistryReconciler {
                 let trigger_name = t.name.clone();
                 let allow_concurrent = t.allow_concurrent;
                 let cron_expression = t.cron_expression.clone();
-                runtime.register_trigger(t.name.clone(), move || {
-                    std::sync::Arc::new(crate::registry::loader::ffi_trigger::FfiTriggerImpl::new(
-                        handle_for_ctor.clone(),
-                        trigger_name.clone(),
-                        poll_interval,
-                        allow_concurrent,
-                        cron_expression.clone(),
-                    )) as std::sync::Arc<dyn cloacina_workflow::Trigger>
-                });
+                runtime
+                    .try_register_trigger(&owner, t.name.clone(), move || {
+                        std::sync::Arc::new(
+                            crate::registry::loader::ffi_trigger::FfiTriggerImpl::new(
+                                handle_for_ctor.clone(),
+                                trigger_name.clone(),
+                                poll_interval,
+                                allow_concurrent,
+                                cron_expression.clone(),
+                            ),
+                        ) as std::sync::Arc<dyn cloacina_workflow::Trigger>
+                    })
+                    .map_err(|e| RegistryError::RegistrationFailed {
+                        message: e.to_string(),
+                    })?;
                 info!(
                     "Package {} v{}: registered FFI trigger adapter for '{}' (poll={:?})",
                     metadata.package_name, metadata.version, t.name, poll_interval
@@ -2080,9 +2117,17 @@ impl RegistryReconciler {
             None
         };
 
+        // CLOACI-T-0924: same claim check as custom triggers — reuse an entry
+        // this package may own, reject one a different package holds.
+        let owner = crate::tenant_scope::TenantOwner::package(&metadata.package_name);
         let mut registered = Vec::new();
         for entry in triggerless_meta {
-            if runtime.get_triggerless_graph(&entry.name).is_some() {
+            let free = runtime
+                .may_claim_triggerless_graph(&owner, &entry.name)
+                .map_err(|e| RegistryError::RegistrationFailed {
+                    message: e.to_string(),
+                })?;
+            if !free {
                 registered.push(entry.name.clone());
                 continue;
             }
@@ -2102,13 +2147,17 @@ impl RegistryReconciler {
                 );
             let name_for_ctor = entry.name.clone();
             let terminal_names = entry.terminal_node_names.clone();
-            runtime.register_triggerless_graph(entry.name.clone(), move || {
-                cloacina_workflow_plugin::TriggerlessGraphRegistration {
-                    name: name_for_ctor.clone(),
-                    graph_fn: graph_fn.clone(),
-                    terminal_node_names: terminal_names.clone(),
-                }
-            });
+            runtime
+                .try_register_triggerless_graph(&owner, entry.name.clone(), move || {
+                    cloacina_workflow_plugin::TriggerlessGraphRegistration {
+                        name: name_for_ctor.clone(),
+                        graph_fn: graph_fn.clone(),
+                        terminal_node_names: terminal_names.clone(),
+                    }
+                })
+                .map_err(|e| RegistryError::RegistrationFailed {
+                    message: e.to_string(),
+                })?;
             info!(
                 "Package {} v{}: registered FFI trigger-less graph '{}' (terminals={:?})",
                 metadata.package_name, metadata.version, entry.name, entry.terminal_node_names,
@@ -2189,7 +2238,7 @@ impl RegistryReconciler {
                 .any(|r| r.name == upstream_reactor_name);
             if !publisher_in_same_package {
                 if let Some(upstream_acc_names) = scheduler
-                    .reactor_accumulator_names(upstream_reactor_name)
+                    .reactor_accumulator_names(upstream_reactor_name, self.tenant_scope())
                     .await
                 {
                     let upstream_set: std::collections::HashSet<&str> =
@@ -2238,14 +2287,21 @@ impl RegistryReconciler {
             let accumulator_names: Vec<String> =
                 decl.accumulators.iter().map(|a| a.name.clone()).collect();
             let reaction_mode = graph_meta.reaction_mode.clone();
-            runtime.register_computation_graph(graph_meta.graph_name.clone(), move || {
-                crate::ComputationGraphRegistration {
-                    graph_fn: graph_fn.clone(),
-                    trigger_reactor: None,
-                    accumulator_names: accumulator_names.clone(),
-                    reaction_mode: reaction_mode.clone(),
-                }
-            });
+            // CLOACI-T-0924: attributed so a second package claiming this graph
+            // name inside the same tenant is rejected loudly.
+            let owner = crate::tenant_scope::TenantOwner::package(&metadata.package_name);
+            runtime
+                .try_register_computation_graph(&owner, graph_meta.graph_name.clone(), move || {
+                    crate::ComputationGraphRegistration {
+                        graph_fn: graph_fn.clone(),
+                        trigger_reactor: None,
+                        accumulator_names: accumulator_names.clone(),
+                        reaction_mode: reaction_mode.clone(),
+                    }
+                })
+                .map_err(|e| RegistryError::RegistrationFailed {
+                    message: e.to_string(),
+                })?;
         }
 
         if let Err(e) = scheduler.load_graph_in(decl, provider_root).await {
@@ -3236,6 +3292,7 @@ mod tests {
             .bind_graph_to_reactor(
                 "subscriber_graph".to_string(),
                 "owned_rx".to_string(),
+                crate::tenant_scope::TenantScope::tenant("public"),
                 graph_fn,
             )
             .await
@@ -3289,7 +3346,10 @@ mod tests {
         // Sanity-check that the reactor is still loaded.
         assert!(
             scheduler
-                .reactor_accumulator_names("owned_rx")
+                .reactor_accumulator_names(
+                    "owned_rx",
+                    crate::tenant_scope::TenantScope::tenant("public")
+                )
                 .await
                 .is_some(),
             "reactor must still exist after rejected unload"
@@ -3314,7 +3374,10 @@ mod tests {
         // Once the subscriber unbinds, the retried unload must succeed and
         // drop tracking for good.
         scheduler
-            .unload_graph("subscriber_graph")
+            .unload_graph(
+                "subscriber_graph",
+                crate::tenant_scope::TenantScope::tenant("public"),
+            )
             .await
             .expect("subscriber graph should unbind");
         reconciler
@@ -3373,7 +3436,10 @@ mod tests {
 
         assert!(
             scheduler
-                .reactor_accumulator_names("lone_rx")
+                .reactor_accumulator_names(
+                    "lone_rx",
+                    crate::tenant_scope::TenantScope::tenant("public")
+                )
                 .await
                 .is_none(),
             "reactor must be torn down after publisher unload"

--- a/crates/cloacina/src/registry/reconciler/mod.rs
+++ b/crates/cloacina/src/registry/reconciler/mod.rs
@@ -322,6 +322,19 @@ impl RegistryReconciler {
         })
     }
 
+    /// The tenant scope this reconciler loads and unloads under
+    /// (CLOACI-T-0924).
+    ///
+    /// The `ComputationGraphScheduler` is a single `Arc` shared by every
+    /// tenant's runner, so unlike the `Runtime` (whose handle carries a scope)
+    /// its name-taking methods need the tenant passed explicitly. Package loads
+    /// already stamp `decl.tenant_id = config.default_tenant_id`, so this is
+    /// exactly the scope the entries were claimed under. Embedded runners leave
+    /// `default_tenant_id` at `"public"` and are self-consistent.
+    pub(super) fn tenant_scope(&self) -> crate::tenant_scope::TenantScope<'_> {
+        crate::tenant_scope::TenantScope::tenant(&self.config.default_tenant_id)
+    }
+
     /// Attach a Runtime to this reconciler. Package load/unload operations
     /// will push registrations through the runtime so executors see the
     /// same view as the reconciler.

--- a/crates/cloacina/src/runner/default_runner/config.rs
+++ b/crates/cloacina/src/runner/default_runner/config.rs
@@ -772,9 +772,14 @@ impl DefaultRunnerBuilder {
         // Resolve runtime: prefer a caller-supplied Arc (so shared state with
         // e.g. Python ScopedRuntime is preserved), else wrap a by-value
         // Runtime, else create a fresh inventory-seeded one.
-        let runtime = self
-            .runtime_arc
-            .unwrap_or_else(|| Arc::new(self.runtime.unwrap_or_default()));
+        // CLOACI-T-0924: bind the handle to this runner's tenant. The caller's
+        // registries are still shared (only the scope differs), so a handle the
+        // caller kept — a Python `ScopedRuntime`, say — sees the same entries.
+        let runtime = Arc::new(
+            self.runtime_arc
+                .unwrap_or_else(|| Arc::new(self.runtime.unwrap_or_default()))
+                .scoped_to_tenant(self.config.tenant_id()),
+        );
 
         // Create scheduler with the scoped runtime
         let scheduler = TaskScheduler::with_poll_interval(

--- a/crates/cloacina/src/runner/default_runner/mod.rs
+++ b/crates/cloacina/src/runner/default_runner/mod.rs
@@ -154,7 +154,19 @@ impl DefaultRunner {
         shared_runtime: Option<Arc<Runtime>>,
         secret_resolver: Option<Arc<dyn cloacina_workflow::secret::SecretResolver>>,
     ) -> Result<Self, WorkflowExecutionError> {
-        let runtime = shared_runtime.unwrap_or_else(|| Arc::new(Runtime::new()));
+        // CLOACI-T-0924: `cloacina-server` hands EVERY tenant's runner the same
+        // `Runtime` allocation (`TenantRunnerCache::shared_runtime`), so bind
+        // this runner's handle to its own tenant. The registries underneath are
+        // keyed `(tenant, name)`; everything this constructor builds
+        // (TaskScheduler, ThreadTaskExecutor, and later the reconciler and cron
+        // scheduler) clones the handle and therefore inherits the scope, so two
+        // tenants shipping a workflow called `pipeline` no longer collide.
+        // Registries stay shared — only the view differs.
+        let runtime = Arc::new(
+            shared_runtime
+                .unwrap_or_else(|| Arc::new(Runtime::new()))
+                .scoped_to_tenant(config.tenant_id()),
+        );
 
         // Create scheduler with the scoped runtime
         let scheduler =

--- a/crates/cloacina/src/runtime.rs
+++ b/crates/cloacina/src/runtime.rs
@@ -32,8 +32,34 @@
 //! runtime.register_task(namespace, || Arc::new(my_task()));
 //! runtime.unregister_workflow("obsolete_workflow");
 //! ```
+//!
+//! # Tenant scoping (CLOACI-T-0924)
+//!
+//! One `Runtime` allocation is shared by every tenant's runner in
+//! `cloacina-server` (`TenantRunnerCache::shared_runtime`), so the name-keyed
+//! registries below carry the tenant **in the key**: they are
+//! [`TenantKey`]`(tenant, name)` maps, matching the `EndpointKey` convention
+//! CLOACI-T-0921 established for the `EndpointRegistry`. (`tasks` stays keyed
+//! by [`TaskNamespace`] — `tenant::package::workflow::task` is persisted on
+//! `task_executions` rows, so its readers genuinely have all four components.
+//! Every reader of the other five registries addresses them by *bare name*.)
+//!
+//! The tenant is not threaded through every `get_workflow(&str)` call site.
+//! Instead the **handle** carries it: `Runtime` is a cheap `Arc` share plus a
+//! scope, and [`Runtime::scoped_to_tenant`] / [`Runtime::untenanted_view`] /
+//! [`Runtime::admin_view`] produce differently-scoped views over the *same*
+//! registries. `DefaultRunner` binds its handle to `config.tenant_id()` at
+//! construction, so the scheduler, executor, reconciler and cron scheduler it
+//! builds all inherit it.
+//!
+//! Resolution order is CLOACI-T-0921's, verbatim: the caller's own tenant, then
+//! the untenanted entry (embedded / pre-multi-tenancy, and what
+//! [`Runtime::seed_from_inventory`] always writes), then — for admin views only
+//! — a *unique* cross-tenant match. Two tenants owning a name is never a guess.
+//! An untenanted deployment therefore behaves exactly as it did before this
+//! change: every entry is untenanted and every lookup hits step 2.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use parking_lot::RwLock;
@@ -43,6 +69,7 @@ use crate::computation_graph::stream_backend::{
 };
 use crate::computation_graph::triggerless::TriggerlessGraphRegistration;
 use crate::task::{Task, TaskNamespace};
+use crate::tenant_scope::{resolve_tenant_key, visible_keys, TenantKey, TenantOwner, TenantScope};
 use crate::trigger::Trigger;
 use crate::workflow::Workflow;
 use cloacina_computation_graph::{
@@ -63,23 +90,202 @@ pub(crate) type WorkflowConstructorFn = Box<dyn Fn() -> Workflow + Send + Sync>;
 /// Type alias for trigger constructor functions.
 pub(crate) type TriggerConstructorFn = Box<dyn Fn() -> Arc<dyn Trigger> + Send + Sync>;
 
+/// A registration was refused because the name is already claimed inside the
+/// same tenant by a different package (CLOACI-T-0924).
+///
+/// This mirrors `RegistryError::EndpointOwnershipConflict` from
+/// CLOACI-T-0921: silently replacing the incumbent would cross-wire two
+/// packages' entities, so the second package must rename.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum RuntimeRegistrationError {
+    #[error(
+        "{kind} '{name}' is already registered in tenant '{tenant}' by {existing}; \
+         {incoming} cannot claim the same name — rename the {kind} in one of the two packages"
+    )]
+    OwnershipConflict {
+        kind: &'static str,
+        name: String,
+        tenant: String,
+        existing: String,
+        incoming: String,
+    },
+}
+
+/// One entry in a [`ScopedRegistry`]: the constructor plus who claimed it.
+struct ScopedEntry<V> {
+    owner: TenantOwner,
+    value: V,
+}
+
+/// A `(tenant, name)`-keyed registry with owner-checked replacement.
+///
+/// Shared by the five bare-name registries so they have exactly one keying and
+/// one resolution rule between them.
+struct ScopedRegistry<V> {
+    /// Operator-facing noun used in conflict errors ("workflow", "reactor", …).
+    kind: &'static str,
+    entries: RwLock<HashMap<TenantKey, ScopedEntry<V>>>,
+}
+
+impl<V> ScopedRegistry<V> {
+    fn new(kind: &'static str) -> Self {
+        Self {
+            kind,
+            entries: RwLock::new(HashMap::new()),
+        }
+    }
+
+    /// Insert under `scope`'s own key, rejecting a claim on a live
+    /// `(tenant, name)` held by a *different, named* package.
+    fn insert(
+        &self,
+        scope: TenantScope<'_>,
+        name: String,
+        owner: TenantOwner,
+        value: V,
+    ) -> Result<(), RuntimeRegistrationError> {
+        let key = scope.own_key(&name);
+        let mut guard = self.entries.write();
+        if let Some(existing) = guard.get(&key) {
+            if !existing.owner.may_replace(&owner) {
+                return Err(RuntimeRegistrationError::OwnershipConflict {
+                    kind: self.kind,
+                    name,
+                    tenant: key.tenant_label().to_string(),
+                    existing: existing.owner.label(),
+                    incoming: owner.label(),
+                });
+            }
+        }
+        guard.insert(key, ScopedEntry { owner, value });
+        Ok(())
+    }
+
+    /// Resolve `name` within `scope` and apply `f` to the stored value while
+    /// the read lock is held (the values are constructor closures, so this is
+    /// "call the constructor" at every call site).
+    fn with<R>(&self, scope: TenantScope<'_>, name: &str, f: impl FnOnce(&V) -> R) -> Option<R> {
+        let guard = self.entries.read();
+        let key = resolve_tenant_key(&*guard, scope, name).ok()?;
+        guard.get(&key).map(|entry| f(&entry.value))
+    }
+
+    /// Remove the entry `name` resolves to within `scope`. A non-admin caller
+    /// can therefore never unregister another tenant's entry.
+    fn remove(&self, scope: TenantScope<'_>, name: &str) -> bool {
+        let mut guard = self.entries.write();
+        let Ok(key) = resolve_tenant_key(&*guard, scope, name) else {
+            return false;
+        };
+        guard.remove(&key).is_some()
+    }
+
+    /// Distinct entry names visible to `scope` (own tenant + untenanted, or
+    /// everything for an admin view). Deduplicated, because a tenant entry and
+    /// an untenanted entry can share a name.
+    fn names(&self, scope: TenantScope<'_>) -> Vec<String> {
+        let guard = self.entries.read();
+        let mut seen = HashSet::new();
+        visible_keys(&*guard, scope)
+            .filter(|k| seen.insert(k.name.clone()))
+            .map(|k| k.name.clone())
+            .collect()
+    }
+
+    /// Every `(tenant, name)` key in the registry, unfiltered. Diagnostics and
+    /// tests only.
+    fn all_keys(&self) -> Vec<TenantKey> {
+        self.entries.read().keys().cloned().collect()
+    }
+
+    /// Provenance of the entry `name` resolves to within `scope`, if any.
+    fn owner(&self, scope: TenantScope<'_>, name: &str) -> Option<TenantOwner> {
+        let guard = self.entries.read();
+        let key = resolve_tenant_key(&*guard, scope, name).ok()?;
+        guard.get(&key).map(|entry| entry.owner.clone())
+    }
+
+    /// Build the conflict error for an incoming claim on `name`.
+    fn conflict(
+        &self,
+        scope: TenantScope<'_>,
+        name: &str,
+        existing: &TenantOwner,
+        incoming: &TenantOwner,
+    ) -> RuntimeRegistrationError {
+        RuntimeRegistrationError::OwnershipConflict {
+            kind: self.kind,
+            name: name.to_string(),
+            tenant: scope.own_key(name).tenant_label().to_string(),
+            existing: existing.label(),
+            incoming: incoming.label(),
+        }
+    }
+
+    /// Whether `incoming` may claim `name` in `scope`: `Ok(true)` when the
+    /// name is free, `Ok(false)` when an entry `incoming` is allowed to reuse
+    /// or replace already exists, `Err` when a different package owns it.
+    fn check_claim(
+        &self,
+        scope: TenantScope<'_>,
+        name: &str,
+        incoming: &TenantOwner,
+    ) -> Result<bool, RuntimeRegistrationError> {
+        match self.owner(scope, name) {
+            None => Ok(true),
+            Some(existing) if existing.may_replace(incoming) => Ok(false),
+            Some(existing) => Err(self.conflict(scope, name, &existing, incoming)),
+        }
+    }
+
+    fn len(&self) -> usize {
+        self.entries.read().len()
+    }
+}
+
 /// A scoped runtime holding the registries for every cloacina extension point.
 ///
 /// All five namespaces — tasks, workflows, triggers, computation graphs, and
 /// stream backends — are registered and unregistered through the same surface.
 /// `Runtime` is cheap to clone: it shares its registries via `Arc`.
+///
+/// A clone carries the same tenant scope; use [`Runtime::scoped_to_tenant`],
+/// [`Runtime::untenanted_view`] or [`Runtime::admin_view`] to get a
+/// differently-scoped view over the same registries.
 #[derive(Clone)]
 pub struct Runtime {
     inner: Arc<RuntimeInner>,
+    scope: RuntimeScope,
+}
+
+/// The owned form of [`TenantScope`] carried on a [`Runtime`] handle.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+struct RuntimeScope {
+    tenant_id: Option<String>,
+    is_admin: bool,
+}
+
+impl RuntimeScope {
+    fn as_tenant_scope(&self) -> TenantScope<'_> {
+        TenantScope {
+            tenant_id: self.tenant_id.as_deref(),
+            is_admin: self.is_admin,
+        }
+    }
 }
 
 struct RuntimeInner {
+    /// Already `tenant::package::workflow::task`-keyed — see the module docs
+    /// for why this one keeps [`TaskNamespace`] rather than [`TenantKey`].
     tasks: RwLock<HashMap<TaskNamespace, TaskConstructorFn>>,
-    workflows: RwLock<HashMap<String, WorkflowConstructorFn>>,
-    triggers: RwLock<HashMap<String, TriggerConstructorFn>>,
-    computation_graphs: RwLock<HashMap<String, ComputationGraphConstructor>>,
-    triggerless_graphs: RwLock<HashMap<String, TriggerlessGraphConstructor>>,
-    reactors: RwLock<HashMap<String, ReactorConstructor>>,
+    workflows: ScopedRegistry<WorkflowConstructorFn>,
+    triggers: ScopedRegistry<TriggerConstructorFn>,
+    computation_graphs: ScopedRegistry<ComputationGraphConstructor>,
+    triggerless_graphs: ScopedRegistry<TriggerlessGraphConstructor>,
+    reactors: ScopedRegistry<ReactorConstructor>,
+    /// Keyed by backend *kind* (`"kafka"`, `"mock"`), not by a tenant-authored
+    /// entity name — CLOACI-T-0921's audit classified this as collision-safe by
+    /// construction, so it stays a plain name map.
     stream_backends: RwLock<HashMap<String, StreamBackendFactory>>,
 }
 
@@ -108,14 +314,80 @@ impl Runtime {
         Self {
             inner: Arc::new(RuntimeInner {
                 tasks: RwLock::new(HashMap::new()),
-                workflows: RwLock::new(HashMap::new()),
-                triggers: RwLock::new(HashMap::new()),
-                computation_graphs: RwLock::new(HashMap::new()),
-                triggerless_graphs: RwLock::new(HashMap::new()),
-                reactors: RwLock::new(HashMap::new()),
+                workflows: ScopedRegistry::new("workflow"),
+                triggers: ScopedRegistry::new("trigger"),
+                computation_graphs: ScopedRegistry::new("computation graph"),
+                triggerless_graphs: ScopedRegistry::new("trigger-less computation graph"),
+                reactors: ScopedRegistry::new("reactor"),
                 stream_backends: RwLock::new(HashMap::new()),
             }),
+            scope: RuntimeScope::default(),
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // Tenant scoping (CLOACI-T-0924)
+    // -----------------------------------------------------------------------
+
+    /// The scope this handle registers and resolves under.
+    fn scope(&self) -> TenantScope<'_> {
+        self.scope.as_tenant_scope()
+    }
+
+    /// A view over the *same* registries bound to `tenant_id`.
+    ///
+    /// Registrations made through the returned handle land under
+    /// `(tenant_id, name)`; lookups try that tenant first, then fall back to
+    /// the untenanted (inventory / embedded) entries. This is what
+    /// `DefaultRunner` calls with `config.tenant_id()`.
+    pub fn scoped_to_tenant(&self, tenant_id: impl Into<String>) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+            scope: RuntimeScope {
+                tenant_id: Some(tenant_id.into()),
+                is_admin: false,
+            },
+        }
+    }
+
+    /// A view over the same registries with no tenant — the embedded /
+    /// pre-multi-tenancy scope, and the scope `seed_from_inventory` writes
+    /// under.
+    pub fn untenanted_view(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+            scope: RuntimeScope::default(),
+        }
+    }
+
+    /// A view that may resolve any tenant's entry, but only when the name is
+    /// unique across tenants. Intended for operator/diagnostic surfaces.
+    pub fn admin_view(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+            scope: RuntimeScope {
+                tenant_id: None,
+                is_admin: true,
+            },
+        }
+    }
+
+    /// The tenant this handle is bound to, if any.
+    pub fn tenant_id(&self) -> Option<&str> {
+        self.scope.tenant_id.as_deref()
+    }
+
+    /// Whether this handle is an admin view.
+    pub fn is_admin(&self) -> bool {
+        self.scope.is_admin
+    }
+
+    /// `true` when both handles are views over the same registry allocation.
+    ///
+    /// Replaces `Arc::ptr_eq` comparisons of `Arc<Runtime>`: two per-tenant
+    /// runners share one `RuntimeInner` but hold differently-scoped handles.
+    pub fn shares_registries_with(&self, other: &Runtime) -> bool {
+        Arc::ptr_eq(&self.inner, &other.inner)
     }
 
     /// Populate the runtime from the `inventory` entries emitted by the
@@ -124,11 +396,21 @@ impl Runtime {
     /// `inventory`'s linker-section collection works across `dlopen`'d cdylibs
     /// on Linux/macOS, so the reconciler calls this again after loading a new
     /// workflow package to pick up the entries emitted by that cdylib.
+    ///
+    /// Inventory entries are always registered **untenanted**, whatever scope
+    /// this handle carries (CLOACI-T-0924). They are host-binary, compile-time
+    /// declarations — never tenant-authored — and the reconciler re-runs this
+    /// after every `dlopen`, so scoping them would cross-stamp one tenant's
+    /// cdylib entries onto whichever tenant happened to load next. Untenanted
+    /// entries stay reachable from every tenant via the resolution fallback,
+    /// which is exactly the pre-CLOACI-T-0924 behaviour.
     pub fn seed_from_inventory(&self) {
         use crate::inventory_entries::{
             ComputationGraphEntry, ReactorEntry, StreamBackendEntry, TaskEntry, TriggerEntry,
             TriggerlessGraphEntry, WorkflowEntry,
         };
+
+        let global = self.untenanted_view();
 
         for entry in inventory::iter::<TaskEntry> {
             let ns = (entry.namespace)();
@@ -137,23 +419,23 @@ impl Runtime {
         }
 
         for entry in inventory::iter::<WorkflowEntry> {
-            self.register_workflow(entry.name.to_string(), entry.constructor);
+            global.register_workflow(entry.name.to_string(), entry.constructor);
         }
 
         for entry in inventory::iter::<TriggerEntry> {
-            self.register_trigger(entry.name.to_string(), entry.constructor);
+            global.register_trigger(entry.name.to_string(), entry.constructor);
         }
 
         for entry in inventory::iter::<ComputationGraphEntry> {
-            self.register_computation_graph(entry.name.to_string(), entry.constructor);
+            global.register_computation_graph(entry.name.to_string(), entry.constructor);
         }
 
         for entry in inventory::iter::<TriggerlessGraphEntry> {
-            self.register_triggerless_graph(entry.name.to_string(), entry.constructor);
+            global.register_triggerless_graph(entry.name.to_string(), entry.constructor);
         }
 
         for entry in inventory::iter::<ReactorEntry> {
-            self.register_reactor(entry.name.to_string(), entry.constructor);
+            global.register_reactor(entry.name.to_string(), entry.constructor);
         }
 
         for entry in inventory::iter::<StreamBackendEntry> {
@@ -207,96 +489,187 @@ impl Runtime {
     // Workflow registry
     // -----------------------------------------------------------------------
 
-    /// Register a workflow constructor by name.
+    /// Register a workflow constructor by name, under this handle's tenant.
+    ///
+    /// Unattributed registration: it never conflicts, so it cannot fail. Use
+    /// [`Runtime::try_register_workflow`] from the package loader, where the
+    /// owning package is known and a same-tenant collision must be loud.
     pub fn register_workflow<F>(&self, name: String, constructor: F)
+    where
+        F: Fn() -> Workflow + Send + Sync + 'static,
+    {
+        let _ = self.inner.workflows.insert(
+            self.scope(),
+            name,
+            TenantOwner::unknown(),
+            Box::new(constructor),
+        );
+    }
+
+    /// Register a workflow constructor attributed to `owner`, rejecting a
+    /// same-tenant claim on a name a *different* package already owns.
+    pub fn try_register_workflow<F>(
+        &self,
+        owner: &TenantOwner,
+        name: String,
+        constructor: F,
+    ) -> Result<(), RuntimeRegistrationError>
     where
         F: Fn() -> Workflow + Send + Sync + 'static,
     {
         self.inner
             .workflows
-            .write()
-            .insert(name, Box::new(constructor));
+            .insert(self.scope(), name, owner.clone(), Box::new(constructor))
     }
 
     /// Remove a workflow constructor. Returns true if the entry existed.
     pub fn unregister_workflow(&self, name: &str) -> bool {
-        self.inner.workflows.write().remove(name).is_some()
+        self.inner.workflows.remove(self.scope(), name)
     }
 
-    /// Look up and instantiate a workflow by name.
+    /// Look up and instantiate a workflow by name, within this handle's scope.
     pub fn get_workflow(&self, name: &str) -> Option<Workflow> {
-        self.inner.workflows.read().get(name).map(|ctor| ctor())
+        self.inner.workflows.with(self.scope(), name, |ctor| ctor())
     }
 
-    /// Get all registered workflow names.
+    /// Get every workflow name visible to this handle's scope.
     pub fn workflow_names(&self) -> Vec<String> {
-        self.inner.workflows.read().keys().cloned().collect()
+        self.inner.workflows.names(self.scope())
+    }
+
+    /// Every `(tenant, workflow)` key in the process, unfiltered. Diagnostics
+    /// and cross-tenant isolation tests.
+    pub fn workflow_keys(&self) -> Vec<TenantKey> {
+        self.inner.workflows.all_keys()
     }
 
     // -----------------------------------------------------------------------
     // Trigger registry
     // -----------------------------------------------------------------------
 
-    /// Register a trigger constructor by name.
+    /// Register a trigger constructor by name, under this handle's tenant.
     pub fn register_trigger<F>(&self, name: String, factory: F)
     where
         F: Fn() -> Arc<dyn Trigger> + Send + Sync + 'static,
     {
-        self.inner.triggers.write().insert(name, Box::new(factory));
+        let _ = self.inner.triggers.insert(
+            self.scope(),
+            name,
+            TenantOwner::unknown(),
+            Box::new(factory),
+        );
+    }
+
+    /// Register a trigger constructor attributed to `owner`, rejecting a
+    /// same-tenant claim on a name a *different* package already owns.
+    pub fn try_register_trigger<F>(
+        &self,
+        owner: &TenantOwner,
+        name: String,
+        factory: F,
+    ) -> Result<(), RuntimeRegistrationError>
+    where
+        F: Fn() -> Arc<dyn Trigger> + Send + Sync + 'static,
+    {
+        self.inner
+            .triggers
+            .insert(self.scope(), name, owner.clone(), Box::new(factory))
+    }
+
+    /// Ask whether `owner` may claim the trigger `name` in this handle's scope
+    /// *before* registering it (CLOACI-T-0924).
+    ///
+    /// The package loader has a "reuse whatever the cdylib's `inventory`
+    /// already registered" fast path, which would otherwise let a second
+    /// package silently adopt (and later tear down) a first package's trigger.
+    /// `Ok(true)` — free, register it. `Ok(false)` — an entry this owner may
+    /// reuse or replace exists. `Err` — a different package owns the name in
+    /// this tenant.
+    pub fn may_claim_trigger(
+        &self,
+        owner: &TenantOwner,
+        name: &str,
+    ) -> Result<bool, RuntimeRegistrationError> {
+        self.inner.triggers.check_claim(self.scope(), name, owner)
     }
 
     /// Remove a trigger constructor. Returns true if the entry existed.
     pub fn unregister_trigger(&self, name: &str) -> bool {
-        self.inner.triggers.write().remove(name).is_some()
+        self.inner.triggers.remove(self.scope(), name)
     }
 
-    /// Look up and instantiate a trigger by name.
+    /// Look up and instantiate a trigger by name, within this handle's scope.
     pub fn get_trigger(&self, name: &str) -> Option<Arc<dyn Trigger>> {
-        self.inner.triggers.read().get(name).map(|ctor| ctor())
+        self.inner.triggers.with(self.scope(), name, |ctor| ctor())
     }
 
-    /// Get all registered trigger names.
+    /// Get every trigger name visible to this handle's scope.
     pub fn trigger_names(&self) -> Vec<String> {
-        self.inner.triggers.read().keys().cloned().collect()
+        self.inner.triggers.names(self.scope())
+    }
+
+    /// Every `(tenant, trigger)` key in the process, unfiltered.
+    pub fn trigger_keys(&self) -> Vec<TenantKey> {
+        self.inner.triggers.all_keys()
     }
 
     // -----------------------------------------------------------------------
     // Computation graph registry
     // -----------------------------------------------------------------------
 
-    /// Register a computation graph constructor by graph name.
+    /// Register a computation graph constructor by graph name, under this
+    /// handle's tenant.
     pub fn register_computation_graph<F>(&self, name: String, constructor: F)
     where
         F: Fn() -> ComputationGraphRegistration + Send + Sync + 'static,
     {
-        self.inner
-            .computation_graphs
-            .write()
-            .insert(name, Box::new(constructor));
+        let _ = self.inner.computation_graphs.insert(
+            self.scope(),
+            name,
+            TenantOwner::unknown(),
+            Box::new(constructor),
+        );
+    }
+
+    /// Register a computation graph attributed to `owner`, rejecting a
+    /// same-tenant claim on a name a *different* package already owns.
+    pub fn try_register_computation_graph<F>(
+        &self,
+        owner: &TenantOwner,
+        name: String,
+        constructor: F,
+    ) -> Result<(), RuntimeRegistrationError>
+    where
+        F: Fn() -> ComputationGraphRegistration + Send + Sync + 'static,
+    {
+        self.inner.computation_graphs.insert(
+            self.scope(),
+            name,
+            owner.clone(),
+            Box::new(constructor),
+        )
     }
 
     /// Remove a computation graph constructor. Returns true if the entry existed.
     pub fn unregister_computation_graph(&self, name: &str) -> bool {
-        self.inner.computation_graphs.write().remove(name).is_some()
+        self.inner.computation_graphs.remove(self.scope(), name)
     }
 
     /// Look up and instantiate a computation graph registration by name.
     pub fn get_computation_graph(&self, name: &str) -> Option<ComputationGraphRegistration> {
         self.inner
             .computation_graphs
-            .read()
-            .get(name)
-            .map(|ctor| ctor())
+            .with(self.scope(), name, |ctor| ctor())
     }
 
-    /// Get all registered computation graph names.
+    /// Get every computation graph name visible to this handle's scope.
     pub fn computation_graph_names(&self) -> Vec<String> {
-        self.inner
-            .computation_graphs
-            .read()
-            .keys()
-            .cloned()
-            .collect()
+        self.inner.computation_graphs.names(self.scope())
+    }
+
+    /// Every `(tenant, graph)` key in the process, unfiltered.
+    pub fn computation_graph_keys(&self) -> Vec<TenantKey> {
+        self.inner.computation_graphs.all_keys()
     }
 
     // -----------------------------------------------------------------------
@@ -313,34 +686,66 @@ impl Runtime {
     where
         F: Fn() -> TriggerlessGraphRegistration + Send + Sync + 'static,
     {
+        let _ = self.inner.triggerless_graphs.insert(
+            self.scope(),
+            name,
+            TenantOwner::unknown(),
+            Box::new(constructor),
+        );
+    }
+
+    /// Register a trigger-less graph attributed to `owner`, rejecting a
+    /// same-tenant claim on a name a *different* package already owns.
+    pub fn try_register_triggerless_graph<F>(
+        &self,
+        owner: &TenantOwner,
+        name: String,
+        constructor: F,
+    ) -> Result<(), RuntimeRegistrationError>
+    where
+        F: Fn() -> TriggerlessGraphRegistration + Send + Sync + 'static,
+    {
+        self.inner.triggerless_graphs.insert(
+            self.scope(),
+            name,
+            owner.clone(),
+            Box::new(constructor),
+        )
+    }
+
+    /// Ask whether `owner` may claim the trigger-less graph `name` in this
+    /// handle's scope before registering it. See
+    /// [`Runtime::may_claim_trigger`] for the three outcomes.
+    pub fn may_claim_triggerless_graph(
+        &self,
+        owner: &TenantOwner,
+        name: &str,
+    ) -> Result<bool, RuntimeRegistrationError> {
         self.inner
             .triggerless_graphs
-            .write()
-            .insert(name, Box::new(constructor));
+            .check_claim(self.scope(), name, owner)
     }
 
     /// Remove a trigger-less graph constructor. Returns true if the entry existed.
     pub fn unregister_triggerless_graph(&self, name: &str) -> bool {
-        self.inner.triggerless_graphs.write().remove(name).is_some()
+        self.inner.triggerless_graphs.remove(self.scope(), name)
     }
 
     /// Look up and instantiate a trigger-less graph registration by name.
     pub fn get_triggerless_graph(&self, name: &str) -> Option<TriggerlessGraphRegistration> {
         self.inner
             .triggerless_graphs
-            .read()
-            .get(name)
-            .map(|ctor| ctor())
+            .with(self.scope(), name, |ctor| ctor())
     }
 
-    /// Get every registered trigger-less graph name.
+    /// Get every trigger-less graph name visible to this handle's scope.
     pub fn triggerless_graph_names(&self) -> Vec<String> {
-        self.inner
-            .triggerless_graphs
-            .read()
-            .keys()
-            .cloned()
-            .collect()
+        self.inner.triggerless_graphs.names(self.scope())
+    }
+
+    /// Every `(tenant, trigger-less graph)` key in the process, unfiltered.
+    pub fn triggerless_graph_keys(&self) -> Vec<TenantKey> {
+        self.inner.triggerless_graphs.all_keys()
     }
 
     // -----------------------------------------------------------------------
@@ -356,25 +761,48 @@ impl Runtime {
     where
         F: Fn() -> ReactorRegistration + Send + Sync + 'static,
     {
+        let _ = self.inner.reactors.insert(
+            self.scope(),
+            name,
+            TenantOwner::unknown(),
+            Box::new(constructor),
+        );
+    }
+
+    /// Register a reactor attributed to `owner`, rejecting a same-tenant claim
+    /// on a name a *different* package already owns.
+    pub fn try_register_reactor<F>(
+        &self,
+        owner: &TenantOwner,
+        name: String,
+        constructor: F,
+    ) -> Result<(), RuntimeRegistrationError>
+    where
+        F: Fn() -> ReactorRegistration + Send + Sync + 'static,
+    {
         self.inner
             .reactors
-            .write()
-            .insert(name, Box::new(constructor));
+            .insert(self.scope(), name, owner.clone(), Box::new(constructor))
     }
 
     /// Remove a reactor constructor. Returns true if the entry existed.
     pub fn unregister_reactor(&self, name: &str) -> bool {
-        self.inner.reactors.write().remove(name).is_some()
+        self.inner.reactors.remove(self.scope(), name)
     }
 
     /// Look up and instantiate a reactor registration by name.
     pub fn get_reactor(&self, name: &str) -> Option<ReactorRegistration> {
-        self.inner.reactors.read().get(name).map(|ctor| ctor())
+        self.inner.reactors.with(self.scope(), name, |ctor| ctor())
     }
 
-    /// Get every registered reactor name.
+    /// Get every reactor name visible to this handle's scope.
     pub fn reactor_names(&self) -> Vec<String> {
-        self.inner.reactors.read().keys().cloned().collect()
+        self.inner.reactors.names(self.scope())
+    }
+
+    /// Every `(tenant, reactor)` key in the process, unfiltered.
+    pub fn reactor_keys(&self) -> Vec<TenantKey> {
+        self.inner.reactors.all_keys()
     }
 
     // -----------------------------------------------------------------------
@@ -432,11 +860,13 @@ impl Default for Runtime {
 impl std::fmt::Debug for Runtime {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let tasks = self.inner.tasks.read().len();
-        let workflows = self.inner.workflows.read().len();
-        let triggers = self.inner.triggers.read().len();
-        let cgs = self.inner.computation_graphs.read().len();
+        let workflows = self.inner.workflows.len();
+        let triggers = self.inner.triggers.len();
+        let cgs = self.inner.computation_graphs.len();
         let sbs = self.inner.stream_backends.read().len();
         f.debug_struct("Runtime")
+            .field("tenant", &self.scope.tenant_id)
+            .field("is_admin", &self.scope.is_admin)
             .field("tasks", &tasks)
             .field("workflows", &workflows)
             .field("triggers", &triggers)
@@ -510,5 +940,237 @@ mod tests {
         let debug = format!("{:?}", rt);
         assert!(debug.contains("computation_graphs: 0"));
         assert!(debug.contains("stream_backends: 0"));
+    }
+
+    // -----------------------------------------------------------------------
+    // CLOACI-T-0924: tenant keying
+    // -----------------------------------------------------------------------
+
+    fn wf(name: &str) -> crate::workflow::Workflow {
+        crate::workflow::Workflow::new(name)
+    }
+
+    /// Two tenants register the same workflow name on ONE shared runtime and
+    /// each resolves its own — the collision T-0924 was filed for.
+    #[test]
+    fn two_tenants_same_workflow_name_do_not_collide() {
+        let shared = Runtime::empty();
+        let acme = shared.scoped_to_tenant("acme");
+        let globex = shared.scoped_to_tenant("globex");
+        assert!(acme.shares_registries_with(&globex));
+
+        let a = wf("acme-only-desc");
+        acme.register_workflow("pipeline".to_string(), move || a.clone());
+        let g = wf("globex-only-desc");
+        globex.register_workflow("pipeline".to_string(), move || g.clone());
+
+        assert_eq!(
+            acme.get_workflow("pipeline").unwrap().name(),
+            "acme-only-desc"
+        );
+        assert_eq!(
+            globex.get_workflow("pipeline").unwrap().name(),
+            "globex-only-desc"
+        );
+        // Both entries are physically present under distinct keys.
+        assert_eq!(shared.workflow_keys().len(), 2);
+    }
+
+    /// Unloading one tenant's entry leaves the other tenant's alive.
+    #[test]
+    fn unregister_is_tenant_scoped() {
+        let shared = Runtime::empty();
+        let acme = shared.scoped_to_tenant("acme");
+        let globex = shared.scoped_to_tenant("globex");
+
+        let a = wf("a");
+        acme.register_workflow("pipeline".to_string(), move || a.clone());
+        let g = wf("g");
+        globex.register_workflow("pipeline".to_string(), move || g.clone());
+
+        assert!(acme.unregister_workflow("pipeline"));
+        assert!(acme.get_workflow("pipeline").is_none());
+        assert_eq!(globex.get_workflow("pipeline").unwrap().name(), "g");
+        assert_eq!(shared.workflow_keys().len(), 1);
+    }
+
+    /// A non-admin handle can never see, resolve, or drop another tenant's
+    /// entry.
+    #[test]
+    fn other_tenants_entries_are_invisible() {
+        let shared = Runtime::empty();
+        let acme = shared.scoped_to_tenant("acme");
+        let a = wf("a");
+        acme.register_workflow("private".to_string(), move || a.clone());
+
+        let globex = shared.scoped_to_tenant("globex");
+        assert!(globex.get_workflow("private").is_none());
+        assert!(globex.workflow_names().is_empty());
+        assert!(!globex.unregister_workflow("private"));
+        // …and the entry is untouched.
+        assert!(acme.get_workflow("private").is_some());
+    }
+
+    /// Two packages inside the SAME tenant claiming one name is a loud error,
+    /// not a silent overwrite; the incumbent survives. Re-registration by the
+    /// same package replaces (the package-reload path depends on it).
+    #[test]
+    fn same_tenant_cross_package_collision_is_loud() {
+        let rt = Runtime::empty().scoped_to_tenant("acme");
+        let first = TenantOwner::package("pkg-a");
+        let second = TenantOwner::package("pkg-b");
+
+        let a = wf("from-a");
+        rt.try_register_workflow(&first, "reports".to_string(), move || a.clone())
+            .expect("first claim");
+
+        let b = wf("from-b");
+        let err = rt
+            .try_register_workflow(&second, "reports".to_string(), move || b.clone())
+            .expect_err("second package must not silently replace");
+        let msg = err.to_string();
+        assert!(msg.contains("pkg-a"), "{msg}");
+        assert!(msg.contains("pkg-b"), "{msg}");
+        assert!(msg.contains("acme"), "{msg}");
+        assert_eq!(rt.get_workflow("reports").unwrap().name(), "from-a");
+
+        // Same owner re-registering replaces.
+        let a2 = wf("from-a-v2");
+        rt.try_register_workflow(&first, "reports".to_string(), move || a2.clone())
+            .expect("same package may replace");
+        assert_eq!(rt.get_workflow("reports").unwrap().name(), "from-a-v2");
+    }
+
+    /// The same name in two *different* tenants is not a conflict even when
+    /// both are owned by named packages.
+    #[test]
+    fn cross_tenant_same_name_is_not_a_conflict() {
+        let shared = Runtime::empty();
+        let owner = TenantOwner::package("pkg-a");
+        for tenant in ["acme", "globex"] {
+            let w = wf(tenant);
+            shared
+                .scoped_to_tenant(tenant)
+                .try_register_workflow(&owner, "reports".to_string(), move || w.clone())
+                .expect("distinct tenants never collide");
+        }
+        assert_eq!(shared.workflow_keys().len(), 2);
+    }
+
+    /// EMBEDDED COMPATIBILITY: an untenanted deployment is unchanged — every
+    /// entry is untenanted and every lookup, listing and unregister behaves
+    /// exactly as it did before tenant keying.
+    #[test]
+    fn untenanted_path_is_unchanged() {
+        let rt = Runtime::empty();
+        assert_eq!(rt.tenant_id(), None);
+        let w = wf("embedded");
+        rt.register_workflow("embedded".to_string(), move || w.clone());
+        assert!(rt.get_workflow("embedded").is_some());
+        assert_eq!(rt.workflow_names(), vec!["embedded".to_string()]);
+        assert!(rt.unregister_workflow("embedded"));
+        assert!(rt.get_workflow("embedded").is_none());
+        assert!(rt.workflow_names().is_empty());
+    }
+
+    /// Untenanted (inventory / macro-seeded) entries stay reachable from every
+    /// tenant view — that fallback is what keeps `seed_from_inventory` working
+    /// on a per-tenant runner.
+    #[test]
+    fn untenanted_entries_are_visible_from_a_tenant_view() {
+        let shared = Runtime::empty();
+        let w = wf("inventory");
+        shared.register_workflow("inventory".to_string(), move || w.clone());
+
+        let acme = shared.scoped_to_tenant("acme");
+        assert!(acme.get_workflow("inventory").is_some());
+        assert_eq!(acme.workflow_names(), vec!["inventory".to_string()]);
+    }
+
+    /// The tenant's own entry shadows a same-named untenanted one.
+    #[test]
+    fn own_tenant_shadows_untenanted() {
+        let shared = Runtime::empty();
+        let global = wf("global");
+        shared.register_workflow("dup".to_string(), move || global.clone());
+        let acme = shared.scoped_to_tenant("acme");
+        let own = wf("own");
+        acme.register_workflow("dup".to_string(), move || own.clone());
+
+        assert_eq!(acme.get_workflow("dup").unwrap().name(), "own");
+        assert_eq!(shared.get_workflow("dup").unwrap().name(), "global");
+        // Deduplicated in listings even though two keys carry the name.
+        assert_eq!(acme.workflow_names(), vec!["dup".to_string()]);
+    }
+
+    /// An admin view resolves a unique cross-tenant name and refuses an
+    /// ambiguous one rather than guessing.
+    #[test]
+    fn admin_view_resolves_unique_and_refuses_ambiguous() {
+        let shared = Runtime::empty();
+        let a = wf("a");
+        shared
+            .scoped_to_tenant("acme")
+            .register_workflow("only-acme".to_string(), move || a.clone());
+
+        let admin = shared.admin_view();
+        assert!(admin.is_admin());
+        assert!(admin.get_workflow("only-acme").is_some());
+
+        for tenant in ["acme", "globex"] {
+            let w = wf(tenant);
+            shared
+                .scoped_to_tenant(tenant)
+                .register_workflow("shared-name".to_string(), move || w.clone());
+        }
+        assert!(
+            admin.get_workflow("shared-name").is_none(),
+            "an ambiguous name must not resolve to a guess"
+        );
+        // But the admin view can still enumerate everything.
+        let mut names = admin.workflow_names();
+        names.sort();
+        assert_eq!(
+            names,
+            vec!["only-acme".to_string(), "shared-name".to_string()]
+        );
+    }
+
+    /// The same isolation holds for the reactor registry, which is what the
+    /// reconciler's unload bookkeeping walks.
+    #[test]
+    fn reactors_and_graphs_are_tenant_scoped_too() {
+        let shared = Runtime::empty();
+        let acme = shared.scoped_to_tenant("acme");
+        let globex = shared.scoped_to_tenant("globex");
+
+        for rt in [&acme, &globex] {
+            rt.register_triggerless_graph("g".to_string(), || unreachable!());
+            rt.register_computation_graph("cg".to_string(), || unreachable!());
+        }
+        assert_eq!(shared.triggerless_graph_keys().len(), 2);
+        assert_eq!(shared.computation_graph_keys().len(), 2);
+
+        assert!(acme.unregister_triggerless_graph("g"));
+        assert!(!acme.unregister_triggerless_graph("g"));
+        assert_eq!(globex.triggerless_graph_names(), vec!["g".to_string()]);
+
+        assert!(acme.unregister_computation_graph("cg"));
+        assert_eq!(globex.computation_graph_names(), vec!["cg".to_string()]);
+    }
+
+    /// `seed_from_inventory` always writes untenanted entries, whatever scope
+    /// the handle carries — otherwise the reconciler's post-dlopen re-seed
+    /// would stamp one tenant's cdylib entries onto the next tenant to load.
+    #[test]
+    fn inventory_seeding_is_always_untenanted() {
+        let shared = Runtime::empty();
+        shared.scoped_to_tenant("acme").seed_from_inventory();
+        assert!(
+            shared.workflow_keys().iter().all(|k| k.tenant_id.is_none()),
+            "inventory entries must never be stamped with a tenant"
+        );
+        assert!(shared.reactor_keys().iter().all(|k| k.tenant_id.is_none()));
+        assert!(shared.trigger_keys().iter().all(|k| k.tenant_id.is_none()));
     }
 }

--- a/crates/cloacina/src/tenant_scope.rs
+++ b/crates/cloacina/src/tenant_scope.rs
@@ -1,0 +1,343 @@
+/*
+ *  Copyright 2026 Colliery Software
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+//! Shared tenant-keying primitives for process-global name registries.
+//!
+//! Tenant is THE isolation boundary (see CLOACI-S-0011 and the authz design),
+//! so any map that lives for the life of the process and is keyed by an entity
+//! name authored by a tenant must carry the tenant *in the key*, not as payload
+//! hanging off the value.
+//!
+//! CLOACI-T-0921 established this shape for the `EndpointRegistry`
+//! (`EndpointKey` / `EndpointOwner` / `EndpointScope`); CLOACI-T-0924 lifted it
+//! here so the [`Runtime`](crate::Runtime) registries and the
+//! [`ComputationGraphScheduler`](crate::computation_graph::ComputationGraphScheduler)
+//! reuse *one* convention instead of inventing a third.
+//!
+//! Three ideas:
+//!
+//! * [`TenantKey`] — the **map key**: `(tenant, name)`. `tenant_id: None` is the
+//!   untenanted/embedded single-tenant case and keeps pre-multi-tenancy
+//!   behaviour byte-for-byte.
+//! * [`TenantOwner`] — the rest of the **provenance** stamped on each entry
+//!   (which package claimed the name), used to make a same-tenant collision
+//!   between two packages a loud error instead of a silent overwrite.
+//! * [`TenantScope`] — the **caller's** scope, used to resolve a bare `name`
+//!   into a concrete key via [`resolve_tenant_key`].
+//!
+//! ## Why not [`TaskNamespace`](crate::task::TaskNamespace)?
+//!
+//! `RuntimeInner.tasks` is keyed by `TaskNamespace`
+//! (`tenant::package::workflow::task`) and is deliberately *not* migrated to
+//! this shape: a task's full namespace string is persisted on `task_executions`
+//! rows, so every reader genuinely has all four components. The registries this
+//! module serves are addressed by **bare name** at their read sites (a workflow
+//! name off a `workflow_executions` row, a trigger name off a cron schedule, a
+//! reactor name off a WebSocket path), so package belongs in the *owner
+//! metadata* used to detect collisions, not in the key.
+
+use std::collections::HashMap;
+use std::fmt;
+
+/// Composite `(tenant, name)` lookup key for a process-global registry.
+///
+/// `tenant_id: None` is the untenanted/embedded entry. The tenant is stored
+/// verbatim — there is deliberately no folding of the reserved `"public"`
+/// tenant onto `None`, so this key matches CLOACI-T-0921's `EndpointKey` and a
+/// single deployment never has two spellings of the same scope.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct TenantKey {
+    pub tenant_id: Option<String>,
+    pub name: String,
+}
+
+impl TenantKey {
+    pub fn new(tenant_id: Option<&str>, name: &str) -> Self {
+        Self {
+            tenant_id: tenant_id.map(|t| t.to_string()),
+            name: name.to_string(),
+        }
+    }
+
+    /// Operator-facing tenant label for error messages.
+    pub fn tenant_label(&self) -> &str {
+        self.tenant_id.as_deref().unwrap_or("<untenanted>")
+    }
+}
+
+impl fmt::Display for TenantKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}::{}", self.tenant_label(), self.name)
+    }
+}
+
+/// Provenance stamped on a registry entry beyond its [`TenantKey`].
+///
+/// The key is `(tenant, name)`; this records *who* claimed it. It exists so a
+/// same-tenant claim on a live name by a **different package** is rejected
+/// loudly at load time instead of silently replacing the incumbent, and so a
+/// package's unload only ever removes entries it installed.
+///
+/// `package: None` means "provenance unknown" — hand-wired registrations,
+/// macro/`inventory` seeding, and the Python decorator paths. An unknown owner
+/// never *causes* a conflict (there is nothing to compare), which keeps every
+/// pre-existing caller behaving exactly as it did.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TenantOwner {
+    pub package: Option<String>,
+}
+
+impl TenantOwner {
+    /// An owner with no package provenance (hand-wired / inventory / embedded).
+    pub fn unknown() -> Self {
+        Self { package: None }
+    }
+
+    /// An owner identified by the package that claimed the name.
+    pub fn package(package: impl Into<String>) -> Self {
+        Self {
+            package: Some(package.into()),
+        }
+    }
+
+    /// `true` when `other` may replace an entry owned by `self`.
+    ///
+    /// Same package replaces (a package reload / restart depends on it); an
+    /// unknown owner on either side is permissive, because there is no
+    /// provenance to contradict. Two *named and different* packages conflict.
+    pub fn may_replace(&self, other: &TenantOwner) -> bool {
+        match (&self.package, &other.package) {
+            (Some(a), Some(b)) => a == b,
+            _ => true,
+        }
+    }
+
+    /// Operator-facing provenance string for conflict errors.
+    pub fn label(&self) -> String {
+        match &self.package {
+            Some(p) => format!("package '{}'", p),
+            None => "an unattributed registration".to_string(),
+        }
+    }
+}
+
+/// Tenant scope of a *caller* performing a lookup.
+///
+/// Routes build this from the authenticated key; in-process callers build it
+/// from the tenant their runner/reconciler is bound to.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct TenantScope<'a> {
+    pub tenant_id: Option<&'a str>,
+    pub is_admin: bool,
+}
+
+impl<'a> TenantScope<'a> {
+    /// A non-admin caller in `tenant_id` (`None` = untenanted deployment).
+    pub fn of(tenant_id: Option<&'a str>) -> Self {
+        Self {
+            tenant_id,
+            is_admin: false,
+        }
+    }
+
+    /// A non-admin caller in a specific tenant.
+    pub fn tenant(tenant_id: &'a str) -> Self {
+        Self::of(Some(tenant_id))
+    }
+
+    /// The untenanted (embedded / single-tenant) caller.
+    pub fn untenanted() -> Self {
+        Self::of(None)
+    }
+
+    /// An admin caller: may reach any tenant's entry, but only when the name
+    /// is unambiguous across tenants.
+    pub fn admin() -> Self {
+        Self {
+            tenant_id: None,
+            is_admin: true,
+        }
+    }
+
+    /// The key this scope *writes* under.
+    pub fn own_key(&self, name: &str) -> TenantKey {
+        TenantKey::new(self.tenant_id, name)
+    }
+}
+
+/// Why a scoped lookup failed to land on exactly one key.
+#[derive(Debug, PartialEq, Eq)]
+pub enum TenantResolveMiss {
+    NotFound,
+    /// The name exists in more than one tenant and the caller is an admin —
+    /// report both rather than guessing.
+    Ambiguous(Vec<String>),
+}
+
+impl fmt::Display for TenantResolveMiss {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            TenantResolveMiss::NotFound => write!(f, "not found in this tenant scope"),
+            TenantResolveMiss::Ambiguous(tenants) => write!(
+                f,
+                "name is ambiguous across tenants {:?}; address it with an explicit tenant",
+                tenants
+            ),
+        }
+    }
+}
+
+/// Resolve a bare `name` to a concrete [`TenantKey`] within `scope`.
+///
+/// Order:
+/// 1. the caller's own tenant — the normal multi-tenant path;
+/// 2. the untenanted entry (`tenant_id: None`) — embedded/pre-tenancy entries,
+///    which were always globally addressable;
+/// 3. admins only: a unique cross-tenant match. Two tenants owning the same
+///    name is [`TenantResolveMiss::Ambiguous`], never a guess.
+///
+/// A non-admin caller can therefore never resolve another tenant's entry.
+pub fn resolve_tenant_key<V>(
+    map: &HashMap<TenantKey, V>,
+    scope: TenantScope<'_>,
+    name: &str,
+) -> Result<TenantKey, TenantResolveMiss> {
+    if let Some(tenant) = scope.tenant_id {
+        let key = TenantKey::new(Some(tenant), name);
+        if map.contains_key(&key) {
+            return Ok(key);
+        }
+    }
+
+    let untenanted = TenantKey::new(None, name);
+    if map.contains_key(&untenanted) {
+        return Ok(untenanted);
+    }
+
+    if scope.is_admin {
+        let mut matches: Vec<&TenantKey> = map.keys().filter(|k| k.name == name).collect();
+        matches.sort();
+        match matches.len() {
+            0 => return Err(TenantResolveMiss::NotFound),
+            1 => return Ok(matches[0].clone()),
+            _ => {
+                return Err(TenantResolveMiss::Ambiguous(
+                    matches
+                        .iter()
+                        .map(|k| k.tenant_label().to_string())
+                        .collect(),
+                ))
+            }
+        }
+    }
+
+    Err(TenantResolveMiss::NotFound)
+}
+
+/// Every key in `map` visible to `scope`: the caller's own tenant plus the
+/// untenanted entries, or everything for an admin.
+pub fn visible_keys<'m, V>(
+    map: &'m HashMap<TenantKey, V>,
+    scope: TenantScope<'_>,
+) -> impl Iterator<Item = &'m TenantKey> {
+    let tenant = scope.tenant_id.map(|t| t.to_string());
+    let is_admin = scope.is_admin;
+    map.keys().filter(move |k| {
+        is_admin || k.tenant_id.is_none() || k.tenant_id.as_deref() == tenant.as_deref()
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn map_with(keys: &[(Option<&str>, &str)]) -> HashMap<TenantKey, u32> {
+        keys.iter()
+            .enumerate()
+            .map(|(i, (t, n))| (TenantKey::new(*t, n), i as u32))
+            .collect()
+    }
+
+    #[test]
+    fn own_tenant_wins_over_untenanted() {
+        let m = map_with(&[(None, "wf"), (Some("a"), "wf")]);
+        let k = resolve_tenant_key(&m, TenantScope::tenant("a"), "wf").unwrap();
+        assert_eq!(k.tenant_id.as_deref(), Some("a"));
+    }
+
+    #[test]
+    fn untenanted_is_the_embedded_fallback() {
+        let m = map_with(&[(None, "wf")]);
+        let k = resolve_tenant_key(&m, TenantScope::tenant("a"), "wf").unwrap();
+        assert_eq!(k.tenant_id, None);
+        let k = resolve_tenant_key(&m, TenantScope::untenanted(), "wf").unwrap();
+        assert_eq!(k.tenant_id, None);
+    }
+
+    #[test]
+    fn non_admin_never_reaches_another_tenant() {
+        let m = map_with(&[(Some("a"), "wf")]);
+        assert_eq!(
+            resolve_tenant_key(&m, TenantScope::tenant("b"), "wf").unwrap_err(),
+            TenantResolveMiss::NotFound
+        );
+        assert_eq!(
+            resolve_tenant_key(&m, TenantScope::untenanted(), "wf").unwrap_err(),
+            TenantResolveMiss::NotFound
+        );
+    }
+
+    #[test]
+    fn admin_resolves_unique_and_refuses_ambiguous() {
+        let m = map_with(&[(Some("a"), "wf")]);
+        assert!(resolve_tenant_key(&m, TenantScope::admin(), "wf").is_ok());
+
+        let m = map_with(&[(Some("a"), "wf"), (Some("b"), "wf")]);
+        match resolve_tenant_key(&m, TenantScope::admin(), "wf") {
+            Err(TenantResolveMiss::Ambiguous(tenants)) => assert_eq!(tenants.len(), 2),
+            other => panic!("expected ambiguity, got {:?}", other.map(|k| k.to_string())),
+        }
+    }
+
+    #[test]
+    fn visible_keys_hides_other_tenants() {
+        let m = map_with(&[(None, "a"), (Some("t1"), "b"), (Some("t2"), "c")]);
+        let mut seen: Vec<String> = visible_keys(&m, TenantScope::tenant("t1"))
+            .map(|k| k.name.clone())
+            .collect();
+        seen.sort();
+        assert_eq!(seen, vec!["a".to_string(), "b".to_string()]);
+
+        let all: Vec<String> = visible_keys(&m, TenantScope::admin())
+            .map(|k| k.name.clone())
+            .collect();
+        assert_eq!(all.len(), 3);
+    }
+
+    #[test]
+    fn owner_replacement_policy() {
+        let pkg_a = TenantOwner::package("a");
+        let pkg_b = TenantOwner::package("b");
+        let unknown = TenantOwner::unknown();
+
+        assert!(pkg_a.may_replace(&pkg_a));
+        assert!(!pkg_a.may_replace(&pkg_b));
+        // Unattributed registrations stay permissive in both directions so no
+        // pre-existing hand-wired caller starts failing.
+        assert!(unknown.may_replace(&pkg_a));
+        assert!(pkg_a.may_replace(&unknown));
+    }
+}

--- a/crates/cloacina/tests/integration/computation_graph.rs
+++ b/crates/cloacina/tests/integration/computation_graph.rs
@@ -347,6 +347,7 @@ use cloacina::computation_graph::scheduler::{
     AccumulatorDeclaration, AccumulatorFactory, AccumulatorSpawnConfig,
     ComputationGraphDeclaration, ComputationGraphScheduler, ReactorDeclaration,
 };
+use cloacina::tenant_scope::TenantScope;
 use tokio::sync::mpsc as tokio_mpsc;
 use tokio::task::JoinHandle;
 
@@ -499,7 +500,10 @@ async fn test_computation_graph_scheduler_end_to_end() {
     );
 
     // Unload
-    scheduler.unload_graph("scheduler_test").await.unwrap();
+    scheduler
+        .unload_graph("scheduler_test", TenantScope::untenanted())
+        .await
+        .unwrap();
 
     // Registry should be empty
     assert!(registry.list_reactors().await.is_empty());
@@ -2566,6 +2570,7 @@ async fn test_cloaci_t_0538_split_form_scheduler_end_to_end() {
     use cloacina::computation_graph::scheduler::{
         AccumulatorDeclaration, ComputationGraphScheduler,
     };
+    use cloacina::tenant_scope::TenantScope;
     use cloacina::{ComputationReactionMode, ReactorRegistration};
     use cloacina_computation_graph::CompiledGraphFn;
     use std::sync::atomic::{AtomicU32, Ordering};
@@ -2626,7 +2631,7 @@ async fn test_cloaci_t_0538_split_form_scheduler_end_to_end() {
     );
 
     scheduler
-        .unload_graph("cloaci_t_0538_split_scheduler")
+        .unload_graph("cloaci_t_0538_split_scheduler", TenantScope::untenanted())
         .await
         .expect("unload should succeed");
 }
@@ -2715,6 +2720,7 @@ async fn test_cloaci_t_0544_two_graphs_share_one_reactor_via_split_form() {
     use cloacina::computation_graph::scheduler::{
         AccumulatorDeclaration, ComputationGraphScheduler,
     };
+    use cloacina::tenant_scope::TenantScope;
     use cloacina::{ComputationReactionMode, ReactorRegistration};
     use cloacina_computation_graph::CompiledGraphFn;
     use std::sync::atomic::{AtomicU32, Ordering};
@@ -2798,7 +2804,10 @@ async fn test_cloaci_t_0544_two_graphs_share_one_reactor_via_split_form() {
 
     // Unloading g1 leaves the reactor running for g2; another event still
     // fires g2.
-    scheduler.unload_graph("g1").await.unwrap();
+    scheduler
+        .unload_graph("g1", TenantScope::untenanted())
+        .await
+        .unwrap();
     registry
         .send_to_accumulator(
             "alpha",
@@ -2823,7 +2832,10 @@ async fn test_cloaci_t_0544_two_graphs_share_one_reactor_via_split_form() {
     );
 
     // Unloading g2 (the last subscriber) tears down the reactor.
-    scheduler.unload_graph("g2").await.unwrap();
+    scheduler
+        .unload_graph("g2", TenantScope::untenanted())
+        .await
+        .unwrap();
     assert!(scheduler.list_graphs().await.is_empty());
 }
 
@@ -2893,7 +2905,10 @@ async fn test_cloaci_t_0544_contract_mismatch_rejected() {
         "error should pinpoint the criteria mismatch: {err}"
     );
 
-    scheduler.unload_graph("first").await.unwrap();
+    scheduler
+        .unload_graph("first", TenantScope::untenanted())
+        .await
+        .unwrap();
 }
 
 /// Dispatch is concurrent: a slow subscriber doesn't push out the fast one's
@@ -2907,6 +2922,7 @@ async fn test_cloaci_t_0544_dispatch_is_concurrent() {
     use cloacina::computation_graph::scheduler::{
         AccumulatorDeclaration, ComputationGraphScheduler,
     };
+    use cloacina::tenant_scope::TenantScope;
     use cloacina::{ComputationReactionMode, ReactorRegistration};
     use cloacina_computation_graph::CompiledGraphFn;
     use std::sync::atomic::{AtomicI64, Ordering};
@@ -3013,8 +3029,14 @@ async fn test_cloaci_t_0544_dispatch_is_concurrent() {
         "slow subscriber should still take ~200ms (slow={slow_ms}ms)"
     );
 
-    scheduler.unload_graph("fast").await.unwrap();
-    scheduler.unload_graph("slow").await.unwrap();
+    scheduler
+        .unload_graph("fast", TenantScope::untenanted())
+        .await
+        .unwrap();
+    scheduler
+        .unload_graph("slow", TenantScope::untenanted())
+        .await
+        .unwrap();
 }
 
 /// T-0545 M1: the new public `load_reactor` + `bind_graph_to_reactor` API
@@ -3027,6 +3049,7 @@ async fn test_cloaci_t_0545_load_reactor_then_bind_graph() {
     use cloacina::computation_graph::scheduler::{
         AccumulatorDeclaration, ComputationGraphScheduler,
     };
+    use cloacina::tenant_scope::TenantScope;
     use cloacina_computation_graph::CompiledGraphFn;
     use std::sync::atomic::{AtomicU32, Ordering};
 
@@ -3118,6 +3141,7 @@ async fn test_cloaci_t_0545_load_reactor_then_bind_graph() {
         .bind_graph_to_reactor(
             "g1".to_string(),
             "cloaci_t_0545_standalone_reactor".to_string(),
+            TenantScope::untenanted(),
             graph_fn,
         )
         .await
@@ -3143,15 +3167,26 @@ async fn test_cloaci_t_0545_load_reactor_then_bind_graph() {
         Box::pin(async { cloacina::computation_graph::GraphResult::completed(vec![]) })
     });
     let err = scheduler
-        .bind_graph_to_reactor("g2".to_string(), "no_such_reactor".to_string(), dummy)
+        .bind_graph_to_reactor(
+            "g2".to_string(),
+            "no_such_reactor".to_string(),
+            TenantScope::untenanted(),
+            dummy,
+        )
         .await
         .expect_err("bind to missing reactor should error");
     assert!(err.contains("not loaded"));
 
     // Cleanup via M4 primitives.
-    scheduler.unbind_graph_from_reactor("g1").await.unwrap();
     scheduler
-        .unload_reactor("cloaci_t_0545_standalone_reactor")
+        .unbind_graph_from_reactor("g1", TenantScope::untenanted())
+        .await
+        .unwrap();
+    scheduler
+        .unload_reactor(
+            "cloaci_t_0545_standalone_reactor",
+            TenantScope::untenanted(),
+        )
         .await
         .unwrap();
 }
@@ -3165,6 +3200,7 @@ async fn test_cloaci_t_0544_unbind_keeps_reactor_running() {
     use cloacina::computation_graph::scheduler::{
         AccumulatorDeclaration, ComputationGraphScheduler,
     };
+    use cloacina::tenant_scope::TenantScope;
     use cloacina::{ComputationReactionMode, ReactorRegistration};
     use cloacina_computation_graph::CompiledGraphFn;
     use std::sync::atomic::{AtomicU32, Ordering};
@@ -3210,8 +3246,12 @@ async fn test_cloaci_t_0544_unbind_keeps_reactor_running() {
         .unwrap();
 
     // Unbind: subscriber removed, reactor still alive.
-    let reactor = scheduler.unbind_graph_from_reactor("g").await.unwrap();
-    assert_eq!(reactor, "cloaci_t_0544_unbind_reactor");
+    let reactor = scheduler
+        .unbind_graph_from_reactor("g", TenantScope::untenanted())
+        .await
+        .unwrap();
+    assert_eq!(reactor.name, "cloaci_t_0544_unbind_reactor");
+    assert_eq!(reactor.tenant_id, None);
     assert!(scheduler.list_graphs().await.is_empty());
 
     // Attach a new subscriber to the same reactor — should bind to the
@@ -3242,9 +3282,12 @@ async fn test_cloaci_t_0544_unbind_keeps_reactor_running() {
     );
 
     // Cleanup: explicit reactor teardown after unbinding the last subscriber.
-    scheduler.unbind_graph_from_reactor("later").await.unwrap();
     scheduler
-        .unload_reactor("cloaci_t_0544_unbind_reactor")
+        .unbind_graph_from_reactor("later", TenantScope::untenanted())
+        .await
+        .unwrap();
+    scheduler
+        .unload_reactor("cloaci_t_0544_unbind_reactor", TenantScope::untenanted())
         .await
         .expect("unload_reactor with no subscribers should succeed");
 }
@@ -3296,7 +3339,7 @@ async fn test_cloaci_t_0544_unload_reactor_rejects_with_subscribers() {
         .unwrap();
 
     let err = scheduler
-        .unload_reactor("cloaci_t_0544_busy_reactor")
+        .unload_reactor("cloaci_t_0544_busy_reactor", TenantScope::untenanted())
         .await
         .expect_err("unload_reactor with bound subscribers should reject");
     assert!(
@@ -3311,15 +3354,15 @@ async fn test_cloaci_t_0544_unload_reactor_rejects_with_subscribers() {
     // Reactor still running — unbind both subscribers explicitly, then
     // unload_reactor succeeds.
     scheduler
-        .unbind_graph_from_reactor("subscriber_a")
+        .unbind_graph_from_reactor("subscriber_a", TenantScope::untenanted())
         .await
         .unwrap();
     scheduler
-        .unbind_graph_from_reactor("subscriber_b")
+        .unbind_graph_from_reactor("subscriber_b", TenantScope::untenanted())
         .await
         .unwrap();
     scheduler
-        .unload_reactor("cloaci_t_0544_busy_reactor")
+        .unload_reactor("cloaci_t_0544_busy_reactor", TenantScope::untenanted())
         .await
         .expect("unload_reactor should succeed once subscribers are unbound");
 }
@@ -3526,6 +3569,7 @@ async fn test_cloaci_t_0921_cross_tenant_accumulator_isolation() {
     use cloacina::computation_graph::scheduler::{
         AccumulatorDeclaration, ComputationGraphScheduler,
     };
+    use cloacina::tenant_scope::TenantScope;
     use cloacina_computation_graph::CompiledGraphFn;
     use std::sync::atomic::{AtomicU32, Ordering};
 
@@ -3568,6 +3612,7 @@ async fn test_cloaci_t_0921_cross_tenant_accumulator_isolation() {
         .bind_graph_to_reactor(
             "t0921_g_a".to_string(),
             "t0921_rx_a".to_string(),
+            TenantScope::tenant("acme"),
             mk_fn(a_fires.clone()),
         )
         .await
@@ -3576,6 +3621,7 @@ async fn test_cloaci_t_0921_cross_tenant_accumulator_isolation() {
         .bind_graph_to_reactor(
             "t0921_g_b".to_string(),
             "t0921_rx_b".to_string(),
+            TenantScope::tenant("globex"),
             mk_fn(b_fires.clone()),
         )
         .await
@@ -3620,7 +3666,10 @@ async fn test_cloaci_t_0921_cross_tenant_accumulator_isolation() {
     );
 
     // ---- Unload tenant A; tenant B survives ----
-    scheduler.unload_graph("t0921_g_a").await.unwrap();
+    scheduler
+        .unload_graph("t0921_g_a", TenantScope::tenant("acme"))
+        .await
+        .unwrap();
 
     initech = registry
         .send_to_accumulator(
@@ -3651,7 +3700,10 @@ async fn test_cloaci_t_0921_cross_tenant_accumulator_isolation() {
         "tenant B's graph still fires after tenant A unloaded"
     );
 
-    scheduler.unload_graph("t0921_g_b").await.unwrap();
+    scheduler
+        .unload_graph("t0921_g_b", TenantScope::tenant("globex"))
+        .await
+        .unwrap();
 }
 
 /// Two packages in the SAME tenant claiming one accumulator name is a LOUD
@@ -3663,6 +3715,7 @@ async fn test_cloaci_t_0921_same_tenant_duplicate_accumulator_rejected() {
     use cloacina::computation_graph::scheduler::{
         AccumulatorDeclaration, ComputationGraphScheduler,
     };
+    use cloacina::tenant_scope::TenantScope;
 
     let registry = EndpointRegistry::new();
     let scheduler = ComputationGraphScheduler::new(registry.clone());
@@ -3718,5 +3771,8 @@ async fn test_cloaci_t_0921_same_tenant_duplicate_accumulator_rejected() {
         "the rejected load must unwind its reactor registration"
     );
 
-    scheduler.unload_reactor("t0921_first_rx").await.unwrap();
+    scheduler
+        .unload_reactor("t0921_first_rx", TenantScope::tenant("acme"))
+        .await
+        .unwrap();
 }

--- a/crates/cloacina/tests/integration/dal/reconciler_e2e_load.rs
+++ b/crates/cloacina/tests/integration/dal/reconciler_e2e_load.rs
@@ -198,7 +198,10 @@ async fn reconciler_loads_cross_package_publisher_subscriber_end_to_end() {
     // Publisher's reactor must be in the scheduler with the declared
     // accumulator contract.
     let reactor_accs = scheduler
-        .reactor_accumulator_names("shared_rx")
+        .reactor_accumulator_names(
+            "shared_rx",
+            cloacina::tenant_scope::TenantScope::tenant("public"),
+        )
         .await
         .expect("shared_rx must be loaded after reconcile");
     assert_eq!(
@@ -238,7 +241,10 @@ async fn reconciler_loads_cross_package_publisher_subscriber_end_to_end() {
     tokio::time::sleep(std::time::Duration::from_millis(200)).await;
     assert!(
         scheduler
-            .reactor_accumulator_names("shared_rx")
+            .reactor_accumulator_names(
+                "shared_rx",
+                cloacina::tenant_scope::TenantScope::tenant("public"),
+            )
             .await
             .is_some(),
         "reactor must still be live after event delivery"
@@ -270,7 +276,10 @@ async fn reconciler_loads_cross_package_publisher_subscriber_end_to_end() {
     );
     assert!(
         scheduler
-            .reactor_accumulator_names("shared_rx")
+            .reactor_accumulator_names(
+                "shared_rx",
+                cloacina::tenant_scope::TenantScope::tenant("public"),
+            )
             .await
             .is_some(),
         "reactor must still be live after rejected publisher unload"
@@ -293,7 +302,10 @@ async fn reconciler_loads_cross_package_publisher_subscriber_end_to_end() {
         .expect("reconcile second pass — picks up publisher unload retry");
     assert!(
         scheduler
-            .reactor_accumulator_names("shared_rx")
+            .reactor_accumulator_names(
+                "shared_rx",
+                cloacina::tenant_scope::TenantScope::tenant("public"),
+            )
             .await
             .is_none(),
         "reactor must be torn down once publisher is unloaded after subscriber"
@@ -410,7 +422,10 @@ async fn reconciler_loads_mixed_rust_with_in_package_trigger_subscription() {
     // Reactor + workflow + graph must also have landed.
     assert!(
         scheduler
-            .reactor_accumulator_names("mixed_reactor")
+            .reactor_accumulator_names(
+                "mixed_reactor",
+                cloacina::tenant_scope::TenantScope::tenant("public"),
+            )
             .await
             .is_some(),
         "mixed_reactor must be loaded"


### PR DESCRIPTION
## Summary

Finishes the re-keying T-0921 started. `RuntimeInner`'s five name-keyed maps and the CG scheduler's three were bare-name keyed while **one** `Arc<Runtime>` is shared by every tenant's runner — so two tenants registering the same name collided in-process (CLOACI-T-0924).

**Keying**: `TenantKey { tenant_id, name }`, lifted out of T-0921's `EndpointKey` into a shared `tenant_scope.rs` so `Runtime`, the scheduler, and the endpoint registry share **one** convention rather than three.

**Why not `TaskNamespace`, despite the ticket suggesting it**: every read site of these registries addresses them by *bare name* and genuinely has no package in hand — `workflow_executions.workflow_name`, a trigger name off a cron row, a reactor name off a WS path, `packaging_bridge` walking `reactor_names()`. `RuntimeInner.tasks` keeps `TaskNamespace` precisely because the full 4-part namespace is *persisted* on `task_executions` rows. Package therefore lives in owner metadata for loud collision detection, not in the key.

## Public API

**`Runtime` changes zero pre-existing signatures.** The scope rides on the handle (it already Clone-shares its `Arc`), so all ~120 `get_workflow`/`register_x`/`x_names` call sites are untouched; the single choke point is the two runner constructors binding the handle to `config.tenant_id()`.

**`ComputationGraphScheduler` signatures do change** — it's one genuinely shared `Arc` and can't carry a scope: `bind_graph_to_reactor`, `unbind_graph_from_reactor` (now returns `TenantKey`), `unload_reactor`, `unload_graph`, `reactor_accumulator_names` take a `TenantScope`. Call sites updated across the reconciler, scheduler tests, python suites, and the server's shared-runtime test.

Rule documented: a **load/bind is a claim** → addresses `scope.own_key(name)` exactly; a **lookup/unload is a resolution** → goes through `resolve_tenant_key`.

## Embedded compatibility

One decision differs from the ticket's own phase-1 note, driven by the zero-behavior-change constraint: **the reconciler does not re-scope to `default_tenant_id`** — it writes through whatever scope its `Arc<Runtime>` carries. Self-scoping to `"public"` would break the embedded user who hands their own untenanted `Runtime` to the builder and then reads `rt.get_workflow(name)` off that same handle. In the server the runner has already bound the tenant and the two agree. With `tenant_id: None` everywhere the keys **are** the bare names, so every map degenerates to the pre-change shape.

## Test plan
- 17 runtime tests + 6 new scheduler tests: two tenants coexist under one name; unload one, the other survives; the other tenant is unreachable across four methods; cross-package conflict is loud while same-owner replace still works; embedded path unchanged
- 792 lib tests, server lib 207, computation_graph 50/50, reconciler_e2e_load 2/2, constructors-wasm and python targets green
- **The 4 postgres integration failures are pre-existing and were proven so**: stashing the entire change reproduces the three `cron_basic` failures identically on unmodified main — they assert `total_executions == 0` against a shared, never-reset dev Postgres and the count climbs run over run (7 on this tree, 14 stashed). The signing and registry_simple failures are order-dependent on the same shared schema and pass in isolation.

## Out of scope (recorded)
`RunningGraph.subscribers` stays bare-name keyed — the dispatcher labels results with it and re-keying reaches into `GraphResult` plumbing; only reachable when two tenants bind same-named graphs to one *untenanted* reactor, which can't occur server-side, and it's mitigated with a loud error rather than silent replacement. Also left: reactor registrations still carry no package provenance into `EndpointOwner` (T-0921's own residual), and `tasks`/`stream_backends` per that audit.