### PR TITLE
fix(T-0893): operational-surface coverage — and three broken verbs it found

### DIFF
--- a/.angreal/demos/features/features.py
+++ b/.angreal/demos/features/features.py
@@ -337,7 +337,27 @@ def _run_to_completed(ctl, home, workflow_name, context_path=None, timeout_s=300
 
 def _default_workflow_steps(workflow_name):
     def steps(ctl, home):
-        _run_to_completed(ctl, home, workflow_name)
+        exec_id = _run_to_completed(ctl, home, workflow_name)
+
+        # CLOACI-T-0893: `execution events` is the operator verb for "what
+        # happened, in what order" — the thing you reach for when a run ended
+        # somewhere you did not expect. Asserted on the DEFAULT lane so every
+        # packaged example exercises it, not just the one whose README
+        # documents it.
+        #
+        # `--follow` is deliberately not asserted: it streams over SSE until
+        # Ctrl-C, so a harness step would hang. The non-follow read covers the
+        # same route.
+        _assert_operational_verbs(
+            ctl,
+            [
+                (["execution", "events", str(exec_id)], "execution events"),
+                (
+                    ["execution", "events", str(exec_id), "--since", "1h"],
+                    "execution events --since",
+                ),
+            ],
+        )
 
     return steps
 

--- a/crates/cloacinactl/src/nouns/execution/mod.rs
+++ b/crates/cloacinactl/src/nouns/execution/mod.rs
@@ -116,7 +116,15 @@ impl ExecutionCmd {
                     path.push_str(&format!("?since={s}"));
                 }
                 let body: serde_json::Value = client.get(&path).await?;
-                render::list(&body, output)
+                // CLOACI-T-0893: this route answers with an `ExecutionEventsResponse`
+                // — `{execution_id, tenant_id, events: [..]}` — not the `items`
+                // envelope or bare array `render::list` understands. Passing the
+                // whole body straight through made the command fail 100% of the
+                // time with "list response is neither an `items` envelope nor a
+                // bare array", even though the server had returned every event
+                // correctly. Unwrap to the rows before rendering.
+                let rows = body.get("events").cloned().unwrap_or(body);
+                render::list(&rows, output)
             }
         }
     }


### PR DESCRIPTION
Closes CLOACI-T-0893. Each operational verb now lives in the README of the example that owns the feature, as a verified "Operate it" section, and — the part that matters — **the demos lanes now run every documented command**.

## The headline: `execution events` never worked

```
Error: list response is neither an `items` envelope nor a bare array:
{"events":[...],"execution_id":"...","tenant_id":"public"}
```

The server returned every event correctly; the CLI handed the whole `ExecutionEventsResponse` envelope to `render::list`, which only understands `items` or a bare array. A shipped, documented operator verb — the one you reach for when a run ends somewhere unexpected — failing **100% of the time**.

That sharpens this ticket's premise. T-0893 says the operational half of the primary interface is *"taught nowhere"*; the real finding is **taught nowhere and therefore never run**.

## Three defects the assertions found

| # | Verb | Defect |
|---|---|---|
| 1 | `accumulator inject` | documented as `inject <name> '<json>'`; CLI requires `--event` — the README command could not work |
| 2 | `trigger fire` | resolves targets from the *subscription* side only, so it cannot fire an `on = "..."` trigger → **CLOACI-T-0929** |
| 3 | `execution events` | broken outright — fixed here |

Defect 2 was a false claim in a README **I wrote in this same PR**, caught minutes later by the assertion. That is the mechanism working exactly as intended.

## What shipped

- **`cloacinactl trigger pause | resume | fire`** — existed as server routes with no CLI in front of them
- **`packaged-triggers/README.md`** — the packaged home for the trigger story had no README at all
- **"Operate it" sections** on `simple-packaged` (execution events, incl. `--since`/`--follow` being mutually exclusive) and `cg-feature-tour` (`graph list/status/accumulators`, `accumulator inject`, `reactor fire --input`, `force-fire`)
- **Lane assertions** via a shared `_assert_operational_verbs` helper that fails naming the broken command

## Verified live

```
ok: graph list / graph accumulators
ok: accumulator inject --event
ok: reactor fire --input / reactor force-fire
ok: trigger list / inspect / pause / resume
ok: execution events / execution events --since
```

`execution events` is asserted on the **default** lane, so every auto-discovered packaged example exercises it. `--follow` is deliberately excluded — it streams SSE until Ctrl-C and would hang a harness step; the reasoning is inline so the "gap" isn't later closed into a wedged lane.

## Two latent harness bugs fixed en route

Both `_graph_kafka_steps` and `_trigger_wait_steps` returned on success from **inside** their poll loops, so anything appended after would be silently skipped — green without running. Converted to `break`/`else`. Same shape twice, so worth watching for elsewhere.

## Scope

The tenant/key/fleet bullet is **dropped** by maintainer decision: that story is already taught in `docs/content/service/how-to/configure-multi-tenant-deployment.md`, which is a better home than a workflow example. Migrating `multi-tenant` to duplicate it was rejected.

Trigger verbs did **not** need `event-triggers` migrated — `packaged-triggers` already existed and is packaged; it just had no README.