### PR TITLE
fix(T-0927): prove the instance surface against a live server — and fix the two bugs that found

### DIFF
--- a/.angreal/test/e2e/compiler.py
+++ b/.angreal/test/e2e/compiler.py
@@ -351,18 +351,30 @@ def _poll_run_workflow(
     home: Path,
     workflow_name: str,
     timeout_s: float = 120.0,
+    context: dict | None = None,
 ) -> str:
     """Try `workflow run` until the runner has actually loaded the workflow
     (HTTP no longer returns 'Workflow not found in registry'). The
     reconciler loads packages on a periodic tick — until that lands, the
     runtime registry doesn't know about the workflow even though the DB
     does. Returns the execution_id from the first accepted run.
+
+    `context` is REQUIRED for a workflow that declares required params: the
+    execute route validates before dispatching, so a bare run of such a
+    workflow is rejected forever and this would spin until timeout on a
+    validation error rather than a load error (CLOACI-T-0927).
     """
     deadline = time.time() + timeout_s
     last_err = ""
+    ctx_args: list[str] = []
+    if context is not None:
+        ctx_path = home / f"run-context-{workflow_name}.json"
+        ctx_path.write_text(json.dumps(context))
+        ctx_args = ["--context", str(ctx_path)]
     while time.time() < deadline:
         code, out, err = _cloacinactl(
-            home, "-o", "json", "workflow", "run", workflow_name, check=False
+            home, "-o", "json", "workflow", "run", workflow_name, *ctx_args,
+            check=False,
         )
         if code == 0:
             try:
@@ -407,6 +419,50 @@ def _poll_execution_status(
         time.sleep(1.0)
     raise AssertionError(
         f"execution {execution_id} never reached {expected}; last: {last_status!r}"
+    )
+
+
+def _poll_instance_fire(
+    workflow_name: str,
+    instance_name: str,
+    timeout_s: float = 120.0,
+) -> tuple[str, dict]:
+    """Wait for a NAMED INSTANCE's cron schedule to actually fire, and return
+    `(execution_id, context)` for the run it produced (CLOACI-T-0927).
+
+    This is the assertion T-0894 could not make: that an instance created over
+    HTTP is picked up by the scheduler and fires with its bound params merged
+    into the run's context. Nothing short of a live server proves it.
+
+    The context is read straight from the DB because the executions API exposes
+    only status — `ExecutionDetail` carries no context — so there is no HTTP
+    channel for this. The schedule row is matched on `instance_name` so a
+    concurrent anonymous schedule for the same workflow can't be mistaken for
+    the instance's own fire.
+    """
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        rows = _psql(
+            "SELECT we.id::text || '|' || c.value "
+            "FROM public.workflow_executions we "
+            "JOIN public.contexts c ON c.id = we.context_id "
+            "JOIN public.schedule_executions se "
+            "  ON se.workflow_execution_id = we.id "
+            "JOIN public.schedules s ON s.id = se.schedule_id "
+            f"WHERE s.workflow_name = '{workflow_name}' "
+            f"  AND s.instance_name = '{instance_name}' "
+            "ORDER BY we.created_at DESC LIMIT 1;"
+        ).strip()
+        if rows:
+            exec_id, _, raw = rows.partition("|")
+            try:
+                return exec_id.strip(), json.loads(raw)
+            except json.JSONDecodeError:
+                pass
+        time.sleep(2.0)
+    raise AssertionError(
+        f"instance '{instance_name}' of '{workflow_name}' never fired within "
+        f"{timeout_s}s (no workflow_execution linked to its schedule)"
     )
 
 
@@ -627,6 +683,137 @@ def compiler(version_deps=False):
             f"execution {execution_id} ended in status {status!r}"
         )
         print(f"  ok: reconciler end-to-end → execution {status}")
+
+        # --- named workflow instances (CLOACI-T-0927) ----------------------
+        # T-0894 shipped the instance surface with only unit-level proof. This
+        # is the lane that proves the FEATURE rather than the endpoint: create
+        # a named instance over HTTP against a live server and watch its cron
+        # schedule fire with the bound params merged into the run's context.
+        inst_dir = _stage_fixture(
+            home, "instance-params-rust", version_deps=version_deps
+        )
+        print("  compiling instance-params fixture")
+        inst_id = _upload(home, inst_dir)
+        body = _poll_build_status(home, inst_id, {"success"}, timeout_s=900.0)
+        assert body.get("build_status") == "success", body
+
+        # Wait for the reconciler to load it — declared params are read from
+        # the registry, so creating an instance before the load would skip
+        # validation (it fails OPEN by design) and prove nothing.
+        #
+        # A VALID context is mandatory here: `region` is declared required, so
+        # a bare run is rejected by the execute route's own validation and this
+        # would spin to timeout on a validation error while the workflow was
+        # loaded all along. (That rejection is itself proof the execute route
+        # validates against a live server — asserted explicitly below for the
+        # instance path.)
+        _poll_run_workflow(
+            home,
+            "instance_params_workflow",
+            timeout_s=120.0,
+            context={"region": "warmup", "batch_size": 1},
+        )
+        print("  ok: instance fixture built + loaded")
+
+        # Validation is real: `region` is declared REQUIRED with no default,
+        # so an instance that omits it must be refused at CREATE time. This is
+        # the whole point of validating at creation rather than at 3am on the
+        # first fire.
+        code, out, err = _cloacinactl(
+            home,
+            "instance", "create", "instance_params_workflow", "bad_instance",
+            "--param", "batch_size=7",
+            "--cron", "*/2 * * * * *",
+            check=False,
+        )
+        assert code != 0, (
+            "creating an instance without the required param 'region' should "
+            f"fail; got exit 0 with: {out!r}"
+        )
+        combined = (out + err).lower()
+        assert "region" in combined, (
+            f"rejection should name the missing param; got: {(out + err)!r}"
+        )
+        print("  ok: missing required param rejected at create time")
+
+        # Every 2 seconds (6-field cron = seconds precision) so the lane
+        # observes a real fire without a long wait.
+        _cloacinactl(
+            home,
+            "instance", "create", "instance_params_workflow", "e2e_prod",
+            "--param", "region=eu-west",
+            "--param", "batch_size=7",
+            "--cron", "*/2 * * * * *",
+        )
+        print("  ok: instance created")
+
+        listed = json.loads(
+            _cloacinactl(
+                home, "-o", "json",
+                "instance", "list", "instance_params_workflow",
+            )[1]
+        )
+        # `-o json` renders a list as a bare JSON array; tolerate an enveloped
+        # shape too so this doesn't break if the renderer gains one.
+        rows = (
+            listed
+            if isinstance(listed, list)
+            else (listed.get("items") or listed.get("data") or [])
+        )
+        names = [i.get("instance_name") for i in rows]
+        assert "e2e_prod" in names, f"created instance not listed: {listed!r}"
+        assert "bad_instance" not in names, (
+            f"rejected instance must not have been persisted: {listed!r}"
+        )
+        print("  ok: instance listed (and the rejected one was never stored)")
+
+        inst_exec_id, ctx = _poll_instance_fire(
+            "instance_params_workflow", "e2e_prod", timeout_s=120.0
+        )
+        print(f"  instance fired: execution {inst_exec_id}")
+
+        # The bound params must arrive as top-level context keys...
+        assert ctx.get("region") == "eu-west", (
+            f"bound param 'region' missing/wrong in fired context: {ctx!r}"
+        )
+        assert ctx.get("batch_size") == 7, (
+            f"bound param 'batch_size' missing/wrong in fired context: {ctx!r}"
+        )
+        # ...and the TASK must have actually seen them, not just the row.
+        assert ctx.get("observed_region") == "eu-west", (
+            f"task did not observe the bound region: {ctx!r}"
+        )
+        assert ctx.get("observed_batch_size") == 7, (
+            f"task did not observe the bound batch_size: {ctx!r}"
+        )
+        # Scheduler-reserved keys still win over any binding.
+        assert ctx.get("schedule_id"), f"scheduler keys missing: {ctx!r}"
+        print(
+            "  ok: instance fire delivered bound params to the task "
+            "(region=eu-west, batch_size=7)"
+        )
+
+        status = _poll_execution_status(
+            home, inst_exec_id, {"Completed", "Failed", "Cancelled"}, timeout_s=60.0
+        )
+        assert status == "Completed", (
+            f"instance execution {inst_exec_id} ended in status {status!r}"
+        )
+        print(f"  ok: instance execution {status}")
+
+        # Delete stops future fires. Assert the row is gone rather than
+        # counting fires, which would race the 2-second schedule.
+        _cloacinactl(
+            home,
+            "instance", "delete", "instance_params_workflow", "e2e_prod",
+        )
+        remaining = _psql(
+            "SELECT count(*) FROM public.schedules "
+            "WHERE workflow_name = 'instance_params_workflow' "
+            "AND instance_name = 'e2e_prod';"
+        ).strip()
+        assert remaining == "0", f"instance row survived delete: {remaining!r}"
+        print("  ok: instance deleted")
 
         # --- package lifecycle: upgrade (T-0497) ---------------------------
         # Upload a new version of the same package. The upload handler

--- a/crates/cloacina-server/src/routes/authz.rs
+++ b/crates/cloacina-server/src/routes/authz.rs
@@ -399,6 +399,21 @@ pub fn build_authz_table() -> AuthzTable {
         "/tenants/{tenant_id}/workflows/{name}/source",
         Access::tenant(Level::Read),
     );
+    // Named workflow instances (CLOACI-T-0894). Reads are tenant-Read; the
+    // mutating verbs are registered with the other writes below. Missing from
+    // this table the routes exist but are unreachable — the middleware is
+    // fail-closed, so an unlisted route is denied with "route not authorized"
+    // no matter the key's role (found by the T-0927 live-stack lane).
+    add(
+        Method::GET,
+        "/tenants/{tenant_id}/workflows/{name}/instances",
+        Access::tenant(Level::Read),
+    );
+    add(
+        Method::GET,
+        "/tenants/{tenant_id}/workflows/{name}/instances/{instance}",
+        Access::tenant(Level::Read),
+    );
     add(
         Method::GET,
         "/tenants/{tenant_id}/triggers",
@@ -459,6 +474,17 @@ pub fn build_authz_table() -> AuthzTable {
     add(
         Method::POST,
         "/tenants/{tenant_id}/workflows/{name}/execute",
+        Access::tenant(Level::Write),
+    );
+    // Named workflow instances — mutating verbs (CLOACI-T-0894).
+    add(
+        Method::POST,
+        "/tenants/{tenant_id}/workflows/{name}/instances",
+        Access::tenant(Level::Write),
+    );
+    add(
+        Method::DELETE,
+        "/tenants/{tenant_id}/workflows/{name}/instances/{instance}",
         Access::tenant(Level::Write),
     );
     add(
@@ -848,6 +874,73 @@ mod tests {
         assert!(!p.platform_admin);
     }
 
+    /// Every documented `/v1` route must be classified in the authz table
+    /// (CLOACI-T-0927).
+    ///
+    /// The size pin below is a no-drift guard on the TABLE — it cannot see the
+    /// ROUTER, so a route added to `lib.rs` without a table entry leaves the
+    /// count untouched and sails past it. That is exactly how T-0894's four
+    /// workflow-instance routes shipped unreachable: the middleware is
+    /// fail-closed, so every call returned "route not authorized" regardless of
+    /// the key's role, and only a live-server lane noticed.
+    ///
+    /// The OpenAPI document is generated from the handlers' own
+    /// `#[utoipa::path]` annotations, so it is a faithful stand-in for the
+    /// router (axum exposes no route enumeration). Any handler annotated and
+    /// served under `/v1` must therefore appear here.
+    #[test]
+    fn every_documented_v1_route_is_classified() {
+        use utoipa::OpenApi;
+
+        let table = build_authz_table();
+        let doc = crate::openapi::ApiDoc::openapi();
+
+        // Routes deliberately NOT behind `authz_mw`: unauthenticated liveness,
+        // and the public auth entry points that MINT the key authorization
+        // would otherwise require (lib.rs merges these outside require_auth /
+        // authz_mw — see the "Public auth entry points" comment there).
+        //
+        // Keep this list minimal and specific: each entry is a route no key is
+        // needed for, so a careless addition here is a genuine auth hole.
+        let exempt = |p: &str| {
+            matches!(
+                p,
+                "/health" | "/ready" | "/auth/local/login" | "/auth/oidc/login" | "/auth/callback"
+            )
+        };
+
+        let mut unclassified = Vec::new();
+        for (path, item) in doc.paths.paths.iter() {
+            let Some(rel) = path.strip_prefix("/v1") else {
+                continue;
+            };
+            if exempt(rel) {
+                continue;
+            }
+            for (method, op) in [
+                (Method::GET, &item.get),
+                (Method::POST, &item.post),
+                (Method::PUT, &item.put),
+                (Method::DELETE, &item.delete),
+                (Method::PATCH, &item.patch),
+            ] {
+                if op.is_none() {
+                    continue;
+                }
+                if !table.contains_key(&(method.clone(), rel.to_string())) {
+                    unclassified.push(format!("{} {}", method, rel));
+                }
+            }
+        }
+        unclassified.sort();
+        assert!(
+            unclassified.is_empty(),
+            "documented routes missing from the authz table — they are \
+             UNREACHABLE at runtime (fail-closed middleware denies them):\n  {}",
+            unclassified.join("\n  ")
+        );
+    }
+
     /// No-drift / behavior-preservation guard for the route table. The runtime
     /// guarantee is the fail-closed middleware (an unclassified route 403s); this
     /// pins the full set + spot-checks the behavior-preserving classifications.
@@ -856,7 +949,7 @@ mod tests {
         let t = build_authz_table();
         assert_eq!(
             t.len(),
-            64,
+            68,
             "authz table size changed — a route was added/removed without updating the table"
         );
 

--- a/crates/cloacina-server/src/routes/instances.rs
+++ b/crates/cloacina-server/src/routes/instances.rs
@@ -59,6 +59,44 @@ use crate::AppState;
 const DEFAULT_INSTANCES_LIMIT: i64 = 100;
 const MAX_INSTANCES_LIMIT: i64 = 1000;
 
+/// Wake the tenant's cron scheduler after a schedule row changes
+/// (CLOACI-T-0927).
+///
+/// These routes write the `schedules` row through the DAL directly rather than
+/// the embedded `register_cron_*` API, which notifies for itself. Without this
+/// the scheduler keeps sleeping against a stale cached due-time and a newly
+/// created instance never fires — its 30s backstop does not rescue it, because
+/// the 1s trigger tick re-arms the cron sleep every iteration before it can
+/// elapse. Found by the T-0927 live-stack lane; the starvation itself is filed
+/// separately as a pre-existing defect.
+///
+/// Best-effort: a missing runner is logged, not fatal. The row is already
+/// committed, and the schedule still fires once anything else re-arms the
+/// timer.
+async fn wake_cron_scheduler(state: &AppState, tenant_id: &str, tenant_db: cloacina::Database) {
+    let runner = if tenant_id == "public" {
+        Some(state.runner.clone())
+    } else {
+        match state
+            .tenant_runners
+            .get_or_create(tenant_id, tenant_db)
+            .await
+        {
+            Ok(r) => Some(r),
+            Err(e) => {
+                warn!(
+                    "could not reach tenant runner for '{}' to re-arm cron: {}",
+                    tenant_id, e
+                );
+                None
+            }
+        }
+    };
+    if let Some(r) = runner {
+        r.notify_cron_change();
+    }
+}
+
 /// Map a stored `schedules` row onto the wire type.
 ///
 /// `params` is stored as a JSON *string*; a row whose params fail to parse is
@@ -267,6 +305,9 @@ pub async fn create_instance(
                 name,
                 tenant_id
             );
+            // Re-arm the scheduler, or a scheduled instance sits there never
+            // firing (CLOACI-T-0927).
+            wake_cron_scheduler(&state, &tenant_id, tenant_db).await;
             Json(to_summary(schedule)).into_response()
         }
         Err(e) => {
@@ -457,7 +498,7 @@ pub async fn delete_instance(
                 .into_response()
         }
     };
-    let dal = cloacina::dal::DAL::new(tenant_db);
+    let dal = cloacina::dal::DAL::new(tenant_db.clone());
 
     let schedule = match dal.schedule().find_by_instance_name(&name, &instance).await {
         Ok(Some(s)) => s,
@@ -479,6 +520,8 @@ pub async fn delete_instance(
                 name,
                 tenant_id
             );
+            // Re-arm against the REMAINING schedules (CLOACI-T-0927).
+            wake_cron_scheduler(&state, &tenant_id, tenant_db).await;
             Json(DeleteInstanceResponse {
                 tenant_id,
                 workflow_name: name,

--- a/crates/cloacina/src/runner/default_runner/mod.rs
+++ b/crates/cloacina/src/runner/default_runner/mod.rs
@@ -266,6 +266,18 @@ impl DefaultRunner {
         self.service_manager.read().await.unified_scheduler.clone()
     }
 
+    /// Wake the timer-driven cron scheduler so it re-reads the due set
+    /// (CLOACI-T-0927).
+    ///
+    /// The embedded `register_cron_*` / `unregister_*` APIs do this for
+    /// themselves. Anything that writes a cron `schedules` row through the DAL
+    /// directly — notably the server's named-instance routes — must call this,
+    /// or the scheduler keeps sleeping against a stale cached due-time and the
+    /// new schedule does not fire.
+    pub fn notify_cron_change(&self) {
+        self.cron_change.notify_one();
+    }
+
     /// Set the graph scheduler for computation graph package routing.
     /// Must be called before `start_services()` so the reconciler can route CG packages.
     pub async fn set_graph_scheduler(

--- a/docs/content/engine/scheduling/workflow-instances.md
+++ b/docs/content/engine/scheduling/workflow-instances.md
@@ -77,6 +77,55 @@ runner.register_workflow_instance(
 )
 ```
 
+## Server (cloacinactl)
+
+The Rust and Python forms above are the **embedded** runner's API. On a server
+deployment, instances are managed with the `instance` noun — no embedding
+required:
+
+```bash
+cloacinactl instance create sync_file sync_prod \
+  --param source=/prod --param dst=/backup/prod --cron "0 * * * *"
+
+cloacinactl instance list sync_file
+cloacinactl instance inspect sync_file sync_prod
+cloacinactl instance delete sync_file sync_prod
+```
+
+`--param` is repeatable. A value that parses as JSON binds as that type
+(`max_files=500` → the number 500), and anything else binds as a string
+(`mode=copy`). `--params <file.json>` supplies a base object that explicit
+`--param` flags override, so a shared configuration can be reused with a couple
+of per-instance tweaks. `--timezone` sets the cron timezone (default `UTC`) and
+`--disabled` creates the schedule switched off.
+
+Values are validated against the workflow's declared `params(...)` **when the
+instance is created**, with the same check that validates a per-run context — a
+missing required param is rejected up front rather than failing at every fire.
+A duplicate instance name for the same workflow is a `409`.
+
+**`--cron` is optional.** Without it the instance is created *unscheduled*: a
+durable named binding that never fires on its own.
+
+The equivalent REST surface is:
+
+| Method | Path |
+|---|---|
+| `POST` | `/v1/tenants/{tenant}/workflows/{name}/instances` |
+| `GET` | `/v1/tenants/{tenant}/workflows/{name}/instances` |
+| `GET` | `/v1/tenants/{tenant}/workflows/{name}/instances/{instance}` |
+| `DELETE` | `/v1/tenants/{tenant}/workflows/{name}/instances/{instance}` |
+
+and the same four operations exist on the Rust, Python and TypeScript clients
+as `create_instance` / `list_instances` / `get_instance` / `delete_instance`.
+
+Instances are tenant-scoped: an instance created in one tenant is invisible to
+another, and a cross-tenant request simply 404s.
+
+Because an instance *is* a schedule row underneath, the existing schedule
+controls apply to it — `cloacinactl trigger pause <workflow>` will pause it.
+There is no separate instance pause verb today.
+
 ## How params reach the workflow
 
 At every fire (cron or trigger), the instance's stored params are merged into

--- a/examples/features/workflows/parameterized-workflow/README.md
+++ b/examples/features/workflows/parameterized-workflow/README.md
@@ -97,12 +97,55 @@ cloacinactl workflow run sync_file --context bad.json
 The server rejects it with a typed error before any task runs — that's the
 declared interface doing its job.
 
-## About named instances
+## Named instances
 
-`params(...)` also powers **workflow instances** — persistent, named,
-scheduled bindings (`sync_prod` = this template + these values + this cron).
-See [Workflow Instances](../../../../docs/content/engine/scheduling/workflow-instances.md).
-Instance *registration* is currently an embedded-runner API
-(`register_cron_workflow_instance`); a server-side registration surface is
-tracked separately. Per-run parameterization — everything above — is fully
-supported on the primary interface today.
+Everything above configures a *single run*. `params(...)` also powers
+**workflow instances** — a persistent, named binding of this template to a set
+of values, optionally on a schedule. `sync_prod` = this workflow + these
+parameters + this cron.
+
+Create one:
+
+```bash
+cloacinactl instance create sync_file sync_prod \
+  --param source=/data/prod \
+  --param dst=/backup/prod \
+  --param max_files=500 \
+  --cron "0 3 * * *"
+```
+
+`--param` is repeatable. Values are parsed as JSON when they parse, so
+`max_files=500` binds the *number* 500 and matches the declared `i64`; bare
+text like `mode=copy` binds a string. To reuse a shared file of values and
+override a couple, combine the two — explicit flags win:
+
+```bash
+cloacinactl instance create sync_file sync_staging \
+  --params shared-params.json --param dst=/backup/staging --cron "0 4 * * *"
+```
+
+The values are validated against `params(...)` at **creation** time, using the
+same check that validates a per-run `--context`. A missing required parameter
+is rejected when you create the instance, not at 3am on the first fire.
+
+Inspect and remove:
+
+```bash
+cloacinactl instance list sync_file
+cloacinactl instance inspect sync_file sync_prod
+cloacinactl instance delete sync_file sync_prod
+```
+
+Omit `--cron` to create an **unscheduled** instance: a durable named set of
+bound values that never fires on its own. Useful for holding a
+known-good configuration you trigger deliberately.
+
+When an instance fires, its bound parameters arrive exactly as they do for a
+per-run `--context` — as top-level context keys — so tasks read them the same
+way, with no instance-specific code.
+
+Because an instance *is* a schedule, the existing pause/resume controls apply
+to it (`cloacinactl trigger pause sync_file`).
+
+See [Workflow Instances](../../../../docs/content/engine/scheduling/workflow-instances.md)
+for the full model.

--- a/examples/fixtures/instance-params-rust/Cargo.toml
+++ b/examples/fixtures/instance-params-rust/Cargo.toml
@@ -1,0 +1,31 @@
+# TEMPLATE — `__WORKSPACE__` is rewritten to an absolute path by
+# .angreal/cloacina/compiler_e2e.py before packing.
+[workspace]
+
+[package]
+name = "instance-params-rust"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+default = ["packaged"]
+packaged = []
+
+[dependencies]
+cloacina-macros = { path = "__WORKSPACE__/crates/cloacina-macros" }
+cloacina-computation-graph = { path = "__WORKSPACE__/crates/cloacina-computation-graph" }
+cloacina-workflow = { path = "__WORKSPACE__/crates/cloacina-workflow", features = ["packaged"] }
+cloacina-workflow-plugin = { path = "__WORKSPACE__/crates/cloacina-workflow-plugin" }
+serde_json = "1.0"
+futures = "0.3"
+async-trait = "0.1"
+tracing = "0.1"
+chrono = { version = "0.4", features = ["serde"] }
+uuid = { version = "1.0", features = ["v4"] }
+tokio = { version = "1.0", features = ["time"] }
+
+[build-dependencies]
+cloacina-build = { path = "__WORKSPACE__/crates/cloacina-build" }

--- a/examples/fixtures/instance-params-rust/build.rs
+++ b/examples/fixtures/instance-params-rust/build.rs
@@ -1,0 +1,19 @@
+/*
+ *  Copyright 2026 Colliery Software
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+fn main() {
+    cloacina_build::configure();
+}

--- a/examples/fixtures/instance-params-rust/package.toml
+++ b/examples/fixtures/instance-params-rust/package.toml
@@ -1,0 +1,14 @@
+# Fixture for the named-workflow-instance e2e lane (CLOACI-T-0927). Declares a
+# REQUIRED param (`region`) plus a defaulted one (`batch_size`) so the harness
+# can prove both create-time validation and fire-time param delivery.
+[package]
+name = "instance-params-rust"
+version = "0.1.0"
+interface = "cloacina-workflow-plugin"
+interface_version = 1
+extension = "cloacina"
+
+[metadata]
+workflow_name = "instance_params_workflow"
+language = "rust"
+description = "named-instance e2e fixture — required + defaulted params"

--- a/examples/fixtures/instance-params-rust/src/lib.rs
+++ b/examples/fixtures/instance-params-rust/src/lib.rs
@@ -1,0 +1,69 @@
+/*
+ *  Copyright 2026 Colliery Software
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+// Fixture for the named-workflow-instance e2e lane (CLOACI-T-0927).
+//
+// Declares one REQUIRED param (`region`, no default) and one DEFAULTED param
+// (`batch_size`). The required one is what makes create-time validation
+// observable: creating an instance without it must be rejected by the server.
+//
+// The task echoes both params back into the context under distinct keys. The
+// bound params themselves already arrive as top-level context keys via the
+// fire-time merge, but echoing them proves the TASK actually saw the bound
+// values rather than the harness merely reading back what it wrote.
+
+use cloacina_workflow::{task, workflow, Context, TaskError};
+
+cloacina_workflow_plugin::package!();
+
+#[workflow(
+    name = "instance_params_workflow",
+    description = "named-instance e2e fixture — required + defaulted params",
+    author = "instance-e2e",
+    params(
+        region: String,
+        batch_size: u32 = 100,
+    )
+)]
+pub mod instance_params_workflow {
+    use super::*;
+
+    #[task(retry_attempts = 0)]
+    pub async fn echo_params(context: &mut Context<serde_json::Value>) -> Result<(), TaskError> {
+        // Read the params as the workflow author would — off the context, where
+        // the fire-time merge put them.
+        let region = context
+            .get("region")
+            .and_then(|v| v.as_str().map(|s| s.to_string()))
+            .ok_or_else(|| TaskError::ExecutionFailed {
+                message: "required param 'region' missing from context".to_string(),
+                task_id: "echo_params".to_string(),
+                timestamp: chrono::Utc::now(),
+            })?;
+        let batch_size = context
+            .get("batch_size")
+            .and_then(|v| v.as_u64())
+            .ok_or_else(|| TaskError::ExecutionFailed {
+                message: "param 'batch_size' missing from context".to_string(),
+                task_id: "echo_params".to_string(),
+                timestamp: chrono::Utc::now(),
+            })?;
+
+        context.insert("observed_region", serde_json::json!(region))?;
+        context.insert("observed_batch_size", serde_json::json!(batch_size))?;
+        Ok(())
+    }
+}

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloacina/ui",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloacina/ui",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@cloacina/client": "file:../clients/typescript",
@@ -49,7 +49,7 @@
     },
     "../clients/typescript": {
       "name": "@cloacina/client",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "Apache-2.0",
       "dependencies": {
         "openapi-fetch": "0.13.5"

--- a/ui/src/api/hooks.ts
+++ b/ui/src/api/hooks.ts
@@ -46,6 +46,8 @@ export const queryKeys = {
   executionTasks: (tenant: string, id: string) => ["executions", tenant, id, "tasks"] as const,
   triggers: (tenant: string) => ["triggers", tenant] as const,
   trigger: (tenant: string, name: string) => ["triggers", tenant, name] as const,
+  instances: (tenant: string, workflow: string) =>
+    ["workflows", tenant, workflow, "instances"] as const,
   keys: (tenant: string) => ["keys", tenant] as const,
   accumulators: (tenant: string) => ["accumulators", tenant] as const,
   reactors: (tenant: string) => ["reactors", tenant] as const,

--- a/ui/src/api/instances.ts
+++ b/ui/src/api/instances.ts
@@ -1,0 +1,37 @@
+/*
+ *  Copyright 2025-2026 Colliery Software
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { useQuery } from "@tanstack/react-query";
+
+import { useClient, useTenant } from "../auth/AuthContext";
+import { queryKeys } from "./hooks";
+
+/**
+ * Named, param-bound instances of a workflow (CLOACI-T-0894 / T-0927).
+ *
+ * Read-only for now: creating an instance means rendering a form driven by the
+ * workflow's declared `params(...)` slots, which is its own piece of design.
+ * The CLI (`cloacinactl instance create`) is the create path today.
+ */
+export function useWorkflowInstances(workflow: string) {
+  const client = useClient();
+  const tenant = useTenant();
+  return useQuery({
+    queryKey: queryKeys.instances(tenant, workflow),
+    queryFn: () => client.listInstances(workflow),
+    enabled: Boolean(workflow),
+  });
+}

--- a/ui/src/routes/WorkflowDetail.tsx
+++ b/ui/src/routes/WorkflowDetail.tsx
@@ -21,6 +21,7 @@ import { useMemo, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 
 import { useDeleteWorkflow, useWorkflow } from "../api/workflows";
+import { useWorkflowInstances } from "../api/instances";
 import { usePauseWorkflow } from "../api/controls";
 import { useCan } from "../auth/AuthContext";
 import { useWorkflowTaskRuntimes } from "../api/executions";
@@ -59,6 +60,9 @@ export function WorkflowDetail() {
 
   const RUNS = 40;
   const runtimes = useWorkflowTaskRuntimes(data?.workflow_name ?? "", { runs: RUNS });
+  // Named instances are keyed by the executable workflow name, not the package
+  // name — same key `workflow run` uses (CLOACI-T-0927).
+  const instances = useWorkflowInstances(data?.workflow_name ?? "");
   const rank = data?.task_graph ? topoRank(data.task_graph) : undefined;
   const stats = useMemo(
     () =>
@@ -191,6 +195,44 @@ export function WorkflowDetail() {
               <List.Item key={t}>{t}</List.Item>
             ))}
           </List>
+        )}
+      </Panel>
+
+      {/* Named instances (CLOACI-T-0927) — read-only. Creating one means a
+          form driven by the declared param slots; the CLI owns create today. */}
+      <Panel
+        title="Named instances"
+        caption="persistent param bindings, optionally scheduled"
+      >
+        {instances.isPending ? (
+          <Loading label="Loading instances…" />
+        ) : instances.isError ? (
+          <Text size="sm" c="dimmed">
+            Couldn't load instances.
+          </Text>
+        ) : (instances.data?.items ?? []).length === 0 ? (
+          <Empty message="No named instances. Create one with `cloacinactl instance create`." />
+        ) : (
+          <Stack gap={6}>
+            {(instances.data?.items ?? []).map((i) => (
+              <Group key={i.id} gap="sm" wrap="nowrap" align="baseline">
+                <Text size="sm" ff={MONO} style={{ minWidth: 160 }}>
+                  {i.instance_name}
+                </Text>
+                <Pill color={i.cron_expression ? TOKEN.teal : TOKEN.muted}>
+                  {i.cron_expression ?? "unscheduled"}
+                </Pill>
+                {i.paused ? <Pill color={TOKEN.gold}>⏸ paused</Pill> : null}
+                {!i.enabled ? <Pill color={TOKEN.muted}>disabled</Pill> : null}
+                <Text size="xs" c="dimmed" ff={MONO} style={{ flex: 1 }}>
+                  {i.params ? JSON.stringify(i.params) : "—"}
+                </Text>
+                <Text size="xs" c="dimmed">
+                  {i.next_run_at ? `next ${formatTimestamp(i.next_run_at)}` : ""}
+                </Text>
+              </Group>
+            ))}
+          </Stack>
         )}
       </Panel>
 


### PR DESCRIPTION
## Summary

T-0894 shipped the named-workflow-instance surface with only unit-level proof, and I closed it with its live-stack acceptance criterion **explicitly unmet**. This adds that proof — and it immediately found **two defects every existing gate waved through**.

## Bug 1 — the routes were merged unreachable

T-0894's four instance routes were never added to the server's authz route table. That middleware is **fail-closed**, so create/list/get/delete all returned `route not authorized` regardless of the key's role.

**All 80 CI checks passed on #247.** Unit tests, OpenAPI drift, SDK coverage and version lockstep are perfectly happy with routes no client can call — none of them exercise a running server.

Fixed the routes (GET → tenant-Read, POST/DELETE → tenant-Write) *and the hole that allowed it*: the existing `authz_table_classifies_known_routes` only pins the table's **size**, so it can't see the router — a route added in `lib.rs` with no table entry leaves the count untouched and sails past. New `every_documented_v1_route_is_classified` walks the OpenAPI document (generated from the handlers' own `#[utoipa::path]` — the only faithful stand-in, since axum exposes no route enumeration) and asserts every `/v1` path+method is classified. It also flagged `POST /auth/local/login`, verified as a **legitimate** exemption: `lib.rs` deliberately mounts the public auth entry points outside `require_auth`/`authz_mw` because they mint the key.

## Bug 2 — a created instance never fired

The row was perfect (enabled, unpaused, cron set, `next_run_at` ~2s out) and nothing happened. The server log gave it away: over ~166s the scheduler logged `Checking trigger schedules` **167 times** and the cron branch **zero** times.

- **Mine:** these routes write the row through the DAL directly and never called `cron_change.notify_one()` — only the embedded `cron_api.rs` does. Added `DefaultRunner::notify_cron_change()`, called after create and delete.
- **Pre-existing → [CLOACI-T-0928]:** the cron backstop *can never elapse*. `cron_sleep` is rebuilt every loop iteration while the 1s trigger tick always preempts it, so a 30s sleep never accumulates; the cron branch is reachable only when the delay is already zero. A process starting with no cron schedules has `next_cron_due = None`, is starved, and **cron scheduling is effectively dead** until some notification arrives. Contradicts T-0743's design — `cron_api.rs`'s own comment says a notify fires "on time instead of waiting for the backstop". Left to its own ticket: wider blast radius than this change.

## The lane

Added to `angreal test e2e compiler` (already owns the server+compiler+postgres lifecycle):

```
ok: missing required param rejected at create time
ok: instance created
ok: instance listed (and the rejected one was never stored)
instance fired: execution b98c2cf6-7f8d-44c7-b38e-e72c2260edd9
ok: instance fire delivered bound params to the task (region=eu-west, batch_size=7)
ok: instance execution Completed
ok: instance deleted
```

**Test-design note:** the lane asserts both that the bad create *fails* **and** that the rejection **names the missing param**. Asserting only failure would have passed here for entirely the wrong reason — the authz denial — and bug 1 would still be in main.

New fixture `instance-params-rust`: one **required** param (so create-time validation is observable) plus a defaulted one. Its task echoes both to `observed_*` keys — bound params already arrive as top-level context keys, so echoing proves the *task* saw them rather than the harness reading back what it wrote.

## Docs + UI
- The parameterized-workflow README said a server-side surface "is tracked separately" — now false, rewritten with real CLI recipes
- `workflow-instances.md` had only embedded Rust/Python; gained a Server section (CLI, REST table, SDK names, tenant scoping)
- Read-only **Named instances** panel on `WorkflowDetail`. Create/delete from the UI is deliberately excluded — it needs a form driven by the declared param slots, which is its own design

## Verification
Full e2e lane **exit 0** (existing upgrade/rollback/concurrent lanes still pass), 9 authz tests, `cargo check --workspace`, `cargo fmt --check`, docs spec-check in sync, SDK coverage 59 ops × 3 SDKs, UI typecheck. The 2 failing UI tests are pre-existing (`ResizeObserver` in jsdom) — proven by stashing and reproducing on the unmodified tree.