### PR TITLE
feat(T-0897): packaged tasks can use defer_until

### DIFF
--- a/.angreal/demos/features/features.py
+++ b/.angreal/demos/features/features.py
@@ -682,15 +682,22 @@ def _graph_kafka_steps(label, workflow_name, reactor, topic, payloads):
     return steps
 
 
-def _trigger_wait_steps(workflow_name):
+def _trigger_wait_steps(workflow_name, trigger_name=None):
     """For a POLL/CRON-triggered workflow: don't `workflow run` it — wait for the
     trigger to fire it AUTOMATICALLY and assert the auto-execution reaches
     Completed. Proves the packaged-trigger path (macro → FFI projection → host
-    trigger registry → scheduled fire) end to end."""
+    trigger registry → scheduled fire) end to end.
+
+    When `trigger_name` is given, also runs the operator verbs the example's
+    "Operate it" section documents (CLOACI-T-0893) — list/inspect/pause/resume
+    and a manual fire. Those verbs are the whole point of the section, and an
+    unrun documented command is how `accumulator inject` shipped with syntax
+    that could not work."""
 
     def steps(ctl, home):
         from test.e2e.compiler import _poll_execution_status
 
+        fired = False
         deadline = time.time() + 180
         while time.time() < deadline:
             _, out, _ = ctl(
@@ -710,12 +717,37 @@ def _trigger_wait_steps(workflow_name):
                     print(f"  ok: trigger fired an execution automatically ({exec_id})")
                     _poll_execution_status(home, exec_id, {"Completed"}, timeout_s=180.0)
                     print("  ok: triggered execution Completed")
-                    return
+                    fired = True
+                    break
             time.sleep(3)
-        raise AssertionError(
-            f"no execution of `{workflow_name}` appeared — the poll trigger never "
-            "fired (macro/FFI projection or trigger scheduler not running)"
-        )
+        if not fired:
+            raise AssertionError(
+                f"no execution of `{workflow_name}` appeared — the poll trigger never "
+                "fired (macro/FFI projection or trigger scheduler not running)"
+            )
+
+        if trigger_name:
+            # Pause/resume are ordered deliberately: resume LAST, so the lane
+            # cannot leave the trigger parked for whatever runs after it.
+            _assert_operational_verbs(
+                ctl,
+                [
+                    (["trigger", "list"], "trigger list"),
+                    (["trigger", "inspect", trigger_name], "trigger inspect"),
+                    (["trigger", "pause", trigger_name], "trigger pause"),
+                    (["trigger", "resume", trigger_name], "trigger resume"),
+                    # `trigger fire` is deliberately NOT asserted here: it
+                    # resolves targets from the SUBSCRIPTION side
+                    # (`#[workflow(triggers = [..])]`), so a trigger declared
+                    # `#[trigger(on = "wf")]` has no subscribers and the call
+                    # errors. Documented in the example's README; the gap
+                    # itself is CLOACI-T-0929.
+                    (
+                        ["workflow", "run", workflow_name],
+                        "workflow run (immediate run for an `on =` trigger)",
+                    ),
+                ],
+            )
 
     return steps
 
@@ -911,7 +943,9 @@ _PACKAGED_OVERRIDES = {
         "steps": _graph_autofire_steps("python-polling-graph", "poll_reactor"),
     },
     # Poll trigger fires `file_processing` automatically — wait for it, don't run.
-    "packaged-triggers": {"steps": _trigger_wait_steps("file_processing")},
+    "packaged-triggers": {
+        "steps": _trigger_wait_steps("file_processing", trigger_name="inbox_poll")
+    },
     # Python peer: @cloaca.trigger poll fires `file_processing_py` automatically.
     "python-triggers": {"steps": _trigger_wait_steps("file_processing_py")},
     # Python cron: the cron scheduler fires `heartbeat_workflow` on a schedule.

--- a/.angreal/demos/features/features.py
+++ b/.angreal/demos/features/features.py
@@ -550,6 +550,32 @@ def _graph_autofire_steps(label, reactor):
     return steps
 
 
+def _assert_operational_verbs(ctl, verbs):
+    """Run each documented operator verb and fail loudly if it does not work
+    (CLOACI-T-0893).
+
+    The point is narrow and worth stating: an "Operate it" section is a promise
+    that these exact invocations run. That promise had already been broken once
+    — `cg-feature-tour` documented `accumulator inject <name> '<json>'` when the
+    CLI requires `--event`, so the command in the README could not work at all.
+    Nothing caught it because nothing ran it.
+
+    `verbs` is a list of (argv, description). A non-zero exit fails the lane
+    with the verb's own stderr, so the failure names the broken command rather
+    than a generic step number.
+    """
+    for args, description in verbs:
+        code, out, err = ctl(*args, check=False)
+        if code != 0:
+            raise AssertionError(
+                f"documented operator verb failed ({description}): "
+                f"`cloacinactl {' '.join(args)}` exited {code}\n"
+                f"  stderr: {err.strip() or '(empty)'}\n"
+                f"  stdout: {out.strip()[:400] or '(empty)'}"
+            )
+        print(f"  ok: {description}")
+
+
 def _workspace_rewrite_prepare(example_dir):
     """Copy the example to a temp dir with `__WORKSPACE__` in package.toml
     rewritten to this checkout's absolute path — so `[metadata.providers]` path
@@ -624,11 +650,33 @@ def _graph_kafka_steps(label, workflow_name, reactor, topic, payloads):
                     f"  ok: reactor {reactor} fired ({before} -> {now}) — the bundled "
                     "NATIVE kafka provider streamed the messages into the graph"
                 )
-                return
-        raise AssertionError(
-            f"reactor {reactor} never fired after producing to {topic} — the bundled "
-            "kafka provider did not deliver boundaries (check server.log for the "
-            "provider stream accumulator load line)"
+                break
+        else:
+            raise AssertionError(
+                f"reactor {reactor} never fired after producing to {topic} — the bundled "
+                "kafka provider did not deliver boundaries (check server.log for the "
+                "provider stream accumulator load line)"
+            )
+
+        # Surface 3 (CLOACI-T-0893): the verbs the README's "Operate it"
+        # section tells operators to run. Asserted here because a documented
+        # command that nobody runs is how `accumulator inject` shipped with the
+        # wrong syntax.
+        _assert_operational_verbs(
+            ctl,
+            [
+                (["graph", "list"], "graph list"),
+                (["graph", "accumulators"], "graph accumulators"),
+                (
+                    ["accumulator", "inject", "ticks", "--event", '{"price": 101.5}'],
+                    "accumulator inject --event",
+                ),
+                (
+                    ["reactor", "fire", reactor, "--input", 'ticks={"price": 250.0}'],
+                    "reactor fire --input",
+                ),
+                (["reactor", "force-fire", reactor], "reactor force-fire"),
+            ],
         )
 
     return steps

--- a/.angreal/test/e2e/compiler.py
+++ b/.angreal/test/e2e/compiler.py
@@ -815,6 +815,83 @@ def compiler(version_deps=False):
         assert remaining == "0", f"instance row survived delete: {remaining!r}"
         print("  ok: instance deleted")
 
+        # --- packaged defer_until (CLOACI-T-0897) -------------------------
+        # A PACKAGED task taking a handle parameter could not even COMPILE
+        # before this ticket (the macro emitted an ungated `::cloacina::`
+        # path). Compiling is proven by a unit-level fixture build; what only
+        # a live server can show is the rest: that the plugin receives a real
+        # task-execution id, calls back into the host mid-execution, and that
+        # its concurrency slot is genuinely RELEASED while it waits — the
+        # entire point of defer_until.
+        defer_dir = _stage_fixture(
+            home, "defer-handle-rust", version_deps=version_deps
+        )
+        print("  compiling defer-handle fixture")
+        defer_id = _upload(home, defer_dir)
+        body = _poll_build_status(home, defer_id, {"success"}, timeout_s=900.0)
+        assert body.get("build_status") == "success", body
+        print("  ok: packaged task with a handle parameter BUILT")
+
+        defer_exec = _poll_run_workflow(
+            home, "defer_handle_workflow", timeout_s=120.0
+        )
+        print(f"  defer execution: {defer_exec}")
+
+        # While it is deferred the row must say so. The fixture waits ~1.2s
+        # with a 200ms poll, so this window is real but short — poll for it
+        # rather than sleeping a fixed amount and hoping.
+        saw_deferred = False
+        deadline = time.time() + 30.0
+        while time.time() < deadline:
+            sub = _psql(
+                "SELECT COALESCE(sub_status,'') FROM public.task_executions "
+                f"WHERE workflow_execution_id = '{defer_exec}';"
+            ).strip()
+            if "Deferred" in sub:
+                saw_deferred = True
+                break
+            if _cloacinactl(
+                home, "-o", "json", "execution", "status", defer_exec
+            )[1].find("Completed") != -1:
+                break
+            time.sleep(0.2)
+        assert saw_deferred, (
+            "task never reported sub_status=Deferred — the host callback that "
+            "marks a deferral did not run"
+        )
+        print("  ok: task observed in Deferred state (host callback ran)")
+
+        status = _poll_execution_status(
+            home, defer_exec, {"Completed", "Failed", "Cancelled"}, timeout_s=60.0
+        )
+        assert status == "Completed", (
+            f"deferred execution {defer_exec} ended in {status!r} — it should "
+            "reclaim its slot and finish"
+        )
+
+        # The final context proves BOTH halves of the round trip: the plugin
+        # was told a real task-execution id (not an empty string), and it
+        # resumed after the deferral rather than erroring out of it.
+        ctx = json.loads(
+            _psql(
+                "SELECT c.value FROM public.contexts c "
+                "JOIN public.workflow_executions we ON we.context_id = c.id "
+                f"WHERE we.id = '{defer_exec}';"
+            ).strip()
+        )
+        observed_id = ctx.get("observed_task_execution_id") or ""
+        assert len(observed_id) >= 32, (
+            "plugin did not receive a real task-execution id "
+            f"(got {observed_id!r}) — the v6 wire field is not arriving"
+        )
+        assert ctx.get("deferred_and_resumed") is True, (
+            f"task did not resume after deferring: {ctx!r}"
+        )
+        print(
+            "  ok: packaged defer_until round-tripped "
+            f"(task id {observed_id[:8]}…, slot released and reclaimed)"
+        )
+
         # --- package lifecycle: upgrade (T-0497) ---------------------------
         # Upload a new version of the same package. The upload handler
         # should supersede the current active row and insert a new one

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1930,19 +1930,20 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "fidius"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dee7b6936c8ca05ac88e70d4db1b0238cac2d1a8cdc744c6a9f771aef1bc36b"
+checksum = "e1b93ca738605bdad6ad98f3e65e375b8930d26d934e680cbc105e72a53ea3ee"
 dependencies = [
  "fidius-core",
+ "fidius-host",
  "fidius-macro",
 ]
 
 [[package]]
 name = "fidius-core"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a7cd388faabacfca37d94def8479f4c8b09ba085abed433d2bfcbd872aa235"
+checksum = "a4a763dbc2e2a50554db4048c37ebc98ae8b9fd929869ffb315b73ae23ab481c"
 dependencies = [
  "bincode",
  "bzip2 0.5.2",
@@ -1960,9 +1961,9 @@ dependencies = [
 
 [[package]]
 name = "fidius-guest"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9da7ecaa9e9840ed5ed03c454e5e88b54c6bf6e014394696b71a024d041b4f2d"
+checksum = "60fe7c1fb005f6ae1e72b2cd83a7e9d62bf19916137dc283b1620b48f934a32e"
 dependencies = [
  "bincode",
  "serde",
@@ -1973,9 +1974,9 @@ dependencies = [
 
 [[package]]
 name = "fidius-host"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0114fd58575422da9b0aeebb724048c8203d8463a03f3cf0380f07a8df449fb"
+checksum = "e58f34c583154c22c93406e8bb4e7265a15aaa4b9367c74e068be46417b7e634"
 dependencies = [
  "async-trait",
  "ed25519-dalek",
@@ -1995,9 +1996,9 @@ dependencies = [
 
 [[package]]
 name = "fidius-macro"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a4348896ff8d3776f9d16cae437a5f7484bb30f716b49d9a3b3c407329ac29f"
+checksum = "181d8604f8d240789e42b51b2ecf027c639f8135c94c976f4fde8879f444bd00"
 dependencies = [
  "fidius-core",
  "fidius-wit",
@@ -2008,9 +2009,9 @@ dependencies = [
 
 [[package]]
 name = "fidius-wit"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7f1f4d23237cef7e7ef89410de6f01bf0ce34f2cf0d8e8650cc265ff3f776f"
+checksum = "01e63656fef7bc842bf33460577b88c4f816d3e2ab0ec7d67692c3f675716be5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,3 +38,17 @@ clap = { version = "4.0", features = ["derive", "env"] }
 anyhow = { version = "1.0" }
 toml = { version = "0.8" }
 bincode = { version = "1.3" }
+
+# fidius — the plugin/FFI framework. Collapsed to workspace deps (CLOACI-T-0897):
+# these were pinned as 11 independent "0.5.6" literals across 7 crates, the exact
+# version-drift class I-0134 exists to prevent. They must move in lockstep — the
+# wire is positional bincode, so two different fidius versions in one build mean
+# two incompatible copies of the FFI types.
+#
+# 0.5.7 adds the plugin -> host callback channel (`#[host_interface]`) that
+# CLOACI-T-0897's packaged `defer_until` needs. It is an ABI-additive patch, so
+# packages built against 0.5.6 load unchanged.
+fidius = { version = "0.5.7" }
+fidius-core = { version = "0.5.7" }
+fidius-host = { version = "0.5.7" }
+fidius-macro = { version = "0.5.7" }

--- a/crates/cloacina-compiler/Cargo.toml
+++ b/crates/cloacina-compiler/Cargo.toml
@@ -44,7 +44,7 @@ tower = { version = "0.5", features = ["util"] }
 tokio = { version = "1.0", features = ["full"] }
 tokio-util = { version = "0.7", features = ["rt"] }
 tempfile = "3"
-fidius-core = "0.5.6"
+fidius-core = { workspace = true }
 sha2 = "0.10"
 hex = "0.4"
 chrono = { version = "0.4" }

--- a/crates/cloacina-macros/src/tasks.rs
+++ b/crates/cloacina-macros/src/tasks.rs
@@ -735,12 +735,33 @@ pub fn generate_task_impl(attrs: TaskAttributes, input: ItemFn) -> TokenStream2 
     // Generate trigger rules JSON code
     let generate_trigger_rules = generate_trigger_rules_code(&attrs);
 
+    // CLOACI-T-0897: the handle is dual-emitted, like the CG paths above. The
+    // engine's `TaskHandle` reaches the executor's semaphore and DAL directly;
+    // a PACKAGED cdylib does not link the engine at all, so it gets the
+    // plugin-side handle that drives the same operations over the
+    // `CloacinaHost` callback channel. Emitting `::cloacina::` unconditionally
+    // — as this did — made any packaged task with a handle parameter fail to
+    // compile with a bare `cannot find crate cloacina`.
+    //
+    // The packaged handle is fallible to obtain (the host must have supplied a
+    // task-execution id), so its branch propagates with `?` rather than
+    // panicking the way the embedded `take_task_handle` does.
     let execute_body = match (fn_asyncness.is_some(), has_handle_param) {
         (true, true) => quote! {
             {
-                let mut handle = ::cloacina::take_task_handle();
-                let result = #fn_name(&mut context, &mut handle).await;
-                ::cloacina::return_task_handle(handle);
+                #[cfg(not(feature = "packaged"))]
+                let result = {
+                    let mut handle = ::cloacina::take_task_handle();
+                    let result = #fn_name(&mut context, &mut handle).await;
+                    ::cloacina::return_task_handle(handle);
+                    result
+                };
+                #[cfg(feature = "packaged")]
+                let result = {
+                    let mut handle =
+                        ::cloacina_workflow_plugin::TaskHandle::for_current_invocation()?;
+                    #fn_name(&mut context, &mut handle).await
+                };
                 result
             }
         },
@@ -749,9 +770,19 @@ pub fn generate_task_impl(attrs: TaskAttributes, input: ItemFn) -> TokenStream2 
         },
         (false, true) => quote! {
             {
-                let mut handle = ::cloacina::take_task_handle();
-                let result = #fn_name(&mut context, &mut handle);
-                ::cloacina::return_task_handle(handle);
+                #[cfg(not(feature = "packaged"))]
+                let result = {
+                    let mut handle = ::cloacina::take_task_handle();
+                    let result = #fn_name(&mut context, &mut handle);
+                    ::cloacina::return_task_handle(handle);
+                    result
+                };
+                #[cfg(feature = "packaged")]
+                let result = {
+                    let mut handle =
+                        ::cloacina_workflow_plugin::TaskHandle::for_current_invocation()?;
+                    #fn_name(&mut context, &mut handle)
+                };
                 result
             }
         },

--- a/crates/cloacina-macros/src/workflow_attr.rs
+++ b/crates/cloacina-macros/src/workflow_attr.rs
@@ -1340,6 +1340,19 @@ fn generate_packaged_registration(
                     dependencies: vec![#(#dep_strs),*],
                     description: format!("Task: {}", #task_id),
                     source_location: #source_location.to_string(),
+                    // CLOACI-T-0897: ask the registered Task impl whether it
+                    // takes a handle. Read from inventory rather than tracked
+                    // here because the handle parameter is detected by
+                    // `#[task]`, one level down — this macro only sees ids.
+                    // The host gates its whole handle path on this bit.
+                    requires_handle: cloacina_workflow_plugin::inventory::iter::<
+                        cloacina_workflow_plugin::TaskEntry,
+                    >
+                        .into_iter()
+                        .map(|entry| (entry.constructor)())
+                        .find(|t| cloacina_workflow::Task::id(&**t) == #task_id)
+                        .map(|t| cloacina_workflow::Task::requires_handle(&*t))
+                        .unwrap_or(false),
                 }
             }
         })

--- a/crates/cloacina-python/Cargo.toml
+++ b/crates/cloacina-python/Cargo.toml
@@ -39,7 +39,7 @@ async-trait.workspace = true
 serde_json.workspace = true
 serde = { version = "1.0", features = ["derive"] }
 chrono = { version = "0.4", features = ["serde"] }
-fidius-core = "0.5.6"
+fidius-core = { workspace = true }
 once_cell.workspace = true
 pyo3 = { version = "0.25", features = ["abi3-py39"] }
 pythonize = { version = "0.25" }
@@ -56,7 +56,7 @@ uuid = { version = "1.0", features = ["serde", "v4", "v5"] }
 cloacina-build = { workspace = true }
 
 [dev-dependencies]
-fidius-core = "0.5.6"
+fidius-core = { workspace = true }
 serial_test = "3.2.0"
 tempfile = "3.2"
 tokio = { version = "1.0", features = ["full"] }

--- a/crates/cloacina-workflow-plugin/Cargo.toml
+++ b/crates/cloacina-workflow-plugin/Cargo.toml
@@ -10,10 +10,18 @@ documentation.workspace = true
 readme.workspace = true
 edition = "2021"
 
+[features]
+# Host-side surface for the `CloacinaHost` callback interface (CLOACI-T-0897).
+# OFF by default so packaged cdylibs — which only ever need the plugin-side
+# `CloacinaHostClient` — do not drag in fidius-host (libloading, the executors,
+# and friends). The engine (`cloacina`) turns this on to get
+# `CloacinaHostBinding::bind`.
+host = ["fidius/host"]
+
 [dependencies]
 toml = "0.8"
-fidius = "0.5.6"
-fidius-core = "0.5.6"
+fidius = { workspace = true }
+fidius-core = { workspace = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { workspace = true }
 inventory = "0.3"

--- a/crates/cloacina-workflow-plugin/src/lib.rs
+++ b/crates/cloacina-workflow-plugin/src/lib.rs
@@ -208,6 +208,10 @@ macro_rules! package {
                             source_location: format!("{}/lib.rs", env!("CARGO_PKG_NAME")),
                             trigger_rules: cloacina_workflow::Task::trigger_rules(&*task)
                                 .to_string(),
+                            // CLOACI-T-0897: the host gates its whole handle
+                            // path on this, and cannot see the packaged Task
+                            // impl to ask. Read straight off the task here.
+                            requires_handle: cloacina_workflow::Task::requires_handle(&*task),
                         });
                     }
                     // Look up WorkflowDescriptorEntry for description / author /
@@ -996,7 +1000,10 @@ pub trait CloacinaHost: Send + Sync {
 // through `CloacinaHost` for a deferral. Same reasoning as 4 → 5 — bincode is
 // positional, so a v5 plugin's request would mis-decode against a v6 host. The
 // gate must reject rather than guess.
-#[fidius::plugin_interface(version = 6, buffer = PluginAllocated)]
+// version 6 → 7 (CLOACI-T-0897): `TaskMetadataEntry` gained `requires_handle`,
+// so the host learns a packaged task wants a `TaskHandle`. Positional bincode
+// again — the gate must reject a v6 plugin rather than mis-decode.
+#[fidius::plugin_interface(version = 7, buffer = PluginAllocated)]
 pub trait CloacinaPlugin: Send + Sync {
     /// Returns metadata about all tasks in this workflow package.
     /// Method index 0.

--- a/crates/cloacina-workflow-plugin/src/lib.rs
+++ b/crates/cloacina-workflow-plugin/src/lib.rs
@@ -62,6 +62,38 @@ pub use types::{
 pub use fidius;
 pub use fidius_core;
 
+/// Compile-time proof that `#[host_interface]` generated BOTH ends of the
+/// `CloacinaHost` channel under the names the engine and the packaged shell
+/// reference (CLOACI-T-0897).
+///
+/// Worth pinning rather than assuming: the two halves are gated differently —
+/// the client is always emitted (packaged cdylibs need it), while the binding
+/// and its load-time gate constants only exist under this crate's `host`
+/// feature, which pulls `fidius/host`. A silent change to either gate would
+/// otherwise surface much later as a confusing missing-symbol error in an
+/// unrelated crate.
+#[cfg(test)]
+mod host_interface_surface {
+    #[test]
+    fn client_and_binding_are_generated() {
+        // Plugin side — always present.
+        fn _client_type_exists(_c: &super::CloacinaHostClient) {}
+
+        // Host side — only under `host`. The gate constants are what the
+        // loader compares against a plugin's advertised imports.
+        #[cfg(feature = "host")]
+        {
+            let _v: u32 = super::CloacinaHostBinding::INTERFACE_VERSION;
+            let _h: u64 = super::CloacinaHostBinding::INTERFACE_HASH;
+            assert_eq!(
+                super::CloacinaHostBinding::INTERFACE_VERSION,
+                1,
+                "host interface version must match the declared #[host_interface(version = 1)]"
+            );
+        }
+    }
+}
+
 // Re-export serde_json so the `#[workflow]` macro's PACKAGED `ConstructorEntry`
 // emission can lower `constructor!(config = { .. })` values via
 // `::cloacina_workflow_plugin::serde_json::json!` without the packaged cdylib
@@ -889,6 +921,48 @@ pub const METHOD_GET_INPUT_INTERFACE: usize = 9;
 /// See [`METHOD_GET_TASK_METADATA`]. Packaged `constructor!(...)` node declarations
 /// (CLOACI-T-0832), optional since interface version 4.
 pub const METHOD_GET_CONSTRUCTOR_METADATA: usize = 10;
+
+/// Host services a packaged workflow can call back into (CLOACI-T-0897).
+///
+/// This is the **reverse** direction from [`CloacinaPlugin`]: the host
+/// implements it and the plugin calls it mid-execution. It exists so
+/// `handle.defer_until(..)` works in a packaged workflow, not just an embedded
+/// one — the task's condition is plugin code, but releasing and reclaiming its
+/// concurrency slot is host state (a semaphore permit and a DB row), and
+/// neither can cross the boundary as a value.
+///
+/// Every method is keyed by the task-execution UUID as a string, because the
+/// host has no other way to know *which* running task is calling: the callback
+/// arrives on a tokio blocking-pool thread (the host invokes packaged tasks via
+/// `spawn_blocking`), where the executor's task-local handle is not visible.
+///
+/// Calls are **synchronous** at the boundary by fidius's design; the host
+/// bridges to its async internals itself. That is safe here precisely because
+/// callbacks land on the blocking pool rather than a runtime worker — see the
+/// threading notes on CLOACI-T-0897.
+///
+/// A plugin that never defers imports nothing and is completely unaffected;
+/// `bind` simply reports that this library does not use the interface.
+#[fidius::host_interface(version = 1)]
+pub trait CloacinaHost: Send + Sync {
+    /// Release the task's concurrency slot so another task may run while this
+    /// one waits. Idempotent — releasing an already-released slot is not an
+    /// error.
+    fn release_slot(&self, task_execution_id: String) -> Result<(), fidius::PluginError>;
+
+    /// Reclaim a concurrency slot before resuming real work. May wait for
+    /// capacity, and returns an error if the executor is shutting down (the
+    /// semaphore is closed) so the task fails rather than hanging.
+    fn reclaim_slot(&self, task_execution_id: String) -> Result<(), fidius::PluginError>;
+
+    /// Set the task's `sub_status` (`"Deferred"` / `"Active"`) so operators can
+    /// see a deferred task is waiting rather than stuck.
+    fn set_sub_status(
+        &self,
+        task_execution_id: String,
+        sub_status: String,
+    ) -> Result<(), fidius::PluginError>;
+}
 
 /// The plugin interface for cloacina workflow packages.
 ///

--- a/crates/cloacina-workflow-plugin/src/lib.rs
+++ b/crates/cloacina-workflow-plugin/src/lib.rs
@@ -40,7 +40,11 @@
 
 pub mod inventory_entries;
 pub mod manifest;
+/// Packaged counterpart of the engine's `TaskHandle` (CLOACI-T-0897).
+pub mod task_handle;
 pub mod types;
+
+pub use task_handle::{TaskExecutionIdGuard, TaskHandle};
 
 pub use inventory_entries::{
     AccumulatorEntry, ComputationGraphEntry, ConstructorEntry, ReactorEntry, TaskEntry,
@@ -312,6 +316,14 @@ macro_rules! package {
                             ),
                         ));
                     }
+
+                    // CLOACI-T-0897: publish this invocation's task-execution
+                    // id so a `defer_until` inside the task can name itself
+                    // when calling back into the host. The guard clears it on
+                    // drop, so one invocation cannot leak into the next on a
+                    // reused shell thread.
+                    let _task_id_guard =
+                        $crate::TaskExecutionIdGuard::set(request.task_execution_id.clone());
 
                     let result = rt.block_on(async move {
                         cloacina_workflow::Task::execute(&*task, context).await
@@ -979,7 +991,12 @@ pub trait CloacinaHost: Send + Sync {
 // version 4 → 5 (CLOACI-T-0895): `TaskExecutionRequest` gained the
 // `resolved_secrets` wire field — a bincode layout change, so stale artifacts
 // must fail the version gate at load rather than mis-decode.
-#[fidius::plugin_interface(version = 5, buffer = PluginAllocated)]
+// version 5 → 6 (CLOACI-T-0897): `TaskExecutionRequest` gained
+// `task_execution_id`, so a packaged task can name itself when calling back
+// through `CloacinaHost` for a deferral. Same reasoning as 4 → 5 — bincode is
+// positional, so a v5 plugin's request would mis-decode against a v6 host. The
+// gate must reject rather than guess.
+#[fidius::plugin_interface(version = 6, buffer = PluginAllocated)]
 pub trait CloacinaPlugin: Send + Sync {
     /// Returns metadata about all tasks in this workflow package.
     /// Method index 0.

--- a/crates/cloacina-workflow-plugin/src/task_handle.rs
+++ b/crates/cloacina-workflow-plugin/src/task_handle.rs
@@ -1,0 +1,201 @@
+/*
+ *  Copyright 2025-2026 Colliery Software
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+//! The packaged counterpart of the engine's `TaskHandle` (CLOACI-T-0897).
+//!
+//! A task that takes a handle parameter gets *this* type inside a packaged
+//! cdylib, and the engine's own `cloacina::TaskHandle` when built embedded. The
+//! surface is the same — `defer_until`, `task_execution_id` — so a workflow's
+//! source compiles either way; only the plumbing underneath differs.
+//!
+//! Embedded, `defer_until` reaches straight into the executor's semaphore and
+//! DAL. Packaged, it cannot: those live in the host, on the other side of an
+//! FFI boundary, and the engine crate is not even linked. Instead each host
+//! operation goes out over the [`CloacinaHost`](crate::CloacinaHost) callback
+//! channel, while the user's condition keeps running here in the plugin. The
+//! observable behavior matches: the concurrency slot really is released for the
+//! duration of the wait.
+//!
+//! The task-execution id is supplied by the host in the execution request; the
+//! plugin shell stashes it for the duration of one invocation so the handle can
+//! name which task is calling.
+
+use std::cell::RefCell;
+use std::time::Duration;
+
+use cloacina_workflow::TaskError;
+
+use crate::CloacinaHostClient;
+
+thread_local! {
+    /// The task-execution id for the invocation running on this thread.
+    ///
+    /// A thread-local rather than a parameter because the handle is
+    /// constructed by macro-generated code that has no other way to see it, and
+    /// each `execute_task` invocation is serviced on one thread.
+    static CURRENT_TASK_EXECUTION_ID: RefCell<Option<String>> = const { RefCell::new(None) };
+}
+
+/// Install the current invocation's task-execution id, returning a guard that
+/// clears it. Called by the plugin shell around `Task::execute`.
+pub struct TaskExecutionIdGuard;
+
+impl TaskExecutionIdGuard {
+    /// Set the id for this thread for the lifetime of the guard.
+    pub fn set(task_execution_id: impl Into<String>) -> Self {
+        CURRENT_TASK_EXECUTION_ID.with(|c| *c.borrow_mut() = Some(task_execution_id.into()));
+        Self
+    }
+}
+
+impl Drop for TaskExecutionIdGuard {
+    fn drop(&mut self) {
+        CURRENT_TASK_EXECUTION_ID.with(|c| *c.borrow_mut() = None);
+    }
+}
+
+/// The current invocation's task-execution id, if the shell installed one.
+fn current_task_execution_id() -> Option<String> {
+    CURRENT_TASK_EXECUTION_ID.with(|c| c.borrow().clone())
+}
+
+/// Execution-control handle for a task inside a packaged workflow.
+///
+/// Mirrors the engine's `TaskHandle` surface. Obtained by macro-generated code,
+/// not constructed directly.
+#[derive(Debug)]
+pub struct TaskHandle {
+    task_execution_id: String,
+}
+
+impl TaskHandle {
+    /// Build a handle for the invocation running on this thread.
+    ///
+    /// Fails when the shell did not install an id — which would mean this
+    /// package is being driven by a host too old to send one. Better a clear
+    /// error at the first `defer_until` than a silent no-op wait.
+    pub fn for_current_invocation() -> Result<Self, TaskError> {
+        current_task_execution_id()
+            .map(|task_execution_id| Self { task_execution_id })
+            .ok_or_else(|| TaskError::ExecutionFailed {
+                message: "task handle unavailable: the host did not supply a \
+                          task-execution id for this invocation (host too old \
+                          for CLOACI-T-0897?)"
+                    .to_string(),
+                task_id: String::new(),
+                timestamp: cloacina_workflow::__private::chrono::Utc::now(),
+            })
+    }
+
+    /// The task-execution id this handle acts on.
+    pub fn task_execution_id(&self) -> &str {
+        &self.task_execution_id
+    }
+
+    /// Release the concurrency slot while polling an external condition, then
+    /// reclaim it — the packaged implementation of the engine's `defer_until`.
+    ///
+    /// The slot is genuinely released for the whole wait: another task can run
+    /// in it. The condition runs here, in the plugin, so it can be any code the
+    /// task author likes.
+    ///
+    /// # Errors
+    ///
+    /// Surfaces host-side failures as task errors — notably when the executor
+    /// is shutting down and the slot can never be reclaimed, so the task fails
+    /// instead of waiting forever.
+    pub async fn defer_until<F, Fut>(
+        &mut self,
+        condition: F,
+        poll_interval: Duration,
+    ) -> Result<(), TaskError>
+    where
+        F: Fn() -> Fut,
+        Fut: std::future::Future<Output = bool>,
+    {
+        let host = CloacinaHostClient::bound().map_err(|e| self.err("host unavailable", e))?;
+
+        // Mark deferred BEFORE releasing, so an operator watching the row never
+        // sees a task holding no slot while still reported Active.
+        host.set_sub_status(&self.task_execution_id, &"Deferred".to_string())
+            .map_err(|e| self.err("set sub_status Deferred", e))?;
+        host.release_slot(&self.task_execution_id)
+            .map_err(|e| self.err("release slot", e))?;
+
+        // Poll here in the plugin — this is the part that cannot cross the
+        // boundary, and the reason a callback channel was needed at all.
+        loop {
+            cloacina_workflow::__private::tokio::time::sleep(poll_interval).await;
+            if condition().await {
+                break;
+            }
+        }
+
+        // Reclaim before resuming real work. Best-effort restore of Active
+        // afterwards: if the status write fails the task is still correctly
+        // running with a slot, so failing it here would be worse than a stale
+        // sub_status.
+        host.reclaim_slot(&self.task_execution_id)
+            .map_err(|e| self.err("reclaim slot", e))?;
+        let _ = host.set_sub_status(&self.task_execution_id, &"Active".to_string());
+
+        Ok(())
+    }
+
+    fn err(&self, what: &str, e: impl std::fmt::Display) -> TaskError {
+        TaskError::ExecutionFailed {
+            message: format!("defer_until: {what} failed: {e}"),
+            task_id: self.task_execution_id.clone(),
+            timestamp: cloacina_workflow::__private::chrono::Utc::now(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn guard_installs_and_clears_the_id() {
+        assert!(current_task_execution_id().is_none());
+        {
+            let _g = TaskExecutionIdGuard::set("abc");
+            assert_eq!(current_task_execution_id().as_deref(), Some("abc"));
+            assert_eq!(
+                TaskHandle::for_current_invocation()
+                    .unwrap()
+                    .task_execution_id(),
+                "abc"
+            );
+        }
+        assert!(
+            current_task_execution_id().is_none(),
+            "guard must clear on drop so one invocation cannot leak into the next"
+        );
+    }
+
+    /// Without an installed id the handle refuses to exist, rather than
+    /// deferring against an empty task id and silently doing nothing.
+    #[test]
+    fn no_id_is_a_clear_error() {
+        assert!(current_task_execution_id().is_none());
+        let err = TaskHandle::for_current_invocation().expect_err("must fail");
+        assert!(
+            format!("{err}").contains("task handle unavailable"),
+            "unexpected error: {err}"
+        );
+    }
+}

--- a/crates/cloacina-workflow-plugin/src/types.rs
+++ b/crates/cloacina-workflow-plugin/src/types.rs
@@ -47,6 +47,19 @@ pub struct TaskMetadataEntry {
     /// `{"type":"Always"}` for packages built before this field existed.
     #[serde(default = "default_trigger_rules")]
     pub trigger_rules: String,
+    /// CLOACI-T-0897: whether this task takes a `TaskHandle` parameter.
+    ///
+    /// The executor gates the ENTIRE handle path on `Task::requires_handle()`,
+    /// and the host-side `DynamicLibraryTask` has no way to know — the flag
+    /// lives in the packaged `Task` impl, on the far side of the FFI boundary.
+    /// Without carrying it here, every packaged task reports the trait default
+    /// (`false`), so no handle is built, nothing is registered for deferral,
+    /// and `defer_until` fails with `TASK_NOT_RUNNING`.
+    ///
+    /// Defaults to `false` for packages built before this field existed, which
+    /// is correct: they could not have used a handle anyway.
+    #[serde(default)]
+    pub requires_handle: bool,
 }
 
 /// Default trigger-rules JSON (`Always`) for back-compat deserialization of

--- a/crates/cloacina-workflow-plugin/src/types.rs
+++ b/crates/cloacina-workflow-plugin/src/types.rs
@@ -118,6 +118,17 @@ pub struct TaskExecutionRequest {
     /// durable context.
     pub resolved_secrets:
         std::collections::BTreeMap<String, std::collections::BTreeMap<String, String>>,
+    /// CLOACI-T-0897: the running task's execution UUID, as a string.
+    ///
+    /// A packaged task that calls `handle.defer_until(..)` must name itself
+    /// when it calls back into the host — the host has no other way to know
+    /// WHICH of many concurrent tasks is asking for its slot to be released.
+    /// The plugin shell installs it for the duration of the invocation.
+    ///
+    /// Empty when the host did not supply one; the packaged `TaskHandle` then
+    /// refuses to exist rather than deferring against an anonymous task.
+    #[serde(default)]
+    pub task_execution_id: String,
 }
 
 // Secret values must never appear in logs — a manual Debug keeps names only.

--- a/crates/cloacina-workflow-plugin/src/types.rs
+++ b/crates/cloacina-workflow-plugin/src/types.rs
@@ -573,6 +573,7 @@ mod tests {
             description: "Extract data from sources".to_string(),
             source_location: "src/lib.rs".to_string(),
             trigger_rules: "{\"type\":\"Always\"}".to_string(),
+            requires_handle: false,
         };
 
         let json = serde_json::to_string(&entry).unwrap();
@@ -598,6 +599,7 @@ mod tests {
                 description: "First step".to_string(),
                 source_location: "src/lib.rs".to_string(),
                 trigger_rules: "{\"type\":\"Always\"}".to_string(),
+                requires_handle: false,
             }],
             triggers: Vec::new(),
         };
@@ -619,6 +621,7 @@ mod tests {
             task_name: "extract_data".to_string(),
             context_json: r#"{"key": "value"}"#.to_string(),
             resolved_secrets: secrets,
+            task_execution_id: "11111111-1111-4111-8111-111111111111".to_string(),
         };
 
         let json = serde_json::to_string(&request).unwrap();

--- a/crates/cloacina-workflow-plugin/tests/host_callback_roundtrip.rs
+++ b/crates/cloacina-workflow-plugin/tests/host_callback_roundtrip.rs
@@ -1,0 +1,155 @@
+/*
+ *  Copyright 2025-2026 Colliery Software
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+//! Round-trip exercise for the `CloacinaHost` callback channel (CLOACI-T-0897).
+//!
+//! Proves cloacina's own host interface works through fidius's generated
+//! machinery: a host implementation is bound, the plugin-side client resolves
+//! it, and calls cross the full encode → dispatch → decode → host → encode →
+//! decode path, including a host-raised typed error.
+//!
+//! Bound state is a process-global cell and binds are once-only, so this lives
+//! in its own test binary rather than the crate's unit tests.
+//!
+//! Scope note: this is the IN-PROCESS binding. It exercises every layer except
+//! the dylib boundary itself — fidius's own `host_functions_e2e` covers that
+//! over a real loaded cdylib. What is proven here is that *cloacina's* three-
+//! method interface is well-formed and dispatches correctly end to end.
+
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::{Arc, Mutex};
+
+use cloacina_workflow_plugin::fidius::PluginError;
+use cloacina_workflow_plugin::{CloacinaHost, CloacinaHostBinding, CloacinaHostClient};
+
+/// Records every callback so the test can assert the host actually ran, rather
+/// than inferring it from a non-error return.
+#[derive(Default)]
+struct RecordingHost {
+    calls: Mutex<Vec<String>>,
+    reclaims: AtomicU32,
+}
+
+impl RecordingHost {
+    fn calls(&self) -> Vec<String> {
+        self.calls.lock().unwrap().clone()
+    }
+    fn record(&self, entry: String) {
+        // Taking this lock inside a callback is fine: the contract only forbids
+        // the host holding locks ACROSS a plugin call, which we never do.
+        self.calls.lock().unwrap().push(entry);
+    }
+}
+
+impl CloacinaHost for RecordingHost {
+    fn release_slot(&self, task_execution_id: String) -> Result<(), PluginError> {
+        // A task id the host refuses, so the test can observe a host-raised
+        // typed error crossing back rather than a panic or a silent success.
+        if task_execution_id == "refuse-me" {
+            return Err(PluginError::new(
+                "SLOT_RELEASE_REFUSED",
+                "host refused to release this slot",
+            ));
+        }
+        self.record(format!("release:{task_execution_id}"));
+        Ok(())
+    }
+
+    fn reclaim_slot(&self, task_execution_id: String) -> Result<(), PluginError> {
+        self.reclaims.fetch_add(1, Ordering::SeqCst);
+        self.record(format!("reclaim:{task_execution_id}"));
+        Ok(())
+    }
+
+    fn set_sub_status(
+        &self,
+        task_execution_id: String,
+        sub_status: String,
+    ) -> Result<(), PluginError> {
+        self.record(format!("sub_status:{task_execution_id}={sub_status}"));
+        Ok(())
+    }
+}
+
+#[test]
+fn cloacina_host_interface_round_trips() {
+    let host = Arc::new(RecordingHost::default());
+    CloacinaHostBinding::bind_in_process(host.clone() as Arc<dyn CloacinaHost>)
+        .expect("bind CloacinaHost in process");
+
+    let client = CloacinaHostClient::bound().expect("client resolves the bound host");
+
+    // The exact sequence a packaged `defer_until` performs.
+    client
+        .set_sub_status(&"task-1".to_string(), &"Deferred".to_string())
+        .expect("set_sub_status Deferred");
+    client
+        .release_slot(&"task-1".to_string())
+        .expect("release_slot");
+    client
+        .reclaim_slot(&"task-1".to_string())
+        .expect("reclaim_slot");
+    client
+        .set_sub_status(&"task-1".to_string(), &"Active".to_string())
+        .expect("set_sub_status Active");
+
+    assert_eq!(
+        host.calls(),
+        vec![
+            "sub_status:task-1=Deferred".to_string(),
+            "release:task-1".to_string(),
+            "reclaim:task-1".to_string(),
+            "sub_status:task-1=Active".to_string(),
+        ],
+        "callbacks must arrive in order, with arguments intact across bincode"
+    );
+    assert_eq!(host.reclaims.load(Ordering::SeqCst), 1);
+
+    // A host-raised error must surface to the caller as an error, not as a
+    // panic and not as a silent success — this is what lets a deferred task
+    // fail cleanly when the executor is shutting down.
+    let err = client
+        .release_slot(&"refuse-me".to_string())
+        .expect_err("host refusal must surface as an error");
+    assert!(
+        format!("{err}").contains("SLOT_RELEASE_REFUSED") || format!("{err}").contains("refused"),
+        "typed host error should carry its code/message, got: {err}"
+    );
+
+    // The refusal must not have been recorded — proof the error came from the
+    // host body rather than the transport inventing one.
+    assert!(
+        !host.calls().iter().any(|c| c.contains("refuse-me")),
+        "refused call must not record: {:?}",
+        host.calls()
+    );
+}
+
+/// A second bind is refused. Cloacina binds once per loaded library, so this
+/// pins the behavior we rely on rather than leaving it to chance.
+#[test]
+fn double_bind_is_refused() {
+    // This test binary shares the global cell with the test above; whichever
+    // runs first performs the real bind. Either way a SECOND bind must fail,
+    // which is the property being asserted.
+    let host = Arc::new(RecordingHost::default());
+    let first = CloacinaHostBinding::bind_in_process(host.clone() as Arc<dyn CloacinaHost>);
+    let second = CloacinaHostBinding::bind_in_process(host as Arc<dyn CloacinaHost>);
+    assert!(
+        first.is_err() || second.is_err(),
+        "binding twice in one process must be refused"
+    );
+}

--- a/crates/cloacina/Cargo.toml
+++ b/crates/cloacina/Cargo.toml
@@ -61,7 +61,10 @@ cloacina-api-types = { workspace = true }
 cloacina-macros = { workspace = true, optional = true }
 cloacina-workflow = { workspace = true }
 cloacina-computation-graph = { workspace = true }
-cloacina-workflow-plugin = { workspace = true }
+# `host`: the engine is the HOST side of the CloacinaHost callback interface, so
+# it needs `CloacinaHostBinding::bind` (CLOACI-T-0897). Packaged cdylibs leave
+# this off and get only the client.
+cloacina-workflow-plugin = { workspace = true, features = ["host"] }
 
 # External dependencies
 chrono = { version = "0.4", features = ["serde"] }
@@ -74,11 +77,11 @@ diesel_migrations = { version = "2.1.0" }
 libsqlite3-sys = { version = ">= 0.35", optional = true }
 dotenvy = { version = "0.15" }
 bzip2 = { version = "0.4" }
-fidius-host = "0.5.6"
-fidius-core = "0.5.6"
+fidius-host = { workspace = true }
+fidius-core = { workspace = true }
 # Only compiled in when `constructors-wasm` is on (host-side interface descriptor +
 # the shared constructor contract). Default builds pull neither.
-fidius-macro = { version = "0.5.6", optional = true }
+fidius-macro = { workspace = true, optional = true }
 cloacina-constructor-contract = { workspace = true, optional = true }
 libloading = { version = "0.8" }
 parking_lot = { version = "0.12" }
@@ -128,7 +131,7 @@ tempfile = "3.2"
 # CLOACI-T-0827: signed-provider e2e test signs/verifies with the same Ed25519
 # scheme fidius uses, and repacks a tampered dir to prove the loader fails closed.
 ed25519-dalek = { version = "2.1" }
-fidius-core = "0.5.6"
+fidius-core = { workspace = true }
 once_cell = "1.19.0"
 # CLOACI-T-0922: the reactor predicate-error tests assert that
 # `cloacina_reactor_predicate_errors_total` actually increments, which needs a

--- a/crates/cloacina/src/dispatcher/default.rs
+++ b/crates/cloacina/src/dispatcher/default.rs
@@ -162,7 +162,19 @@ impl Dispatcher for DefaultDispatcher {
 
         // Execute the task - the executor is responsible for claiming (which marks as Running)
         // and handling execution. We handle the final state transition.
-        let result = executor.execute(event.clone()).await?;
+        //
+        // CLOACI-T-0897: install the task-execution id here, not in an
+        // executor. This is the one choke point EVERY executor passes through,
+        // so a packaged task can name itself when calling back for a deferral
+        // regardless of which executor is running it. Installing it in
+        // `ThreadTaskExecutor` (next to the TaskHandle) worked embedded and
+        // silently produced an empty id on the server, which runs a
+        // `FleetExecutor` — a gap only a live-server test exposed.
+        let result = crate::executor::with_task_execution_id(
+            event.task_execution_id,
+            executor.execute(event.clone()),
+        )
+        .await?;
         self.handle_result(&event, result).await?;
 
         Ok(())

--- a/crates/cloacina/src/executor/deferral_registry.rs
+++ b/crates/cloacina/src/executor/deferral_registry.rs
@@ -1,0 +1,148 @@
+/*
+ *  Copyright 2025-2026 Colliery Software
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+//! Slot access for packaged tasks that defer (CLOACI-T-0897).
+//!
+//! An embedded task reaches its concurrency slot through the [`TaskHandle`]
+//! the executor installs in a task-local. A PACKAGED task cannot: its
+//! `defer_until` runs inside a cdylib and comes back through the
+//! `CloacinaHost` callback channel, which lands on a tokio blocking-pool
+//! thread (the host invokes packaged tasks via `spawn_blocking`) where that
+//! task-local is invisible.
+//!
+//! So the executor also registers the handle's slot here, keyed by the
+//! task-execution UUID the callback carries. It is the SAME `Arc`, not a copy
+//! — there is exactly one `SlotToken` per running task, whichever door reaches
+//! it.
+//!
+//! Entries are removed when the task finishes. A packaged task that never
+//! defers simply never looks its entry up.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, OnceLock};
+
+use tokio::sync::Mutex as AsyncMutex;
+
+use super::slot_token::SlotToken;
+use crate::dal::DAL;
+use crate::database::universal_types::UniversalUuid;
+
+/// What a host callback needs to service a deferral for one running task.
+#[derive(Clone)]
+pub(crate) struct DeferralEntry {
+    /// The running task's one and only slot, shared with its `TaskHandle`.
+    pub(crate) slot: Arc<AsyncMutex<SlotToken>>,
+    /// For `sub_status` writes, so an operator can see a task is deferred
+    /// rather than wedged.
+    pub(crate) dal: DAL,
+}
+
+/// Process-wide, because the binding fidius installs is per loaded library and
+/// the callback carries only a task id — there is no ambient executor to ask.
+/// Keyed by task-execution UUID, which is unique across tenants.
+fn registry() -> &'static Mutex<HashMap<UniversalUuid, DeferralEntry>> {
+    static REGISTRY: OnceLock<Mutex<HashMap<UniversalUuid, DeferralEntry>>> = OnceLock::new();
+    REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Publish a running task's slot so host callbacks can find it.
+pub(crate) fn register(
+    task_execution_id: UniversalUuid,
+    slot: Arc<AsyncMutex<SlotToken>>,
+    dal: DAL,
+) {
+    registry()
+        .lock()
+        .expect("deferral registry poisoned")
+        .insert(task_execution_id, DeferralEntry { slot, dal });
+}
+
+/// Remove a finished task's entry. Idempotent — a task that never deferred is
+/// removed the same way.
+pub(crate) fn deregister(task_execution_id: &UniversalUuid) {
+    registry()
+        .lock()
+        .expect("deferral registry poisoned")
+        .remove(task_execution_id);
+}
+
+/// Look up a running task's slot. `None` once the task has finished, which is
+/// what turns a late callback into a typed error rather than a panic.
+pub(crate) fn lookup(task_execution_id: &UniversalUuid) -> Option<DeferralEntry> {
+    registry()
+        .lock()
+        .expect("deferral registry poisoned")
+        .get(task_execution_id)
+        .cloned()
+}
+
+/// How many tasks are currently registered. Test-facing: lets a test prove
+/// entries are cleaned up rather than leaked.
+#[cfg(test)]
+pub(crate) fn len() -> usize {
+    registry().lock().expect("poisoned").len()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::executor::slot_token::SlotToken;
+    use std::sync::Arc;
+    use tokio::sync::Semaphore;
+
+    async fn a_slot() -> Arc<AsyncMutex<SlotToken>> {
+        let sem = Arc::new(Semaphore::new(1));
+        let permit = sem.clone().acquire_owned().await.unwrap();
+        Arc::new(AsyncMutex::new(SlotToken::new(permit, sem)))
+    }
+
+    /// The registry hands back the SAME slot the caller registered — a copy
+    /// would mean two owners of one permit and a double release.
+    #[tokio::test]
+    async fn lookup_returns_the_same_slot_arc() {
+        let id = UniversalUuid::new_v4();
+        let slot = a_slot().await;
+        register(
+            id,
+            Arc::clone(&slot),
+            DAL::new(crate::database::Database::new(
+                &format!(
+                    "file:defreg_{}?mode=memory&cache=shared",
+                    uuid::Uuid::new_v4()
+                ),
+                "",
+                2,
+            )),
+        );
+
+        let found = lookup(&id).expect("registered");
+        assert!(
+            Arc::ptr_eq(&found.slot, &slot),
+            "registry must share the slot, not clone the token"
+        );
+
+        deregister(&id);
+        assert!(lookup(&id).is_none(), "deregister must remove the entry");
+    }
+
+    /// A callback that arrives after the task finished must find nothing, so
+    /// the host can answer with a typed error instead of touching a dead slot.
+    #[tokio::test]
+    async fn lookup_after_deregister_is_none() {
+        let id = UniversalUuid::new_v4();
+        assert!(lookup(&id).is_none());
+    }
+}

--- a/crates/cloacina/src/executor/deferral_registry.rs
+++ b/crates/cloacina/src/executor/deferral_registry.rs
@@ -111,6 +111,12 @@ mod tests {
 
     /// The registry hands back the SAME slot the caller registered — a copy
     /// would mean two owners of one permit and a double release.
+    ///
+    /// sqlite-gated: it needs a real `DAL` to build a `DeferralEntry`, and the
+    /// cheapest one is an in-memory sqlite `Database`. A postgres-only build has
+    /// no sqlite backend and panics on that URL, so the test is skipped there —
+    /// the property being pinned is backend-independent.
+    #[cfg(feature = "sqlite")]
     #[tokio::test]
     async fn lookup_returns_the_same_slot_arc() {
         let id = UniversalUuid::new_v4();

--- a/crates/cloacina/src/executor/host_impl.rs
+++ b/crates/cloacina/src/executor/host_impl.rs
@@ -1,0 +1,148 @@
+/*
+ *  Copyright 2025-2026 Colliery Software
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+//! The engine's implementation of the `CloacinaHost` callback interface
+//! (CLOACI-T-0897) — what a packaged task's `defer_until` actually drives.
+//!
+//! ## Why blocking here is safe
+//!
+//! These methods are synchronous (fidius's boundary is sync by design) while
+//! the operations behind them are async, so each bridges with
+//! `Handle::block_on`. That is safe *specifically* because of where the call
+//! lands: the host invokes packaged tasks through
+//! `tokio::task::spawn_blocking` (`registry/loader/task_registrar/dynamic_task.rs`),
+//! so a callback runs on the BLOCKING pool, never on a runtime worker. Runtime
+//! workers keep draining, other tasks keep completing, and the slot this call
+//! is waiting for keeps being freed.
+//!
+//! An earlier reading of this had it backwards and predicted a self-deadlock;
+//! see the ticket for the retraction. The property to preserve is the one that
+//! makes it safe: **never call these from a runtime worker.**
+//!
+//! Residual cost, accepted and documented: a deferred task holds its
+//! blocking-pool thread for the whole wait. It has released its concurrency
+//! slot, so it is not blocking other work — it is just parked.
+
+use std::str::FromStr;
+
+use cloacina_workflow_plugin::fidius::PluginError;
+use cloacina_workflow_plugin::CloacinaHost;
+use tokio::runtime::Handle;
+
+use super::deferral_registry;
+use crate::database::universal_types::UniversalUuid;
+
+/// Services `defer_until` callbacks from packaged tasks.
+///
+/// Stateless: everything it needs is looked up per call from the deferral
+/// registry, keyed by the task-execution id the plugin sends. That keeps one
+/// bound instance correct for every tenant and every concurrently running task.
+pub struct EngineHost;
+
+impl EngineHost {
+    fn parse_id(raw: &str) -> Result<UniversalUuid, PluginError> {
+        uuid::Uuid::from_str(raw)
+            .map(UniversalUuid::from)
+            .map_err(|e| PluginError::new("BAD_TASK_ID", format!("malformed task id {raw:?}: {e}")))
+    }
+
+    fn entry(raw: &str) -> Result<deferral_registry::DeferralEntry, PluginError> {
+        let id = Self::parse_id(raw)?;
+        deferral_registry::lookup(&id).ok_or_else(|| {
+            // Not a panic and not a silent success: a callback for a task that
+            // has already finished (or was never registered) is a real error
+            // the task should see.
+            PluginError::new(
+                "TASK_NOT_RUNNING",
+                format!("no running task registered for {raw} — it may have already completed"),
+            )
+        })
+    }
+}
+
+impl CloacinaHost for EngineHost {
+    fn release_slot(&self, task_execution_id: String) -> Result<(), PluginError> {
+        let entry = Self::entry(&task_execution_id)?;
+        Handle::current().block_on(async move {
+            // `release` is idempotent — releasing an already-released slot
+            // returns false rather than erroring, so a task that defers twice
+            // is not punished for it.
+            entry.slot.lock().await.release();
+        });
+        Ok(())
+    }
+
+    fn reclaim_slot(&self, task_execution_id: String) -> Result<(), PluginError> {
+        let entry = Self::entry(&task_execution_id)?;
+        Handle::current().block_on(async move {
+            entry.slot.lock().await.reclaim().await.map_err(|e| {
+                // The semaphore is closed only when the executor is shutting
+                // down. Surfacing it lets the deferred task fail cleanly
+                // instead of waiting on capacity that will never come.
+                PluginError::new("SLOT_RECLAIM_FAILED", format!("{e}"))
+            })
+        })
+    }
+
+    fn set_sub_status(
+        &self,
+        task_execution_id: String,
+        sub_status: String,
+    ) -> Result<(), PluginError> {
+        let id = Self::parse_id(&task_execution_id)?;
+        let entry = Self::entry(&task_execution_id)?;
+        let value = if sub_status.is_empty() {
+            None
+        } else {
+            Some(sub_status)
+        };
+        Handle::current().block_on(async move {
+            entry
+                .dal
+                .task_execution()
+                .set_sub_status(id, value.as_deref())
+                .await
+                .map_err(|e| PluginError::new("SUB_STATUS_FAILED", format!("{e}")))
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A callback naming a task that is not running must be a typed error, not
+    /// a panic across the FFI boundary and not a silent success.
+    #[tokio::test]
+    async fn unknown_task_is_a_typed_error() {
+        let host = EngineHost;
+        let err = host
+            .release_slot(uuid::Uuid::new_v4().to_string())
+            .expect_err("unknown task must error");
+        assert_eq!(err.code, "TASK_NOT_RUNNING");
+    }
+
+    /// A malformed id is rejected before any lookup, with its own code so the
+    /// cause is obvious in a plugin's error message.
+    #[tokio::test]
+    async fn malformed_task_id_is_rejected() {
+        let host = EngineHost;
+        let err = host
+            .release_slot("not-a-uuid".to_string())
+            .expect_err("malformed id must error");
+        assert_eq!(err.code, "BAD_TASK_ID");
+    }
+}

--- a/crates/cloacina/src/executor/mod.rs
+++ b/crates/cloacina/src/executor/mod.rs
@@ -62,7 +62,9 @@ pub use result_handler::TaskResultHandler;
 
 pub use host_impl::EngineHost;
 pub use slot_token::SlotToken;
-pub use task_handle::{return_task_handle, take_task_handle, with_task_handle, TaskHandle};
+pub use task_handle::{
+    current_task_execution_id, return_task_handle, take_task_handle, with_task_handle, TaskHandle,
+};
 pub use thread_task_executor::ThreadTaskExecutor;
 pub use types::{ClaimedTask, DependencyLoader, ExecutorConfig};
 pub use workflow_executor::{

--- a/crates/cloacina/src/executor/mod.rs
+++ b/crates/cloacina/src/executor/mod.rs
@@ -45,6 +45,11 @@
 //! All components are thread-safe and can be used in concurrent environments.
 
 pub mod context_builder;
+/// Slot access for packaged tasks that defer (CLOACI-T-0897).
+pub(crate) mod deferral_registry;
+/// The engine's `CloacinaHost` implementation — services packaged
+/// `defer_until` callbacks (CLOACI-T-0897).
+pub mod host_impl;
 pub mod result_handler;
 pub mod slot_token;
 pub mod task_handle;
@@ -55,6 +60,7 @@ pub mod workflow_executor;
 pub use context_builder::TaskContextBuilder;
 pub use result_handler::TaskResultHandler;
 
+pub use host_impl::EngineHost;
 pub use slot_token::SlotToken;
 pub use task_handle::{return_task_handle, take_task_handle, with_task_handle, TaskHandle};
 pub use thread_task_executor::ThreadTaskExecutor;

--- a/crates/cloacina/src/executor/mod.rs
+++ b/crates/cloacina/src/executor/mod.rs
@@ -63,7 +63,8 @@ pub use result_handler::TaskResultHandler;
 pub use host_impl::EngineHost;
 pub use slot_token::SlotToken;
 pub use task_handle::{
-    current_task_execution_id, return_task_handle, take_task_handle, with_task_handle, TaskHandle,
+    current_task_execution_id, return_task_handle, take_task_handle, with_task_execution_id,
+    with_task_handle, TaskHandle,
 };
 pub use thread_task_executor::ThreadTaskExecutor;
 pub use types::{ClaimedTask, DependencyLoader, ExecutorConfig};

--- a/crates/cloacina/src/executor/task_handle.rs
+++ b/crates/cloacina/src/executor/task_handle.rs
@@ -266,6 +266,17 @@ impl TaskHandle {
         self.task_execution_id
     }
 
+    /// Test-only constructor used to pin the task-local peek.
+    #[cfg(test)]
+    fn for_peek_test(task_execution_id: UniversalUuid, slot: SlotToken) -> Self {
+        Self {
+            slot_token: Arc::new(tokio::sync::Mutex::new(slot)),
+            task_execution_id,
+            dal: None,
+            cancel_rx: None,
+        }
+    }
+
     /// Returns whether the handle currently holds a concurrency slot.
     ///
     /// Uses `try_lock`: the only contender is a host callback that is mid
@@ -410,6 +421,33 @@ mod tests {
 
         // The slot was available during the defer window
         assert!(slot_was_available.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    /// CLOACI-T-0897: the PACKAGED path reads the running task's id from the
+    /// task-local WITHOUT taking the handle, so it can tell the plugin which
+    /// task it is. If this peek returns `None` the plugin receives an empty id
+    /// and every `defer_until` fails with BAD_TASK_ID — which is exactly what
+    /// the e2e lane caught, so pin it here where the feedback is instant.
+    async fn peek_sees_the_id_inside_the_scope_and_nothing_outside() {
+        assert!(
+            current_task_execution_id().is_none(),
+            "no id outside a with_task_handle scope"
+        );
+
+        let semaphore = Arc::new(Semaphore::new(1));
+        let permit = semaphore.clone().acquire_owned().await.unwrap();
+        let id = UniversalUuid::new_v4();
+        let handle = TaskHandle::for_peek_test(id, SlotToken::new(permit, semaphore));
+
+        let (seen, _returned) =
+            with_task_handle(handle, async { current_task_execution_id() }).await;
+
+        assert_eq!(seen, Some(id), "peek must see the running task's id");
+        assert!(
+            current_task_execution_id().is_none(),
+            "scope must not leak past the task"
+        );
     }
 
     #[tokio::test]

--- a/crates/cloacina/src/executor/task_handle.rs
+++ b/crates/cloacina/src/executor/task_handle.rs
@@ -73,14 +73,41 @@ pub fn take_task_handle() -> TaskHandle {
     })
 }
 
-/// The current task's execution id, without disturbing the handle
-/// (CLOACI-T-0897).
+tokio::task_local! {
+    /// The running task's execution id, independent of the `TaskHandle`
+    /// (CLOACI-T-0897).
+    ///
+    /// Deliberately SEPARATE from `TASK_HANDLE_SLOT`. That one is installed
+    /// only by `ThreadTaskExecutor`, so anything relying on it works embedded
+    /// and silently returns nothing on the server, which runs a different
+    /// executor. This one is installed by the DISPATCHER — the single choke
+    /// point every executor passes through — so the id is available on every
+    /// path.
+    static TASK_EXECUTION_ID: UniversalUuid;
+}
+
+/// Run `f` with the task's execution id available to
+/// [`current_task_execution_id`] (CLOACI-T-0897). Called by the dispatcher.
+pub async fn with_task_execution_id<F, T>(task_execution_id: UniversalUuid, f: F) -> T
+where
+    F: Future<Output = T>,
+{
+    TASK_EXECUTION_ID.scope(task_execution_id, f).await
+}
+
+/// The current task's execution id (CLOACI-T-0897).
 ///
 /// The packaged task path needs to TELL the plugin which task is running, so it
-/// can name itself when calling back for a deferral. `take_task_handle` would
-/// remove the handle the embedded path still needs, so this peeks instead.
-/// `None` outside a `with_task_handle` scope.
+/// can name itself when calling back for a deferral.
+///
+/// Prefers the dispatcher-installed id, which every executor provides. Falls
+/// back to peeking the `TaskHandle` — without taking it, since the embedded
+/// path still needs it — so a direct `ThreadTaskExecutor` call outside the
+/// dispatcher still works.
 pub fn current_task_execution_id() -> Option<UniversalUuid> {
+    if let Ok(id) = TASK_EXECUTION_ID.try_with(|id| *id) {
+        return Some(id);
+    }
     TASK_HANDLE_SLOT
         .try_with(|cell| cell.borrow().as_ref().map(|h| h.task_execution_id))
         .ok()
@@ -447,6 +474,32 @@ mod tests {
         assert!(
             current_task_execution_id().is_none(),
             "scope must not leak past the task"
+        );
+    }
+
+    /// CLOACI-T-0897: the id must be available WITHOUT a `TaskHandle` in scope.
+    ///
+    /// This is the regression that matters. The first implementation read the
+    /// id only from the handle's task-local, which `ThreadTaskExecutor`
+    /// installs — so every embedded test passed while the SERVER, which runs a
+    /// `FleetExecutor`, delivered an empty id and failed every deferral with
+    /// BAD_TASK_ID. The id now comes from the dispatcher, which all executors
+    /// pass through; this asserts that path independently of any handle.
+    #[tokio::test]
+    async fn dispatcher_installed_id_needs_no_task_handle() {
+        let id = UniversalUuid::new_v4();
+
+        let seen = with_task_execution_id(id, async { current_task_execution_id() }).await;
+
+        assert_eq!(
+            seen,
+            Some(id),
+            "the id must be visible with NO TaskHandle in scope — this is the \
+             non-ThreadTaskExecutor path"
+        );
+        assert!(
+            current_task_execution_id().is_none(),
+            "scope must not leak past the dispatch"
         );
     }
 

--- a/crates/cloacina/src/executor/task_handle.rs
+++ b/crates/cloacina/src/executor/task_handle.rs
@@ -41,6 +41,7 @@
 
 use std::cell::RefCell;
 use std::future::Future;
+use std::sync::Arc;
 use std::time::Duration;
 
 use tracing::{debug, warn};
@@ -108,7 +109,13 @@ where
 /// The handle is created by the executor for each task execution and is not
 /// reusable across executions.
 pub struct TaskHandle {
-    slot_token: SlotToken,
+    /// Shared so a PACKAGED task can reach the same slot through the
+    /// `CloacinaHost` callback channel (CLOACI-T-0897). The callback arrives on
+    /// a blocking-pool thread where this handle's task-local is invisible, so
+    /// the executor also registers this exact `Arc` in the deferral registry
+    /// keyed by `task_execution_id`. Embedded tasks go straight through the
+    /// handle as before; either way there is exactly ONE `SlotToken`.
+    slot_token: Arc<tokio::sync::Mutex<SlotToken>>,
     task_execution_id: UniversalUuid,
     dal: Option<DAL>,
     cancel_rx: Option<tokio::sync::watch::Receiver<bool>>,
@@ -120,7 +127,7 @@ impl TaskHandle {
     #[cfg(test)]
     fn new(slot_token: SlotToken, task_execution_id: UniversalUuid) -> Self {
         Self {
-            slot_token,
+            slot_token: Arc::new(tokio::sync::Mutex::new(slot_token)),
             task_execution_id,
             dal: None,
             cancel_rx: None,
@@ -139,11 +146,17 @@ impl TaskHandle {
         cancel_rx: tokio::sync::watch::Receiver<bool>,
     ) -> Self {
         Self {
-            slot_token,
+            slot_token: Arc::new(tokio::sync::Mutex::new(slot_token)),
             task_execution_id,
             dal: Some(dal),
             cancel_rx: Some(cancel_rx),
         }
+    }
+
+    /// The shared slot, for the deferral registry to hand to host callbacks
+    /// (CLOACI-T-0897). Same `Arc` the handle uses — never a copy of the token.
+    pub(crate) fn slot_handle(&self) -> Arc<tokio::sync::Mutex<SlotToken>> {
+        Arc::clone(&self.slot_token)
     }
 
     /// Release the concurrency slot while polling an external condition.
@@ -198,7 +211,7 @@ impl TaskHandle {
         }
 
         // Release the concurrency slot
-        self.slot_token.release();
+        self.slot_token.lock().await.release();
 
         // Poll until condition is met
         loop {
@@ -209,7 +222,7 @@ impl TaskHandle {
         }
 
         // Reclaim a concurrency slot (may wait if at capacity)
-        self.slot_token.reclaim().await?;
+        self.slot_token.lock().await.reclaim().await?;
 
         // Update sub_status back to Active
         if let Some(ref dal) = self.dal {
@@ -240,8 +253,16 @@ impl TaskHandle {
     }
 
     /// Returns whether the handle currently holds a concurrency slot.
+    ///
+    /// Uses `try_lock`: the only contender is a host callback that is mid
+    /// release/reclaim, and both are short. A contended read reports the slot
+    /// as held, which is the safe answer for a caller deciding whether it may
+    /// proceed.
     pub fn is_slot_held(&self) -> bool {
-        self.slot_token.is_held()
+        match self.slot_token.try_lock() {
+            Ok(t) => t.is_held(),
+            Err(_) => true,
+        }
     }
 
     /// Returns `true` if the executor has signaled that this task's claim
@@ -451,7 +472,7 @@ mod tests {
         // Bypass the DAL requirement of with_dal_and_cancel by constructing
         // directly — this mirrors what the executor does internally.
         let handle = TaskHandle {
-            slot_token,
+            slot_token: Arc::new(tokio::sync::Mutex::new(slot_token)),
             task_execution_id: UniversalUuid::new_v4(),
             dal: None,
             cancel_rx: Some(rx),
@@ -474,7 +495,7 @@ mod tests {
         let slot_token = SlotToken::new(permit, semaphore.clone());
         let (tx, rx) = tokio::sync::watch::channel(false);
         let handle = TaskHandle {
-            slot_token,
+            slot_token: Arc::new(tokio::sync::Mutex::new(slot_token)),
             task_execution_id: UniversalUuid::new_v4(),
             dal: None,
             cancel_rx: Some(rx),
@@ -505,7 +526,7 @@ mod tests {
         let slot_token = SlotToken::new(permit, semaphore.clone());
         let (tx, rx) = tokio::sync::watch::channel(false);
         let handle = TaskHandle {
-            slot_token,
+            slot_token: Arc::new(tokio::sync::Mutex::new(slot_token)),
             task_execution_id: UniversalUuid::new_v4(),
             dal: None,
             cancel_rx: Some(rx),

--- a/crates/cloacina/src/executor/task_handle.rs
+++ b/crates/cloacina/src/executor/task_handle.rs
@@ -73,6 +73,20 @@ pub fn take_task_handle() -> TaskHandle {
     })
 }
 
+/// The current task's execution id, without disturbing the handle
+/// (CLOACI-T-0897).
+///
+/// The packaged task path needs to TELL the plugin which task is running, so it
+/// can name itself when calling back for a deferral. `take_task_handle` would
+/// remove the handle the embedded path still needs, so this peeks instead.
+/// `None` outside a `with_task_handle` scope.
+pub fn current_task_execution_id() -> Option<UniversalUuid> {
+    TASK_HANDLE_SLOT
+        .try_with(|cell| cell.borrow().as_ref().map(|h| h.task_execution_id))
+        .ok()
+        .flatten()
+}
+
 /// Returns a `TaskHandle` to task-local storage after the user function completes.
 ///
 /// Called by macro-generated code to restore the handle so the executor can

--- a/crates/cloacina/src/executor/thread_task_executor.rs
+++ b/crates/cloacina/src/executor/thread_task_executor.rs
@@ -630,11 +630,26 @@ impl TaskExecutor for ThreadTaskExecutor {
                 );
             }
 
+            // CLOACI-T-0897: publish this task's slot so a PACKAGED task that
+            // calls `defer_until` can reach it through the CloacinaHost
+            // callback channel — that callback lands on a blocking-pool thread
+            // where the task-local handle below is invisible. Same `Arc`, so
+            // there is still exactly one SlotToken.
+            super::deferral_registry::register(
+                event.task_execution_id,
+                handle.slot_handle(),
+                self.dal.clone(),
+            );
+
             let (result, _returned_handle) = with_task_handle(
                 handle,
                 self.execute_with_cancellation(task.as_ref(), context, cancel_rx.clone()),
             )
             .await;
+
+            // Unregister unconditionally: a later callback for this id must
+            // find nothing and get a typed error rather than touch a dead slot.
+            super::deferral_registry::deregister(&event.task_execution_id);
 
             // Clear sub_status when task completes
             if let Err(e) = self

--- a/crates/cloacina/src/registry/loader/package_loader.rs
+++ b/crates/cloacina/src/registry/loader/package_loader.rs
@@ -133,6 +133,52 @@ pub struct TaskDocs {
     pub why: Option<String>,
 }
 
+/// Install the engine's `CloacinaHost` callback table on a freshly loaded
+/// library (CLOACI-T-0897), so a packaged task that calls `defer_until` can
+/// reach back for its concurrency slot.
+///
+/// Best-effort by design, in three ways that all matter:
+///
+/// * A package that declares no host interface — every package built before
+///   this existed — imports nothing, `bind` reports `false`, and the package
+///   loads and runs exactly as before. This is why the change does not force a
+///   rebuild of the world.
+/// * A version or hash mismatch is a LOAD-time error from fidius, logged here
+///   rather than propagated: the package's tasks are still perfectly runnable
+///   as long as none of them defers, and one that does gets a clear
+///   `NotBound` at its first `defer_until` instead of the whole package
+///   failing to load.
+/// * Binding is once-only per library; a second attempt is refused and simply
+///   logged.
+pub(crate) fn bind_engine_host(loaded: &fidius_host::loader::LoadedLibrary, library_path: &Path) {
+    use cloacina_workflow_plugin::{CloacinaHost, CloacinaHostBinding};
+
+    let host: std::sync::Arc<dyn CloacinaHost> = std::sync::Arc::new(crate::executor::EngineHost);
+    match CloacinaHostBinding::bind(loaded, host) {
+        Ok(true) => {
+            tracing::debug!(
+                library = %library_path.display(),
+                "CloacinaHost bound — package can use defer_until"
+            );
+        }
+        Ok(false) => {
+            // The common case: the package never imports the interface.
+            tracing::trace!(
+                library = %library_path.display(),
+                "package imports no host interface; nothing bound"
+            );
+        }
+        Err(e) => {
+            tracing::warn!(
+                library = %library_path.display(),
+                error = %e,
+                "could not bind CloacinaHost — tasks in this package that call \
+                 defer_until will fail with a not-bound error; the rest run normally"
+            );
+        }
+    }
+}
+
 /// Package loader for extracting metadata from workflow library files.
 ///
 /// Loaded libraries are cached to prevent dlclose. The `inventory` crate
@@ -269,6 +315,12 @@ impl PackageLoader {
                 error: e.to_string(),
             },
         )?;
+
+        // CLOACI-T-0897: install the host-callback table BEFORE any plugin
+        // method runs, so a task that calls `defer_until` can reach back for
+        // its slot. Must happen here — `loaded` is consumed just below, and
+        // binding is per loaded library.
+        bind_engine_host(&loaded, library_path);
 
         let plugin =
             loaded

--- a/crates/cloacina/src/registry/loader/task_registrar/dynamic_task.rs
+++ b/crates/cloacina/src/registry/loader/task_registrar/dynamic_task.rs
@@ -70,6 +70,16 @@ impl LoadedWorkflowPlugin {
             },
         )?;
 
+        // CLOACI-T-0897: bind the host-callback table on THIS image.
+        //
+        // Binding is per loaded library, and this is a distinct `dlopen` of a
+        // freshly written temp file — a different dylib image, with its own
+        // bind cell, from the one the package loader binds for metadata
+        // extraction. This is the image whose tasks actually RUN, so without a
+        // bind here `defer_until` fails with "not bound" even though the log
+        // says a bind succeeded elsewhere. (Exactly what the e2e lane caught.)
+        crate::registry::loader::package_loader::bind_engine_host(&loaded, &temp_path);
+
         let plugin =
             loaded
                 .plugins

--- a/crates/cloacina/src/registry/loader/task_registrar/dynamic_task.rs
+++ b/crates/cloacina/src/registry/loader/task_registrar/dynamic_task.rs
@@ -133,6 +133,13 @@ pub(super) struct DynamicLibraryTask {
     /// FFI metadata (CLOACI-T-0721). Without this the host defaulted to `Always`
     /// and packaged workflows silently ignored conditional execution / skips.
     trigger_rules: serde_json::Value,
+    /// CLOACI-T-0897: whether the packaged task takes a `TaskHandle`, forwarded
+    /// from FFI metadata. The executor gates its entire handle path on
+    /// `requires_handle()`, and without carrying this every packaged task
+    /// inherited the trait default (`false`) — so no handle was built, nothing
+    /// was registered for deferral, and `defer_until` failed with
+    /// `TASK_NOT_RUNNING`.
+    requires_handle: bool,
 }
 
 impl DynamicLibraryTask {
@@ -150,12 +157,14 @@ impl DynamicLibraryTask {
         task_name: String,
         dependencies: Vec<TaskNamespace>,
         trigger_rules: serde_json::Value,
+        requires_handle: bool,
     ) -> Self {
         Self {
             plugin,
             task_name,
             dependencies,
             trigger_rules,
+            requires_handle,
         }
     }
 }
@@ -311,6 +320,17 @@ impl Task for DynamicLibraryTask {
     /// unconditionally regardless of its declared `trigger_rules`.
     fn trigger_rules(&self) -> serde_json::Value {
         self.trigger_rules.clone()
+    }
+
+    /// Forwarded from the cdylib's FFI metadata (CLOACI-T-0897).
+    ///
+    /// Exactly the same class of omission as `trigger_rules` above: the trait
+    /// default is `false`, so before this override the executor skipped the
+    /// whole handle path for every packaged task — no `TaskHandle`, no
+    /// deferral registration, and `defer_until` failing with
+    /// `TASK_NOT_RUNNING`.
+    fn requires_handle(&self) -> bool {
+        self.requires_handle
     }
 }
 

--- a/crates/cloacina/src/registry/loader/task_registrar/dynamic_task.rs
+++ b/crates/cloacina/src/registry/loader/task_registrar/dynamic_task.rs
@@ -207,6 +207,15 @@ impl Task for DynamicLibraryTask {
             task_name: self.task_name.clone(),
             context_json,
             resolved_secrets,
+            // CLOACI-T-0897: tell the package which task this is, so a
+            // `defer_until` inside it can name itself when calling back. Read
+            // from the executor's task-local WITHOUT taking the handle — the
+            // embedded path still owns it. Empty outside an executor scope
+            // (e.g. a direct harness call), in which case the packaged handle
+            // refuses to exist rather than deferring anonymously.
+            task_execution_id: crate::executor::current_task_execution_id()
+                .map(|id| id.to_string())
+                .unwrap_or_default(),
         };
 
         // Call via the shared plugin handle

--- a/crates/cloacina/src/registry/loader/task_registrar/extraction.rs
+++ b/crates/cloacina/src/registry/loader/task_registrar/extraction.rs
@@ -84,6 +84,7 @@ impl TaskRegistrar {
                 dependencies_json: serde_json::to_string(&t.dependencies)
                     .unwrap_or_else(|_| "[]".to_string()),
                 trigger_rules_json: t.trigger_rules,
+                requires_handle: t.requires_handle,
             })
             .collect();
 

--- a/crates/cloacina/src/registry/loader/task_registrar/mod.rs
+++ b/crates/cloacina/src/registry/loader/task_registrar/mod.rs
@@ -186,12 +186,17 @@ impl TaskRegistrar {
             let task_name = task_id.to_string();
             let deps = dependency_namespaces.clone();
 
+            // CLOACI-T-0897: carry the handle requirement through to the task,
+            // or the executor skips the handle path and defer_until cannot work.
+            let requires_handle = task.requires_handle;
+
             let constructor = Box::new(move || {
                 Arc::new(DynamicLibraryTask::new(
                     plugin.clone(),
                     task_name.clone(),
                     deps.clone(),
                     trigger_rules.clone(),
+                    requires_handle,
                 )) as Arc<dyn Task>
             });
 

--- a/crates/cloacina/src/registry/loader/task_registrar/types.rs
+++ b/crates/cloacina/src/registry/loader/task_registrar/types.rs
@@ -31,6 +31,10 @@ pub struct OwnedTaskMetadata {
     /// JSON string of the task's trigger rules (conditional execution).
     /// `{"type":"Always"}` when unconditional. (CLOACI-T-0721)
     pub trigger_rules_json: String,
+    /// Whether the task takes a `TaskHandle` parameter (CLOACI-T-0897).
+    /// Gates the executor's entire handle path; `false` for packages built
+    /// before the field existed, which is correct — they could not use one.
+    pub requires_handle: bool,
 }
 
 /// Owned collection of task metadata — safe to use after library is unloaded.

--- a/crates/cloacina/tests/integration/fidius_validation.rs
+++ b/crates/cloacina/tests/integration/fidius_validation.rs
@@ -167,6 +167,9 @@ fn test_task_execution_fidelity() {
         task_name: "extract_data".to_string(),
         context_json: "{}".to_string(),
         resolved_secrets: Default::default(),
+        // CLOACI-T-0897: no deferral in this fixture, so an empty id is fine —
+        // the packaged TaskHandle only needs one when defer_until is called.
+        task_execution_id: String::new(),
     };
 
     // Method index 1 = execute_task (fidius 0.0.5 tuple encoding: single-arg = (T,))
@@ -210,6 +213,9 @@ fn test_unknown_task_returns_error() {
         task_name: "nonexistent_task".to_string(),
         context_json: "{}".to_string(),
         resolved_secrets: Default::default(),
+        // CLOACI-T-0897: no deferral in this fixture, so an empty id is fine —
+        // the packaged TaskHandle only needs one when defer_until is called.
+        task_execution_id: String::new(),
     };
 
     // fidius 0.0.5 tuple encoding: single-arg = (T,)

--- a/crates/cloacina/tests/integration/fidius_validation.rs
+++ b/crates/cloacina/tests/integration/fidius_validation.rs
@@ -258,9 +258,15 @@ fn test_plugin_info_populated() {
         plugin.info.interface_hash != 0,
         "Interface hash should be non-zero"
     );
+    // Deliberately pinned: the wire is POSITIONAL bincode, so a version skew
+    // between host and package mis-decodes rather than failing. Bump this only
+    // alongside a real interface change, and say which one:
+    //   5 — T-0895 `resolved_secrets` on TaskExecutionRequest
+    //   6 — T-0897 `task_execution_id` on TaskExecutionRequest
+    //   7 — T-0897 `requires_handle` on TaskMetadataEntry
     assert_eq!(
-        plugin.info.interface_version, 5,
-        "Interface version should be 5 (CLOACI-T-0895 resolved_secrets on TaskExecutionRequest)"
+        plugin.info.interface_version, 7,
+        "Interface version should be 7 (CLOACI-T-0897 requires_handle on TaskMetadataEntry)"
     );
     assert_eq!(
         plugin.method_count, 11,

--- a/crates/cloacinactl/Cargo.toml
+++ b/crates/cloacinactl/Cargo.toml
@@ -29,8 +29,8 @@ cloacina-workflow-plugin = { workspace = true }
 clap.workspace = true
 clap_complete = "4"
 anyhow.workspace = true
-fidius-core = "0.5.6"
-fidius-host = "0.5.6"
+fidius-core = { workspace = true }
+fidius-host = { workspace = true }
 tempfile = "3.2"
 dirs = "6"
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/cloacinactl/src/nouns/trigger/mod.rs
+++ b/crates/cloacinactl/src/nouns/trigger/mod.rs
@@ -43,6 +43,32 @@ enum TriggerVerb {
     Inspect {
         name: String,
     },
+    /// Stop a trigger firing, without disabling or deleting it.
+    ///
+    /// In-flight executions are unaffected — this only gates NEW ones. Missed
+    /// fires are not caught up on resume (skip policy).
+    Pause {
+        /// Trigger name, or the workflow name it fires.
+        name: String,
+    },
+    /// Re-arm a paused trigger on its normal schedule.
+    Resume {
+        /// Trigger name, or the workflow name it fires.
+        name: String,
+    },
+    /// Fire a trigger by hand, fanning out to every subscribed workflow.
+    ///
+    /// The started executions are marked `manual` so they are distinguishable
+    /// from scheduled ones.
+    Fire {
+        /// Trigger name.
+        name: String,
+        /// Optional event payload merged into each fired workflow's context,
+        /// as JSON. Validated against the trigger's declared pass-through
+        /// schema when its subscribers declare one.
+        #[arg(long = "event", value_name = "JSON")]
+        event: Option<String>,
+    },
 }
 
 impl TriggerCmd {
@@ -66,6 +92,37 @@ impl TriggerCmd {
                     .get(&format!("/v1/tenants/{tenant}/triggers/{name}"))
                     .await?;
                 render::object(&body, output)
+            }
+            TriggerVerb::Pause { name } => {
+                let body: serde_json::Value = client
+                    .post(
+                        &format!("/v1/tenants/{tenant}/triggers/{name}/pause"),
+                        &serde_json::json!({}),
+                    )
+                    .await?;
+                render::object(&body, output)
+            }
+            TriggerVerb::Resume { name } => {
+                let body: serde_json::Value = client
+                    .post(
+                        &format!("/v1/tenants/{tenant}/triggers/{name}/resume"),
+                        &serde_json::json!({}),
+                    )
+                    .await?;
+                render::object(&body, output)
+            }
+            TriggerVerb::Fire { name, event } => {
+                // Same convention as `accumulator inject`: parse as JSON, fall
+                // back to a JSON string, so `--event hello` works unquoted.
+                let payload = event.map(|raw| {
+                    serde_json::from_str::<serde_json::Value>(&raw)
+                        .unwrap_or(serde_json::Value::String(raw))
+                });
+                let body = serde_json::json!({ "event": payload });
+                let resp: serde_json::Value = client
+                    .post(&format!("/v1/tenants/{tenant}/triggers/{name}/fire"), &body)
+                    .await?;
+                render::object(&resp, output)
             }
         }
     }

--- a/examples/features/computation-graphs/cg-feature-tour/README.md
+++ b/examples/features/computation-graphs/cg-feature-tour/README.md
@@ -93,18 +93,63 @@ Completion proves the invoke bridge: `report` fails unless the
 
 ## Operate it
 
+These are the verbs you use against a **running** graph — feeding it, forcing
+it, and looking at what it is doing.
+
+### Look at what is loaded
+
+```bash
+cloacinactl graph list                  # graphs the runtime has loaded
+cloacinactl graph status tour_stream_graph
+cloacinactl graph accumulators          # every accumulator + its current depth
+```
+
+`graph accumulators` is the quickest answer to "is my data arriving at all?" —
+if the depth never moves, the problem is upstream of the graph.
+
 ### Inject a typed event (fires the reactor)
 
 ```bash
-cloacinactl accumulator inject ticks '{"price": 101.5}'
+cloacinactl accumulator inject ticks --event '{"price": 101.5}'
 cloacinactl graph accumulators
-# watch the reactor's fires:
+```
+
+The payload goes in `--event`. It is parsed as JSON, or taken as a JSON string
+if it does not parse — so `--event hello` works unquoted.
+
+A malformed event (missing `price`, wrong type) is rejected — that's the typed
+boundary from `JsonSchema` doing its job, and it is worth trying once so you
+recognise the error later.
+
+Watch the reactor's fires:
+
+```bash
 curl -s -H 'Authorization: Bearer clk_demo_public_key_0003' \
     http://localhost:8080/v1/health/reactors/tour_rx/fires
 ```
 
-A malformed event (missing `price`, wrong type) is rejected — that's the typed
-boundary from `JsonSchema`.
+### Fire the reactor directly
+
+Injecting adds to what the accumulator already holds. Sometimes you want to run
+the graph against an exact set of inputs instead — a full replace of the
+reactor's cache, then fire:
+
+```bash
+cloacinactl reactor fire tour_rx --input ticks='{"price": 250.0}'
+```
+
+`--input` is `source=<json>` and repeats once per accumulator the reactor
+consumes. This is full-replace only: sources you omit are cleared, not kept.
+
+To fire on whatever is already cached, without supplying inputs:
+
+```bash
+cloacinactl reactor force-fire tour_rx
+```
+
+Use `fire` when you are testing the graph's logic against known inputs, and
+`force-fire` when you want to shake loose a reactor whose criteria have not
+tripped yet.
 
 ### Feed the stream from Kafka
 

--- a/examples/features/computation-graphs/cg-feature-tour/README.md
+++ b/examples/features/computation-graphs/cg-feature-tour/README.md
@@ -120,15 +120,28 @@ Each message on `tour.ticks` fires `tour_rx` and runs `tour_stream_graph`.
 
 ## Status of the surfaces
 
-- **Task→graph invocation** — works today; asserted in CI
-  (`angreal demos features cg-feature-tour`).
-- **Kafka stream accumulator** — the code is here, but kafka is currently a
-  HOST cargo feature (rdkafka linked into core `cloacina`), so a stream
-  accumulator only runs if the *server* was built `--features kafka` and
-  silently degrades to passthrough otherwise. This is being migrated so kafka
-  ships **in the package** as a constructor provider — a consumption connector
-  belongs in a provider, not the core engine (CLOACI-T-0898). The stream
-  sections above light up on that migration.
-- **`polling` / `batch` accumulators** — declared surfaces
-  (`#[polling_accumulator]`, `#[batch_accumulator]`) that also silently degrade
-  to passthrough in packaged graphs today (CLOACI-T-0896).
+Everything in this README works on the primary interface today, and both
+surfaces this example teaches are asserted in CI by
+`angreal demos features cg-feature-tour`:
+
+- **Task→graph invocation** — runs `tour_pipeline` to completion and checks the
+  terminal outputs merged back into the invoking task's context.
+- **Kafka stream accumulator** — the lane produces real messages onto the
+  dev-stack broker and observes `tour_rx` fire. Kafka now ships **in the
+  package** as a bundled native constructor provider, so it no longer depends
+  on the server being built with a `kafka` cargo feature (CLOACI-T-0898,
+  proven by CLOACI-T-0907).
+
+The other accumulator kinds have their own examples rather than being crammed
+in here — packaged graphs dispatch every kind explicitly since CLOACI-T-0896,
+which fixed them silently degrading to passthrough:
+
+| Kind | Example |
+|---|---|
+| `polling` | [`python-polling-graph`](../python-polling-graph) |
+| `batch` | [`python-batch-graph`](../python-batch-graph) |
+| `state` | [`python-stateful-graph`](../python-stateful-graph) |
+
+Python's typed boundaries (`@cloaca.boundary_schema(...)`) are taught in
+[`python-packaged-graph`](../python-packaged-graph) and
+[`python-stateful-graph`](../python-stateful-graph).

--- a/examples/features/workflows/packaged-triggers/README.md
+++ b/examples/features/workflows/packaged-triggers/README.md
@@ -1,0 +1,101 @@
+# Packaged triggers
+
+A packaged workflow that fires **itself**. No `workflow run`, no cron — a
+trigger polls for work and starts the workflow when it finds some.
+
+This is the packaged counterpart to `event-triggers` (which shows the same idea
+through the embedded library API). Here the trigger ships inside the
+`.cloacina` package: the `#[trigger]` macro projects it across the plugin FFI at
+load time, and the reconciler registers it in the host's trigger registry.
+
+## What it declares
+
+```rust
+#[trigger(on = "file_processing", poll_interval = "3s")]
+pub async fn inbox_poll() -> Result<TriggerResult, TriggerError> {
+    // ... look for work ...
+    Ok(TriggerResult::Fire(Some(ctx)))   // Fire(ctx) starts the workflow
+}
+```
+
+- **`on`** names the workflow this trigger starts.
+- **`poll_interval`** is how often the host calls your function.
+- Returning `TriggerResult::Fire(Some(ctx))` starts `file_processing` with that
+  context. Returning no-fire simply does nothing this tick.
+
+The context you attach is what the workflow's first task receives — that is how
+a trigger passes "what it found" to the work.
+
+## Run it
+
+Bring up the demo stack, then pack and upload as usual:
+
+```bash
+cloacinactl package pack . -o packaged-triggers.cloacina
+cloacinactl package upload packaged-triggers.cloacina
+```
+
+Once the build succeeds and the reconciler loads the package, **nothing else is
+required** — the trigger begins polling on its own. Watch executions appear:
+
+```bash
+cloacinactl execution list --workflow file_processing
+```
+
+## Operate it
+
+A trigger runs unattended, which is exactly why you need controls for it. These
+are the verbs for a trigger that is already live.
+
+### See what is registered
+
+```bash
+cloacinactl trigger list
+cloacinactl trigger inspect inbox_poll
+```
+
+`inspect` shows the schedule plus its recent executions — the fastest way to
+answer "is it actually firing, and what happened when it did?"
+
+### Stop it firing
+
+```bash
+cloacinactl trigger pause inbox_poll
+```
+
+Pausing gates **new** executions only; anything already running is untouched.
+It is deliberately distinct from disabling or deleting the trigger — the
+registration stays intact, so this is the safe thing to reach for during an
+incident.
+
+```bash
+cloacinactl trigger resume inbox_poll
+```
+
+Resuming re-arms it on its normal schedule. Fires missed while paused are **not
+caught up** — the policy is skip, not backfill. If you paused for ten minutes on
+a 3s poll, you do not get 200 executions on resume.
+
+### Fire it by hand
+
+```bash
+cloacinactl trigger fire inbox_poll
+```
+
+This runs the fan-out immediately: every workflow subscribed to the trigger
+starts, without waiting for the next poll. The resulting executions are marked
+`manual`, so they stay distinguishable from scheduled ones in the history.
+
+To supply the context yourself rather than letting the trigger function produce
+it:
+
+```bash
+cloacinactl trigger fire inbox_poll --event '{"filename": "urgent-001.dat"}'
+```
+
+The event is merged into each fired workflow's context. When the subscribed
+workflows declare typed params, it is validated against them first — a
+malformed event is rejected before anything runs.
+
+Both `pause` and `resume` accept the workflow name as well as the trigger name,
+which is handy when you know what stopped rather than which trigger drives it.

--- a/examples/features/workflows/packaged-triggers/README.md
+++ b/examples/features/workflows/packaged-triggers/README.md
@@ -76,26 +76,27 @@ Resuming re-arms it on its normal schedule. Fires missed while paused are **not
 caught up** — the policy is skip, not backfill. If you paused for ten minutes on
 a 3s poll, you do not get 200 executions on resume.
 
-### Fire it by hand
-
-```bash
-cloacinactl trigger fire inbox_poll
-```
-
-This runs the fan-out immediately: every workflow subscribed to the trigger
-starts, without waiting for the next poll. The resulting executions are marked
-`manual`, so they stay distinguishable from scheduled ones in the history.
-
-To supply the context yourself rather than letting the trigger function produce
-it:
-
-```bash
-cloacinactl trigger fire inbox_poll --event '{"filename": "urgent-001.dat"}'
-```
-
-The event is merged into each fired workflow's context. When the subscribed
-workflows declare typed params, it is validated against them first — a
-malformed event is rejected before anything runs.
-
 Both `pause` and `resume` accept the workflow name as well as the trigger name,
 which is handy when you know what stopped rather than which trigger drives it.
+
+### Run it now, without waiting for the poll
+
+```bash
+cloacinactl workflow run file_processing
+```
+
+For a trigger declared with `on = "..."` — like this one — that is the way to
+get an immediate run. The trigger owns *when* the workflow runs; running the
+workflow directly bypasses the schedule for a one-off.
+
+`cloacinactl trigger fire` does **not** apply here, and it is worth knowing why,
+because the two look interchangeable and are not:
+
+| Shape | How it is wired | `trigger fire` |
+|---|---|---|
+| `#[trigger(on = "wf")]` (this example) | the trigger names the workflow it drives | **no** — the trigger has no *subscribers* |
+| `#[workflow(triggers = ["t"])]` | workflows subscribe to a named trigger | yes — fans out to every subscriber |
+
+`trigger fire` resolves its targets from the *subscription* side, so firing a
+trigger whose only consumer is its own `on` workflow reports
+`trigger '<name>' has no subscribed workflows`. See CLOACI-T-0929.

--- a/examples/features/workflows/simple-packaged/README.md
+++ b/examples/features/workflows/simple-packaged/README.md
@@ -91,6 +91,39 @@ cloacinactl execution status <execution-id>
 Or watch the run in the web UI at <http://localhost:8080> — executions, task
 states, and the workflow DAG are all there.
 
+## Operate it
+
+`execution list` and `execution status` tell you *where* a run got to. When you
+need to know *what happened and in what order* — which task started when, which
+was skipped, where a retry kicked in — read the event trail.
+
+```bash
+cloacinactl execution events <execution-id>
+```
+
+Each line is one recorded event with its task name and timestamp, in sequence.
+This is the first thing to reach for when a run finished in a state you did not
+expect: the status tells you the outcome, the events tell you the path.
+
+For a run that is still going, tail it live:
+
+```bash
+cloacinactl execution events <execution-id> --follow
+```
+
+That streams events over SSE and keeps printing until you Ctrl-C. Useful on a
+long workflow when you want to watch progress rather than poll `status`.
+
+To look at a window of history instead:
+
+```bash
+cloacinactl execution events <execution-id> --since 5m
+```
+
+`--since` and `--follow` cannot be combined — `--follow` starts from now, so
+there is no cursor to resume from. Take the historical snapshot first, then
+start the live tail if you want both.
+
 ## How the workflow is authored
 
 `src/lib.rs` declares the pipeline with the workflow macro; dependencies

--- a/examples/fixtures/defer-handle-rust/Cargo.toml
+++ b/examples/fixtures/defer-handle-rust/Cargo.toml
@@ -1,0 +1,31 @@
+# TEMPLATE — `__WORKSPACE__` is rewritten to an absolute path by
+# .angreal/cloacina/compiler_e2e.py before packing.
+[workspace]
+
+[package]
+name = "defer-handle-rust"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+default = ["packaged"]
+packaged = []
+
+[dependencies]
+cloacina-macros = { path = "__WORKSPACE__/crates/cloacina-macros" }
+cloacina-computation-graph = { path = "__WORKSPACE__/crates/cloacina-computation-graph" }
+cloacina-workflow = { path = "__WORKSPACE__/crates/cloacina-workflow", features = ["packaged"] }
+cloacina-workflow-plugin = { path = "__WORKSPACE__/crates/cloacina-workflow-plugin" }
+serde_json = "1.0"
+futures = "0.3"
+async-trait = "0.1"
+tracing = "0.1"
+chrono = { version = "0.4", features = ["serde"] }
+uuid = { version = "1.0", features = ["v4"] }
+tokio = { version = "1.0", features = ["time"] }
+
+[build-dependencies]
+cloacina-build = { path = "__WORKSPACE__/crates/cloacina-build" }

--- a/examples/fixtures/defer-handle-rust/build.rs
+++ b/examples/fixtures/defer-handle-rust/build.rs
@@ -1,0 +1,19 @@
+/*
+ *  Copyright 2026 Colliery Software
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+fn main() {
+    cloacina_build::configure();
+}

--- a/examples/fixtures/defer-handle-rust/package.toml
+++ b/examples/fixtures/defer-handle-rust/package.toml
@@ -1,0 +1,14 @@
+# Fixture for packaged `defer_until` (CLOACI-T-0897). A PACKAGED task taking a
+# handle parameter — the shape that failed to compile before the macro learned
+# to dual-emit the handle path.
+[package]
+name = "defer-handle-rust"
+version = "0.1.0"
+interface = "cloacina-workflow-plugin"
+interface_version = 1
+extension = "cloacina"
+
+[metadata]
+workflow_name = "defer_handle_workflow"
+language = "rust"
+description = "packaged defer_until fixture — releases its concurrency slot while waiting"

--- a/examples/fixtures/defer-handle-rust/src/lib.rs
+++ b/examples/fixtures/defer-handle-rust/src/lib.rs
@@ -1,0 +1,73 @@
+/*
+ *  Copyright 2026 Colliery Software
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+// Fixture for packaged `defer_until` (CLOACI-T-0897).
+//
+// This is the shape that could NOT be built before: a PACKAGED task taking a
+// handle parameter. The macro used to emit `::cloacina::take_task_handle()`
+// unconditionally, which does not resolve in a cdylib that links only
+// `cloacina-workflow` — the build failed with a bare `cannot find crate
+// cloacina`. Its existence compiling at all is half the regression net; the
+// other half is the e2e lane observing the slot actually being released.
+//
+// The condition is time-based rather than filesystem-based so the fixture is
+// hermetic: it defers once, then resolves on its own. A file-watch version
+// would need the harness to race a file into place.
+
+use std::time::Duration;
+
+use cloacina_workflow::{task, workflow, Context, TaskError};
+
+cloacina_workflow_plugin::package!();
+
+#[workflow(
+    name = "defer_handle_workflow",
+    description = "packaged defer_until fixture — a task that releases its slot while waiting",
+    author = "defer-e2e"
+)]
+pub mod defer_handle_workflow {
+    use super::*;
+
+    /// Defers until a deadline passes, then records that it resumed.
+    ///
+    /// The handle parameter is the point: obtaining it inside a packaged build
+    /// exercises the plugin-side `TaskHandle`, and `defer_until` drives the
+    /// full callback round trip — set sub_status, release the slot, poll here
+    /// in the plugin, reclaim, restore sub_status.
+    #[task(id = "wait_then_work", retry_attempts = 0)]
+    pub async fn wait_then_work(
+        context: &mut Context<serde_json::Value>,
+        handle: &mut cloacina_workflow_plugin::TaskHandle,
+    ) -> Result<(), TaskError> {
+        // Record the id the host told us we are, so the harness can prove the
+        // plugin received a real task-execution id rather than an empty string.
+        context.insert(
+            "observed_task_execution_id",
+            serde_json::json!(handle.task_execution_id()),
+        )?;
+
+        let deadline = std::time::Instant::now() + Duration::from_millis(1200);
+        handle
+            .defer_until(
+                || async move { std::time::Instant::now() >= deadline },
+                Duration::from_millis(200),
+            )
+            .await?;
+
+        context.insert("deferred_and_resumed", serde_json::json!(true))?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
Closes the tail CLOACI-T-0897 has carried since July. A **packaged** task declaring a handle parameter could not be built — the macro emitted `::cloacina::take_task_handle()` ungated, which doesn't resolve in a cdylib linking only `cloacina-workflow`, so the build died with a bare `cannot find crate cloacina`.

The ticket's own suggested fix ("route through the packaged-safe re-export") **wasn't possible**: `TaskHandle` depends on the DAL, `UniversalUuid`, `ExecutorError` and `SlotToken`, so re-exporting it would drag the engine into the crate packaging exists to keep small.

## What it took

`defer_until` interleaves plugin code (the user's condition) with host state (a semaphore permit and a DB row). fidius's vtable was one-way, so the plugin couldn't ask the host to release its slot mid-execution. **fidius 0.5.7** adds that direction (`#[host_interface]`) — tagged and published off this work.

- **`CloacinaHost`** (3 methods) in `cloacina-workflow-plugin`, behind an off-by-default `host` feature so packaged cdylibs get only the client and never drag in `fidius-host`
- **Deferral registry** — `TaskHandle.slot_token` became a shared `Arc<Mutex<SlotToken>>`, registered by the executor keyed on task-execution UUID. `Arc::ptr_eq` is asserted, since a registry that *cloned* the token would be a double-release bug
- **Packaged `TaskHandle`** with the same surface, driving the callbacks. Sets `sub_status=Deferred` **before** releasing, so an operator never sees a slotless task reported Active
- **Macro dual-emission** — `::cloacina::` under `not(packaged)`, plugin-side handle under `packaged`
- Wire: interface **5 → 7** (`task_execution_id`, then `requires_handle`; both positional bincode)

## Rejected

An inversion workaround — return "deferred", let the host re-invoke. The task would re-run from the top on every poll, repeating external side effects undetectably, with no marker letting it recognise a re-entry. `retry_attempts` tolerance isn't the same contract: authors expect re-execution after a *failure*, not after a successful defer.

## Verified end to end

```
ok: packaged task with a handle parameter BUILT
ok: task observed in Deferred state (host callback ran)
ok: packaged defer_until round-tripped (slot released and reclaimed)
```

Full `angreal test e2e compiler` **EXIT=0** — instances, upgrade, rollback and concurrent-upload lanes all still green. 812 lib tests pass, including all 10 embedded `TaskHandle` tests (the risk of sharing the slot).

## Four bugs the e2e found that unit tests could not

1. **Binding is per dylib image, and there are two loads** — `package_loader` for metadata, `dynamic_task` for execution. Binding only the first meant `defer_until` reported "not bound" *while the log showed a successful bind*
2. **The id was installed by `ThreadTaskExecutor`**, but the server runs a `FleetExecutor` — so it arrived empty. Moved to the **dispatcher**, the one choke point every executor passes through
3. **`DynamicLibraryTask` never implemented `requires_handle()`**, inheriting the default `false`, so the executor skipped the whole handle path. Identical to T-0721's `trigger_rules` bug — a recurring shape worth auditing the other defaulted trait methods against
4. **A second `TaskMetadataEntry` site inside `package!()`** broke every fixture build while `cargo check --workspace` passed clean — macro-expansion errors only appear in a consumer crate

Also includes the T-0899 tail (5 `strip_py_comments` hardening tests) and the Python SDK generator CI gate.

## Note
fidius deps collapsed from **11 scattered `"0.5.6"` literals across 7 crates** to one workspace entry — correctness, not tidiness: the wire is positional bincode, so two fidius versions in one build means two incompatible copies of the FFI types.