### PR TITLE
fix(T-0899): pin the Python SDK generator in CI; close the strip_py_comments tail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,6 +224,17 @@ jobs:
           npm run typecheck
           npm run build
 
+      # Python generated-client drift. The TS client has had a drift gate since
+      # T-0645; the Python client's generator version lived only in a README
+      # sentence with nothing enforcing it, and the committed tree silently fell
+      # behind the documented pin (~100 files, plus an undeclared
+      # typing_extensions dependency). Same guard, both languages.
+      - name: Install uv (pinned Python SDK generator)
+        uses: astral-sh/setup-uv@v5
+
+      - name: Python generated-client drift check
+        run: python3 scripts/check_python_sdk_generated.py
+
   # UI ship-readiness gate (CLOACI-I-0117 / T-0661) — the cheap, Node-only PR
   # checks: version lockstep, generated-types drift, and the UI typechecks +
   # builds against the SDK. The full Playwright acceptance lane (Docker + Rust

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -57,6 +57,16 @@ uvx openapi-python-client@0.29.0 generate \
   --output-path src/cloacina_client/_generated --overwrite
 ```
 
+The pin is **enforced**, not just documented: `scripts/check_python_sdk_generated.py`
+regenerates into a temp directory and fails CI if the committed tree differs.
+Change the version in that script and in the recipe above together — they are
+the same pin, and the script is the half that CI reads.
+
+This gate exists because the two drifted apart once already: the committed
+output had been produced by a different generator build than this README named,
+and regenerating with the documented version rewrote ~100 files and introduced
+an import (`typing_extensions`) that was not a declared dependency.
+
 ## Contract tests
 
 `tests/test_contract.py` exercises every documented endpoint plus the WebSocket lifecycle against a live server:

--- a/crates/cloacina-compiler/src/param_parse.rs
+++ b/crates/cloacina-compiler/src/param_parse.rs
@@ -566,6 +566,80 @@ mod tests {
         out
     }
 
+    /// CLOACI-T-0899 hardening tail. The scanners are string-split heuristics,
+    /// not a Python tokenizer, so `strip_py_comments` is the single guard
+    /// standing between an author's ordinary habits (inline comments,
+    /// documenting a decorator) and a corrupted declaration. These pin the
+    /// edges the original fix reasoned about but never asserted.
+    mod strip_comments {
+        use super::*;
+
+        /// A `#` INSIDE a string is data, not a comment — stripping it would
+        /// silently rewrite a default value.
+        #[test]
+        fn hash_inside_a_string_is_preserved() {
+            let out = strip_py_comments(r#"x = "a#b"  # trailing"#);
+            assert!(out.contains(r#""a#b""#), "hash in string lost: {out}");
+            assert!(!out.contains("trailing"), "comment not stripped: {out}");
+        }
+
+        /// The docstring case that caused the live failure: decorator syntax
+        /// quoted as example text must be invisible to the scanner.
+        #[test]
+        fn triple_quoted_interior_is_blanked() {
+            let src =
+                "def f():\n    \"\"\"Example: @cloaca.workflow_params(name)\"\"\"\n    pass\n";
+            let out = strip_py_comments(src);
+            assert!(
+                !out.contains("workflow_params"),
+                "docstring interior not blanked: {out}"
+            );
+            // Delimiters and line structure survive so later line-based
+            // scanning stays aligned with the original source.
+            assert_eq!(
+                out.lines().count(),
+                src.lines().count(),
+                "line count changed: {out}"
+            );
+            assert!(out.contains("\"\"\""), "delimiters lost: {out}");
+        }
+
+        /// An escaped quote must not be read as closing the string, or
+        /// everything after it flips to "outside string" and comment-stripping
+        /// eats real code.
+        #[test]
+        fn escaped_quote_does_not_end_the_string() {
+            let out = strip_py_comments(r##"x = "a\"# not a comment"  # yes a comment"##);
+            assert!(
+                out.contains("# not a comment"),
+                "escaped quote ended the string early: {out}"
+            );
+            assert!(!out.contains("yes a comment"), "real comment kept: {out}");
+        }
+
+        /// The needle inside a single-quoted string is data too — same class as
+        /// the docstring bug, one quote style down.
+        #[test]
+        fn needle_in_a_single_quoted_string_is_not_a_declaration() {
+            let src = "note = '@cloaca.workflow_params(ghost)'\n";
+            let out = strip_py_comments(src);
+            // Single/double-quoted contents are PRESERVED verbatim (they carry
+            // real default values), so the guard here is the scanner's, not the
+            // stripper's — assert the stripper at least leaves it intact and
+            // does not blank a value-bearing string.
+            assert!(out.contains("ghost"), "value-bearing string blanked: {out}");
+        }
+
+        /// Regression for the pair the original bug report named: an inline
+        /// comment after a param must not become part of the declaration.
+        #[test]
+        fn inline_comment_after_a_param_is_stripped() {
+            let out = strip_py_comments("source=str,  # required\n    dst=str,\n");
+            assert!(!out.contains("required"), "comment survived: {out}");
+            assert!(out.contains("dst=str"), "following line lost: {out}");
+        }
+    }
+
     #[test]
     fn boundary_schema_builds_accumulator_surface() {
         let src = r#"

--- a/scripts/check_python_sdk_generated.py
+++ b/scripts/check_python_sdk_generated.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Python-SDK generated-code drift gate (CLOACI-T-0899 follow-on / SDK pin).
+
+The TypeScript client has had `npm run check:generated` in CI since T-0645, so
+its committed types cannot drift from the spec. The Python client had no
+equivalent: its generator version lived only in a README sentence, nothing
+enforced it, and the committed output silently fell behind.
+
+That is not hypothetical. Regenerating with the version the README already
+specified rewrote ~100 committed model files (`from_dict(cls: type[T]) -> T`
+becoming `-> Self`, plus a `typing_extensions` import that was not even a
+declared dependency). The committed tree had been produced by a different
+generator build than the documented pin, and nothing noticed.
+
+This script closes that hole the same way spec-check does: regenerate into a
+temp dir with the PINNED generator and diff against what is committed.
+
+Run:  python3 scripts/check_python_sdk_generated.py
+"""
+
+from __future__ import annotations
+
+import filecmp
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+CLIENT = ROOT / "clients" / "python"
+GENERATED = CLIENT / "src" / "cloacina_client" / "_generated"
+SPEC = ROOT / "docs" / "static" / "openapi.json"
+CONFIG = CLIENT / "generator-config.yaml"
+
+# THE pin. Keep this in lockstep with clients/python/README.md's regeneration
+# recipe — the README is documentation, this is the enforcement.
+GENERATOR = "openapi-python-client@0.29.0"
+
+# Artifacts the generator's own tooling drops next to the output (it shells out
+# to ruff to format). They are never committed and are not part of the
+# contract, so comparing them would make this gate fail on every clean tree.
+IGNORED = {".ruff_cache", "__pycache__", ".mypy_cache", ".pytest_cache"}
+
+
+def _fail(msg: str) -> int:
+    print(f"PYTHON SDK DRIFT — {msg}", file=sys.stderr)
+    print(
+        "\nRegenerate with the pinned generator and commit the result:\n"
+        f"  cd clients/python && uvx {GENERATOR} generate \\\n"
+        "    --path ../../docs/static/openapi.json \\\n"
+        "    --config generator-config.yaml --meta none \\\n"
+        "    --output-path src/cloacina_client/_generated --overwrite",
+        file=sys.stderr,
+    )
+    return 1
+
+
+def _diff_trees(a: Path, b: Path, rel: Path = Path(".")) -> list[str]:
+    """Recursively compare two trees, returning human-readable differences.
+
+    `filecmp.dircmp` is not used directly because its `left_only`/`right_only`
+    reporting is shallow-by-default and we want exact per-file content
+    comparison across the whole tree.
+    """
+    out: list[str] = []
+    cmp = filecmp.dircmp(a, b, ignore=sorted(IGNORED))
+    for name in sorted(cmp.left_only):
+        out.append(f"  only in committed: {rel / name}")
+    for name in sorted(cmp.right_only):
+        out.append(f"  only in freshly generated: {rel / name}")
+    # shallow=False forces content comparison, not just stat.
+    _, mismatch, errors = filecmp.cmpfiles(
+        a, b, cmp.common_files, shallow=False
+    )
+    for name in sorted(mismatch):
+        out.append(f"  content differs: {rel / name}")
+    for name in sorted(errors):
+        out.append(f"  could not compare: {rel / name}")
+    for name in sorted(cmp.common_dirs):
+        out.extend(_diff_trees(a / name, b / name, rel / name))
+    return out
+
+
+def main() -> int:
+    if not GENERATED.is_dir():
+        return _fail(f"{GENERATED} does not exist")
+    if not SPEC.is_file():
+        return _fail(f"{SPEC} does not exist — emit the OpenAPI spec first")
+
+    if shutil.which("uvx") is None:
+        # Do not silently pass when the gate cannot run: a skipped check that
+        # reports success is how the drift survived in the first place.
+        print(
+            "uvx not found — cannot run the pinned generator. Install uv, or "
+            "skip this check explicitly.",
+            file=sys.stderr,
+        )
+        return 2
+
+    with tempfile.TemporaryDirectory(prefix="cloacina-pysdk-") as tmp:
+        target = Path(tmp) / "_generated"
+        proc = subprocess.run(
+            [
+                "uvx", GENERATOR, "generate",
+                "--path", str(SPEC),
+                "--config", str(CONFIG),
+                "--meta", "none",
+                "--output-path", str(target),
+                "--overwrite",
+            ],
+            cwd=CLIENT,
+            capture_output=True,
+            text=True,
+        )
+        if proc.returncode != 0:
+            print(proc.stdout, file=sys.stderr)
+            print(proc.stderr, file=sys.stderr)
+            return _fail(f"generator exited {proc.returncode}")
+
+        differences = _diff_trees(GENERATED, target)
+        if differences:
+            print(
+                "PYTHON SDK DRIFT — the committed _generated/ tree does not "
+                f"match a fresh run of {GENERATOR}:\n",
+                file=sys.stderr,
+            )
+            for line in differences[:40]:
+                print(line, file=sys.stderr)
+            if len(differences) > 40:
+                print(
+                    f"  … and {len(differences) - 40} more", file=sys.stderr
+                )
+            return _fail("committed output is stale")
+
+    print(f"Python SDK generated code matches {GENERATOR}.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Two backlog tails found during a stale-ticket audit.

## T-0899 tail — hardening tests for `strip_py_comments`

The Python source scanners are string-split heuristics, not a tokenizer, so `strip_py_comments` is the only thing between an author's ordinary habits and a corrupted declaration. The core bug was fixed long ago, but the ticket's own *"remaining hardening"* tail was never done.

Five tests added — they **pin correct behavior rather than fix anything** (all passed on first run):
- a `#` inside a string is preserved (stripping it would rewrite a default value)
- a triple-quoted docstring's interior is blanked, with delimiters and line count preserved so later line-based scanning stays aligned. This is the case that caused the live failure — a docstring showing `@cloaca.workflow_secrets("name")` was parsed as a real required secret
- an escaped quote doesn't end the string early (if it did, everything after flips to "outside string" and comment-stripping eats real code)
- a needle inside a *single*-quoted string stays intact — those carry real default values and must **not** be blanked
- an inline comment after a param is stripped and the following line survives

## SDK generator pin — enforced, not just documented

The TypeScript client has had a generated-drift gate in CI since T-0645. The Python client had **none**: its generator version lived only in a README sentence with nothing enforcing it.

That's not hypothetical. Regenerating with the version the README *already named* rewrote ~100 committed model files (`from_dict(cls: type[T]) -> T` → `-> Self`) and pulled in `typing_extensions`, which wasn't even a declared dependency. The committed tree had been produced by a different generator build than the documented pin, and nothing noticed.

New `scripts/check_python_sdk_generated.py` closes it the same way `angreal docs spec-check` does for the OpenAPI spec: regenerate with the **pinned** generator into a temp dir, diff against what's committed. Wired into the same CI job as the TS check so both languages are guarded identically.

**Verified both directions** — it passes on the current tree (confirming #247's regeneration genuinely aligned it with the pin), and it *fails naming the exact file* when drift is injected. Generator run artifacts (`.ruff_cache` and friends) are ignored or it would fail on every clean tree. It exits 2 rather than passing when `uvx` is absent: a skipped check that reports success is how the drift survived in the first place.

## Test plan
- 5 new tests pass; full `param_parse` suite 14/14
- Drift gate verified passing on a clean tree and failing on injected drift
- `py_compile` clean, CI YAML parses

## Note on the ticket audit
Four backlog tickets looked closeable. Two genuinely were (**T-0887**, **T-0910** — now closed with evidence). This PR clears T-0899's tail. **T-0897's tail is a design question, not a fix** — see the PR discussion; its `take_task_handle` emission can't route through a "packaged-safe re-export" because `task_handle.rs` depends on the DAL, `UniversalUuid` and `ExecutorError`, none of which a packaged cdylib links. That ticket stays open.