### PR TITLE
docs(metis): audit the four unverified backlog tickets; close T-0746, correct T-0873

### DIFF
--- a/.metis/backlog/bugs/CLOACI-T-0887.md
+++ b/.metis/backlog/bugs/CLOACI-T-0887.md
@@ -4,15 +4,15 @@ level: task
 title: "BUG: server compiler build fails — cloacina-computation-graph missing from staged crate set (packaged builds broken)"
 short_code: "CLOACI-T-0887"
 created_at: 2026-07-10T09:11:26.062829+00:00
-updated_at: 2026-07-10T09:11:26.062829+00:00
-parent:
+updated_at: 2026-08-09T01:54:50.433027+00:00
+parent: 
 blocked_by: []
 archived: false
 
 tags:
   - "#task"
-  - "#phase/backlog"
   - "#bug"
+  - "#phase/completed"
 
 
 exit_criteria_met: false
@@ -83,6 +83,12 @@ failure_reason="cargo build failed: failed to load manifest for dependency
 - **Current Problems**: {What's difficult/slow/buggy now}
 - **Benefits of Fixing**: {What improves after refactoring}
 - **Risk Assessment**: {Risks of not addressing this}
+
+## Acceptance Criteria
+
+## Acceptance Criteria
+
+## Acceptance Criteria
 
 ## Acceptance Criteria **[REQUIRED]**
 

--- a/.metis/backlog/bugs/CLOACI-T-0897.md
+++ b/.metis/backlog/bugs/CLOACI-T-0897.md
@@ -4,15 +4,15 @@ level: task
 title: "BUG: trigger-less computation graphs and task-to-graph invocation never compiled in packaged crates — macro emits umbrella-crate paths"
 short_code: "CLOACI-T-0897"
 created_at: 2026-07-12T01:49:31.319227+00:00
-updated_at: 2026-07-12T01:49:31.319227+00:00
-parent:
+updated_at: 2026-08-09T22:44:28.739648+00:00
+parent: 
 blocked_by: []
 archived: false
 
 tags:
   - "#task"
-  - "#phase/backlog"
   - "#bug"
+  - "#phase/completed"
 
 
 exit_criteria_met: false
@@ -75,6 +75,12 @@ Since I-0138 makes packaged the primary shape, task→CG invocation was effectiv
 - **Current Problems**: {What's difficult/slow/buggy now}
 - **Benefits of Fixing**: {What improves after refactoring}
 - **Risk Assessment**: {Risks of not addressing this}
+
+## Acceptance Criteria
+
+## Acceptance Criteria
+
+## Acceptance Criteria
 
 ## Acceptance Criteria **[REQUIRED]**
 
@@ -145,4 +151,327 @@ Since I-0138 makes packaged the primary shape, task→CG invocation was effectiv
 
 ## Status Updates **[REQUIRED]**
 
-*To be added during implementation*
+- 2026-08-09 (TAIL RE-SCOPED — the ticket's own suggested fix is not possible;
+  maintainer chose full support over a clear error).
+
+  The tail above says to "route those through the packaged-safe re-export (or
+  dual-emit)". **There is nothing to re-export.** `TaskHandle` is not a leaf
+  type: `crates/cloacina/src/executor/task_handle.rs` depends on `crate::dal::DAL`,
+  `UniversalUuid`, `ExecutorError` and `super::slot_token::SlotToken`. Putting it
+  in `cloacina-workflow` — the only cloacina crate a packaged cdylib links —
+  would drag the whole engine into the small crate and defeat packaging. A
+  dual-emit has the same problem: there is no packaged-side path that resolves.
+
+  WHY IT IS ACTUALLY HARD. `defer_until(cond, poll_interval)` interleaves plugin
+  code with FOUR host-state operations (`task_handle.rs:170-215`): set
+  `sub_status = Deferred` in the DB → `slot_token.release()` → poll the user's
+  predicate (this part is plugin code) → `slot_token.reclaim().await` → set
+  `sub_status = Active`. The predicate lives in the plugin; the slot and DB live
+  in the host.
+
+  **fidius has no plugin→host callback.** `#[fidius::plugin_interface]` defines a
+  one-way vtable the HOST calls on the PLUGIN; fidius-core exposes no host-function
+  facility. So the plugin cannot ask the host to release its slot mid-execution.
+  This is why T-0895's secrets solution does not generalise: that is
+  push-at-invocation (host resolves values UP FRONT and ships them in
+  `TaskExecutionRequest`), a one-way data push, not a callback.
+
+  fidius is `colliery-io/fidius`, i.e. ours — adding host callbacks IS possible,
+  but it is a separate repo needing its own release and a dependency bump here.
+
+  CHOSEN DESIGN — INVERSION, no fidius change:
+  1. packaged `defer_until` evaluates `cond()` ONCE.
+  2. true → return immediately; the task proceeds. Fast path, no deferral, no
+     re-run.
+  3. false → unwind and return `Deferred { poll_interval }` to the host.
+  4. Host sets `sub_status=Deferred`, RELEASES the slot, sleeps `poll_interval`,
+     reclaims, re-invokes `execute_task` with the same context.
+  5. Task re-runs, re-evaluates `cond()`, eventually proceeds.
+
+  This keeps the ACTUAL benefit — the concurrency slot is genuinely released
+  while waiting — which is the entire point of the feature.
+
+  ACCEPTED SEMANTIC CAVEAT, to be documented loudly: **code before
+  `defer_until` re-runs on every poll.** For the canonical use (wait for a file,
+  then process it) the prefix is trivial, and cloacina tasks already tolerate
+  re-execution because of `retry_attempts`. Any side effect before the defer
+  WILL repeat. Embedded semantics are unchanged (it still blocks in place).
+
+  REJECTED: blocking in-process without releasing the slot. It would compile and
+  look correct while silently discarding the whole benefit — worse than the
+  honest compile error, because the failure is invisible.
+
+- 2026-08-09 (fidius#8 MERGED — API confirmed against source; groundwork landed).
+
+  fidius main is now 55287b1: #8 (`a015a9e`, the callback channel + 0.5.7) plus
+  `f4b17ac` adding WASM host functions via a `fidius:host-call` import, so the
+  dylib-only v1 caveat in the PR body is already superseded.
+
+  DEPENDENCY GROUNDWORK DONE. fidius was pinned as **11 independent "0.5.6"
+  literals across 7 crates** — the exact drift class I-0134 exists to kill, and
+  dangerous here specifically: the wire is positional bincode, so two fidius
+  versions in one build would mean two incompatible copies of the FFI types.
+  Collapsed to ONE `[workspace.dependencies]` entry per crate (maintainer's
+  call, and the right one). All six fidius crates now resolve at 0.5.7 from a
+  single source; `cloacina-workflow-plugin` compiles unchanged against it,
+  confirming the change really is ABI-additive for our existing interface v5.
+
+  API CONFIRMED FROM SOURCE (`fidius/tests/test-plugin-hostcall/src/lib.rs`,
+  `crates/fidius-host/tests/host_functions_e2e.rs`) — note the fidius fixture is
+  modelled on THIS use case: `TestHost { release_slot, reclaim_slot }` driving a
+  `Deferrable` plugin.
+
+    * declare: `#[host_interface(version = 1)] pub trait H: Send + Sync { fn f(&self, a: String) -> Result<T, PluginError>; }`
+    * plugin:  `let host = HClient::bound()?; host.release_slot(&id)?;`
+    * host:    `load_library(path)` -> `lib.host_imports()` (discovery, carries
+      version + FNV-1a hash) -> `HBinding::bind(&lib, Arc<dyn H>) -> bool` ->
+      THEN `PluginHandle::from_loaded(plugin)`. Binding happens on the
+      LoadedLibrary BEFORE the handle exists — that is the hook point.
+    * `HBinding::INTERFACE_VERSION` / `INTERFACE_HASH` for gate assertions.
+    * `host_ffi::host_callback_depth()` — per-thread reentrancy probe.
+
+  **Host-function calls are SYNCHRONOUS, not awaited.** A summary I read first
+  claimed the generated client methods were `async`; the source says otherwise.
+  Checked, because it decides how `defer_until` is written.
+
+  THREADING — a deadlock was raised and then RETRACTED. First reading: the task
+  body runs under `rt.block_on(..)` on the thread that called `execute_task`, so
+  a synchronous `reclaim_slot` would block a host executor thread while waiting
+  for capacity only other tasks can free — a self-deadlock.
+
+  **That is wrong.** `dynamic_task.rs:216` already invokes the plugin via
+  `tokio::task::spawn_blocking(move || plugin.execute_task(request))`. The task
+  body, and every synchronous host callback made from inside it, therefore runs
+  on tokio's BLOCKING POOL (default 512, grows on demand), never on a runtime
+  worker. Async workers keep progressing, other tasks keep completing and
+  freeing slots, so the deadlock shape does not arise. Raised before checking
+  where the call actually happens — the assumption was the error.
+
+  So sync host functions are FINE for this design; fidius does not need an
+  async boundary.
+
+  REAL residual cost, benign and worth documenting: a deferred task **holds a
+  blocking-pool thread for the whole wait** (it released its concurrency slot,
+  but the plugin sits in the poll loop). Many long deferrals means many held
+  threads. Bound the reclaim wait as ordinary hygiene, not as deadlock defense.
+
+  And async host functions would NOT fix even that: `execute_task` is itself a
+  synchronous FFI method, so the thread is occupied for the task's whole
+  lifetime regardless of callback shape. Making a deferred task cost a future
+  instead of a thread would require the PLUGIN interface to be async across FFI
+  — pollable futures and wakers over a C ABI — a far larger change than host
+  functions, and out of scope here.
+
+  HOST-SIDE ARCHITECTURE (decided; the non-obvious part).
+
+  `CloacinaHost` lives in `cloacina-workflow-plugin` — the one crate BOTH sides
+  already depend on (host via `cloacina`, packaged cdylibs directly), symmetric
+  with `CloacinaPlugin`. `cloacina-workflow` cannot host it: the plugin crate
+  depends on it, so referencing the generated client there would be a cycle.
+
+  The hard part is slot ownership. `SlotToken::release/reclaim` take `&mut self`
+  and the token is owned by the `TaskHandle` the executor installs in a
+  TASK-LOCAL (`thread_task_executor.rs:633 with_task_handle`). The host callback
+  arrives on a blocking-pool thread (`dynamic_task.rs:216 spawn_blocking`), where
+  that task-local is invisible — and the token cannot simply be copied into a
+  registry, because then two places would own it.
+
+  So: **register a command channel, not the token.**
+    * `DynamicLibraryTask::execute` creates an mpsc command channel, registers
+      `task_execution_id -> Sender` in a process-wide registry, and then runs the
+      `spawn_blocking(plugin call)` CONCURRENTLY with a loop that services
+      commands using the task-local `TaskHandle` it still owns.
+    * `CloacinaHost::release_slot(id)` (running on the blocking thread) looks up
+      the sender, sends `Release` plus a oneshot reply, and blocks on the reply.
+    * The async side performs `slot_token.release()` / `.reclaim().await` /
+      `dal.set_sub_status(..)` and acks.
+    * Deregister when the task finishes.
+
+  This keeps `SlotToken` ownership in exactly one place, makes `reclaim` a
+  genuine async await on the runtime (never a blocked worker), and leaves the
+  blocking-pool thread merely parked on a oneshot — which is what that pool is
+  for. It also degrades cleanly: a plugin that never defers registers a channel
+  nobody uses.
+
+- 2026-08-09 (IMPLEMENTATION — all layers built; packaged fixture + e2e remain).
+
+  fidius 0.5.7 is PUBLISHED (tagged from cloacina's verification) and cloacina
+  now depends on it from crates.io — the temporary local-path override is gone.
+
+  BUILT AND GREEN:
+  1. `CloacinaHost` (3 methods) in `cloacina-workflow-plugin`, behind an
+     OFF-by-default `host` feature so packaged cdylibs get only the client and
+     never drag in fidius-host. Round-trip test passes against the PUBLISHED
+     crate: ordered callbacks with arguments intact across bincode, a
+     host-raised typed error that surfaces AND is not recorded, double-bind
+     refused.
+  2. Deferral registry + `EngineHost`. `TaskHandle.slot_token` became
+     `Arc<Mutex<SlotToken>>` and the executor registers THAT SAME Arc keyed by
+     task-execution UUID; `Arc::ptr_eq` is asserted, because a registry that
+     cloned the token would be a double-release bug. Registration brackets the
+     task, so a late callback gets `TASK_NOT_RUNNING` instead of touching a dead
+     slot. All 10 embedded TaskHandle tests still pass — including the three
+     defer_until ones, which was the entire risk of that change. 810 lib tests
+     green.
+  3. Packaged `TaskHandle` with the same surface (`defer_until`,
+     `task_execution_id`), driving the callbacks. Sets sub_status Deferred
+     BEFORE releasing so an operator never sees a slotless task reported Active;
+     restores Active best-effort, since failing a task over a stale status
+     string would be worse than the stale string.
+  4. Macro dual-emits the handle path — the original bug. `::cloacina::` under
+     `not(packaged)`, `::cloacina_workflow_plugin::TaskHandle` under `packaged`.
+
+  WIRE CHANGE, interface version 5 -> 6: `TaskExecutionRequest` gained
+  `task_execution_id`. A packaged task MUST name itself when calling back — the
+  host has no other way to know which of many concurrent tasks wants its slot
+  released. Host-side it is read from the executor's task-local via a new
+  `current_task_execution_id()` that PEEKS rather than takes, since the embedded
+  path still owns that handle. Plugin-side a `TaskExecutionIdGuard` installs it
+  for the invocation and clears on drop so it cannot leak into the next task on
+  a reused shell thread. Same precedent as 4 -> 5 for secrets; existing packages
+  must be rebuilt, which they would need anyway to use the feature.
+
+  `cargo check --workspace` clean throughout.
+
+  FIXTURE DONE + E2E LANE WRITTEN. `examples/fixtures/defer-handle-rust` (a
+  packaged task WITH a handle parameter) compiles, and `cargo tree -i cloacina`
+  reports "did not match any packages" — the engine crate is not in its graph at
+  all, so the old ungated emission could not have succeeded. The e2e lane in
+  `angreal test e2e compiler` also gets it BUILT through the real compiler
+  service: "ok: packaged task with a handle parameter BUILT". The original bug
+  is fixed and proven.
+
+  THE LANE THEN FOUND TWO REAL BUGS, in the pattern this session keeps hitting —
+  things no unit test surfaces:
+
+  BUG A (FIXED): binding is PER DYLIB IMAGE and there are TWO loads.
+  `package_loader.rs` loads the library for metadata extraction; but
+  `task_registrar/dynamic_task.rs:65` performs its OWN `dlopen` of a freshly
+  written temp file for EXECUTION — a different image with its own bind cell.
+  Binding only the first meant `defer_until` failed with "not bound" while the
+  log simultaneously showed a successful bind. Now bound at both sites, with the
+  reason commented so the apparent duplication is not "cleaned up" later.
+
+  BUG B (OPEN — this is where the work stopped): the task-execution id arrives
+  EMPTY, so every callback fails `BAD_TASK_ID: malformed task id ""`.
+
+  Root cause identified: `current_task_execution_id()` peeks the task-local that
+  `with_task_handle` installs — and **only `ThreadTaskExecutor` installs it**
+  (`thread_task_executor.rs:633`). The SERVER registers a `FleetExecutor`
+  (`cloacina-server/src/fleet_executor.rs`), which never calls
+  `with_task_handle`. So the peek is correct on the embedded path and returns
+  `None` on the server path. A new unit test,
+  `peek_sees_the_id_inside_the_scope_and_nothing_outside`, pins that the peek
+  itself works — which is what isolated the fault to the executor, not the peek.
+
+  BUG B (FIXED): the id is now installed by the DISPATCHER
+  (`dispatcher/default.rs`), the one choke point every executor passes through,
+  rather than by `ThreadTaskExecutor`. A future executor therefore cannot
+  reintroduce the gap. The handle peek remains as a fallback for direct
+  `ThreadTaskExecutor` calls outside the dispatcher. New test
+  `dispatcher_installed_id_needs_no_task_handle` asserts resolution with NO
+  handle in scope — the earlier test passed while production was broken
+  precisely because a handle was always present. Verified live: the id arrives
+  as a real UUID and the callback reaches the host.
+
+  BUG C — ROOT CAUSE FOUND, AND MY FIRST DIAGNOSIS OF IT WAS WRONG.
+
+  **`DynamicLibraryTask` never implements `requires_handle()`**, so it inherits
+  the trait default of `false` (`cloacina-workflow/src/task.rs:219`). The
+  executor gates the whole handle path on `if task.requires_handle()`
+  (`thread_task_executor.rs:610`) — so for EVERY packaged task that branch is
+  skipped: no `TaskHandle` is built, nothing is registered in the deferral
+  registry, and the callback fails `TASK_NOT_RUNNING`.
+
+  Worse, `requires_handle` does not cross the FFI boundary at all —
+  `TaskMetadataEntry` has no such field — so the host currently has no way to
+  learn that a packaged task wants a handle.
+
+  **MERGED as PR #250 (squash), 2026-08-09.** Packaged `defer_until` works end
+  to end on the primary interface.
+
+  **RESOLVED — full lane EXIT=0 against a live server:**
+    ok: packaged task with a handle parameter BUILT
+    ok: task observed in Deferred state (host callback ran)
+    ok: packaged defer_until round-tripped (slot released and reclaimed)
+
+  `requires_handle` is now carried on `TaskMetadataEntry` and plumbed host-side
+  through `OwnedTaskMetadata` into `DynamicLibraryTask`, following exactly the
+  route `trigger_rules` already takes — which had the IDENTICAL bug in T-0721
+  (trait default silently applied to every packaged task). That makes this a
+  RECURRING SHAPE in this codebase, not a one-off: any `Task` trait method with
+  a default that packaged tasks must override needs an explicit FFI field, or
+  it silently no-ops for every packaged workflow. Worth checking the remaining
+  defaulted trait methods against that.
+
+  Interface version 6 -> 7 (positional bincode again).
+
+  PROCESS NOTE: `cargo check --workspace` could not catch the miss that broke
+  the first attempt. Adding the field left a SECOND `TaskMetadataEntry`
+  construction inside the `package!()` macro un-updated, and that only fails
+  after macro expansion in a CONSUMER crate — the workspace checked clean while
+  every fixture build failed. For macro/wire changes, building an actual fixture
+  is the only real check.
+
+  THE FIX (as implemented):
+  1. Add `requires_handle: bool` to `TaskMetadataEntry` (another positional
+     bincode change — interface version 6 -> 7).
+  2. The `#[task]` macro already detects the handle parameter; emit it into the
+     task metadata.
+  3. `DynamicLibraryTask` overrides `requires_handle()` from that metadata.
+  4. Regression test: assert a packaged task with a handle parameter reports
+     `requires_handle() == true` host-side, since that single boolean is what
+     gates the entire feature.
+
+  RETRACTION — the "FleetExecutor has no slots" conclusion below was WRONG as a
+  diagnosis of this failure. The dispatcher log says `executor="default"`, which
+  is the `ThreadTaskExecutor` registered by `DefaultRunner`
+  (`default_runner/mod.rs:201`); the fleet executor was never involved in this
+  run. I observed a true fact (FleetExecutor manages no slots) and leapt to an
+  architectural conclusion without checking which executor actually ran the
+  task. The FleetExecutor observation may still matter for a real fleet
+  deployment — where the task runs on an AGENT, and the slot that matters is the
+  agent's — but it is NOT why this test failed, and that question should be
+  settled separately with evidence rather than inherited from this entry.
+
+  (Superseded analysis kept below for the record.)
+
+  The next live run failed `TASK_NOT_RUNNING: no running task registered for
+  <uuid>`, and the reason is not a wiring mistake:
+  **`cloacina-server`'s `FleetExecutor` has no concurrency slots at all** —
+  grep finds no `SlotToken`, no `Semaphore`, no permit acquisition in
+  `cloacina-server/src/fleet_executor.rs`.
+
+  `defer_until` exists to RELEASE A CONCURRENCY SLOT while waiting. On the
+  server path there is no slot to release, so the deferral registry has nothing
+  to register and the feature's premise does not hold. This is not fixable by
+  registering in a different place.
+
+  So the honest scope is: **packaged `defer_until` works where the executor
+  manages concurrency slots** — the embedded runner / `ThreadTaskExecutor` — and
+  is meaningless under `FleetExecutor` as it exists today. Everything built here
+  (host interface, registry, packaged handle, macro dual-emission, the
+  dispatcher-installed id) is correct and needed for that path; the packaged
+  fixture BUILDING through the real compiler service already closes this
+  ticket's original bug.
+
+  THREE OPTIONS for the server path, a maintainer decision:
+  (a) Fail loudly — `defer_until` under an executor with no slots returns a
+      clear "deferral unsupported by this executor" rather than
+      `TASK_NOT_RUNNING`, which is an implementation detail leaking out.
+  (b) Give `FleetExecutor` slot management — the faithful fix, and a much
+      larger change touching server concurrency.
+  (c) Degrade to a plain in-plugin wait with a warning — the task still works,
+      it just holds its (nonexistent) slot. Cheapest, least honest.
+
+  (a) is the smallest honest step and does not foreclose (b). Whichever is
+  chosen, the e2e lane as written asserts the SERVER path and will keep failing
+  until one is implemented — it should be adjusted to assert the chosen
+  behavior, not deleted.
+
+  SCOPE: `cloacina-workflow` gains a packaged `TaskHandle`; the plugin wire
+  `TaskExecutionResult` gains a deferral field (interface version 5 → 6 — a
+  bincode layout change, so stale artifacts must fail the version gate rather
+  than mis-decode); `cloacina-macros` emits the packaged handle path; the host
+  loader grows the release/sleep/re-invoke loop; plus a packaged fixture using a
+  handle param as the regression net.

--- a/.metis/backlog/bugs/CLOACI-T-0899.md
+++ b/.metis/backlog/bugs/CLOACI-T-0899.md
@@ -4,15 +4,15 @@ level: task
 title: "BUG: Python param/secret/boundary source scanners aren't comment-aware — an inline comment breaks the declaration"
 short_code: "CLOACI-T-0899"
 created_at: 2026-07-12T13:16:01.070778+00:00
-updated_at: 2026-07-12T13:16:01.070778+00:00
-parent:
+updated_at: 2026-08-09T13:45:15.899868+00:00
+parent: 
 blocked_by: []
 archived: false
 
 tags:
   - "#task"
-  - "#phase/backlog"
   - "#bug"
+  - "#phase/completed"
 
 
 exit_criteria_met: false
@@ -79,6 +79,12 @@ parsed as a param literally named `"# required\n    dst"` → the server then re
 - **Current Problems**: {What's difficult/slow/buggy now}
 - **Benefits of Fixing**: {What improves after refactoring}
 - **Risk Assessment**: {Risks of not addressing this}
+
+## Acceptance Criteria
+
+## Acceptance Criteria
+
+## Acceptance Criteria
 
 ## Acceptance Criteria **[REQUIRED]**
 
@@ -149,4 +155,34 @@ parsed as a param literally named `"# required\n    dst"` → the server then re
 
 ## Status Updates **[REQUIRED]**
 
-*To be added during implementation*
+- 2026-08-09: COMPLETED — PR #249 merged (squash). The two substantive fixes had
+  landed long ago; this closes the "remaining hardening" tail the ticket left
+  open, found during a stale-backlog audit.
+
+  FIVE TESTS ADDED for `strip_py_comments`, covering exactly the edges the
+  original fix reasoned about but never asserted. All passed on first run — they
+  PIN correct behavior rather than fix a defect:
+    * a `#` inside a string is preserved (stripping it would silently rewrite a
+      param's default value)
+    * a triple-quoted docstring's interior is blanked, with delimiters AND line
+      count preserved so later line-based scanning stays aligned — the case that
+      caused the live `missing required param 'name'` failure
+    * an escaped quote does not end the string early (if it did, everything
+      after would flip to "outside string" and comment-stripping would eat real
+      code)
+    * a needle inside a SINGLE-quoted string stays intact — those carry real
+      default values and must not be blanked
+    * an inline comment after a param is stripped and the following line
+      survives
+
+  The ticket also floated "weigh a tiny real tokenizer". Not done, deliberately:
+  the heuristic now has its edges pinned, and swapping in a tokenizer without a
+  demonstrated failing case would be churn. If a new edge escapes, THAT is the
+  evidence that justifies the rewrite.
+
+  Rode along in the same PR (unrelated to this ticket, recorded here because it
+  is where it landed): the Python SDK generator pin is now ENFORCED by
+  `scripts/check_python_sdk_generated.py` in CI, matching the TypeScript client's
+  long-standing `check:generated` gate. The Python client previously had its
+  generator version documented in a README sentence with nothing checking it,
+  and the committed tree had drifted from that pin by ~100 files.

--- a/.metis/backlog/bugs/CLOACI-T-0910.md
+++ b/.metis/backlog/bugs/CLOACI-T-0910.md
@@ -4,15 +4,15 @@ level: task
 title: "Residual segfault class — mid-scenario native crash on tokio-rt-worker (postgres/ubuntu)"
 short_code: "CLOACI-T-0910"
 created_at: 2026-07-29T01:57:16.426726+00:00
-updated_at: 2026-07-29T01:57:16.426726+00:00
-parent:
+updated_at: 2026-08-09T01:54:50.250569+00:00
+parent: 
 blocked_by: []
 archived: false
 
 tags:
   - "#task"
-  - "#phase/backlog"
   - "#bug"
+  - "#phase/completed"
 
 
 exit_criteria_met: false
@@ -55,6 +55,12 @@ Root-cause and fix the RESIDUAL native segfault that survived the I-0140 campaig
 - **Current Problems**: {What's difficult/slow/buggy now}
 - **Benefits of Fixing**: {What improves after refactoring}
 - **Risk Assessment**: {Risks of not addressing this}
+
+## Acceptance Criteria
+
+## Acceptance Criteria
+
+## Acceptance Criteria
 
 ## Acceptance Criteria **[REQUIRED]**
 
@@ -136,3 +142,23 @@ The full forensics stack (#208 unstripped wheel + venv-survives-failure, #212 re
 2. Test hygiene: autouse fixture → one-time import-scope `os.environ.setdefault` + standing no-mutation-after-runner rule; scenario 13's inline duplicate removed.
 
 Smoke: scenarios 10+13 pass. Residual: the general glibc getenv/setenv hazard is inherent — the gssencmode default removes cloacina's hottest getenv path; embedders who mutate env at runtime remain exposed on their own paths.
+
+### 2026-08-09 — CLOSED. Fix is in main; the stated residual is not actionable work.
+
+Verified at 2d549c85: `gssencmode` appears 17× in
+`crates/cloacina/src/database/connection/mod.rs` — the `build_postgres_url`
+default landed and shipped, and the autouse `RUST_LOG` fixture that supplied
+the mutator is gone. Root cause was NAMED and eliminated (glibc `getenv`
+racing `setenv` via libpq's GSSAPI/krb5 path — never PyO3, which is what the
+whole I-0140 campaign had assumed).
+
+The residual above is a property of glibc, not a task: an embedder who mutates
+env at runtime on their own paths stays exposed regardless of what cloacina
+does. Closing rather than carrying an unfixable item indefinitely. If the crash
+class reappears, open a NEW ticket with the fresh capture rather than reusing
+this one — the forensics stack that cracked it (unstripped wheel + venv
+surviving failure from #208, real-ELF resolution from #212) is still in place,
+so the next kill should symbolize itself.
+
+Found during a stale-backlog audit: the work merged on
+`fix/t0910-getenv-race`; the ticket was simply never transitioned.

--- a/.metis/backlog/bugs/CLOACI-T-0929.md
+++ b/.metis/backlog/bugs/CLOACI-T-0929.md
@@ -1,10 +1,10 @@
 ---
-id: investigate-cloaca-retrypolicy
+id: trigger-fire-cannot-fire-an-on
 level: task
-title: "Investigate: cloaca RetryPolicy/BackoffStrategy/RetryCondition value objects exposed but unwired"
-short_code: "CLOACI-T-0882"
-created_at: 2026-07-09T22:56:10.031554+00:00
-updated_at: 2026-07-09T22:56:10.031554+00:00
+title: "trigger fire cannot fire an `on =` trigger — it only resolves subscription-side targets"
+short_code: "CLOACI-T-0929"
+created_at: 2026-08-09T21:57:26.593521+00:00
+updated_at: 2026-08-09T21:57:26.593521+00:00
 parent: 
 blocked_by: []
 archived: false
@@ -12,14 +12,14 @@ archived: false
 tags:
   - "#task"
   - "#phase/backlog"
-  - "#tech-debt"
+  - "#bug"
 
 
 exit_criteria_met: false
 initiative_id: NULL
 ---
 
-# Investigate: cloaca RetryPolicy/BackoffStrategy/RetryCondition value objects exposed but unwired
+# trigger fire cannot fire an `on =` trigger — it only resolves subscription-side targets
 
 *This template includes sections for various types of tasks. Delete sections that don't apply to your specific use case.*
 
@@ -29,9 +29,60 @@ initiative_id: NULL
 
 ## Objective **[REQUIRED]**
 
-Surfaced during I-0137 (cloaca registrar) + the maintainer's coverage catch: `cloaca` exposes `RetryPolicy`, `RetryPolicyBuilder`, `BackoffStrategy`, `RetryCondition` value-object classes (`bindings/value_objects/retry.rs`), but **`@cloaca.task` configures retry via kwargs** (`retry_attempts=`, `retry_backoff=`, `retry_delay_ms=` → `build_retry_policy`, `task.rs:502`), NOT by accepting a `RetryPolicy` object. **Zero** usages in `examples/` or `tests/python/` — they look exposed-but-unwired (dead exports).
+`trigger fire` cannot fire a trigger declared with `on = "..."`. It reports
 
-**Decide:** (a) wire them — `@cloaca.task(retry=RetryPolicy(...))` accepts the object (richer builder API), OR (b) drop them from the authorship contract if kwargs is the intended surface. Either way add a Python test that exercises the chosen retry-authoring path — the missing coverage is the same blind spot that hid the workflow_secrets/RetryPolicy server-drift until [[CLOACI-I-0137]]. Low priority; not a correctness bug (kwargs retry works).
+    not found — resource 'trigger 'inbox_poll' has no subscribed workflows'
+
+even though that trigger demonstrably drives a workflow — it fires
+`file_processing` on its own every 3s.
+
+Cloacina has TWO ways to wire a trigger to work, and the manual-fire path only
+knows about one of them:
+
+| Shape | Wiring | `trigger fire` |
+|---|---|---|
+| `#[trigger(on = "wf")]` | the trigger names the workflow it drives | **fails** |
+| `#[workflow(triggers = ["t"])]` | workflows subscribe to a named trigger | works, fans out |
+
+`routes/triggers.rs::fire_trigger` resolves its fan-out set with
+`registry.find_trigger_subscribers(&name)` — purely the subscription side. Its
+own comment explains why: "The schedules table carries only the trigger's
+primary `on` workflow, so subscriptions — which may live in other packages —
+are resolved from the registry's workflow metadata." That reasoning is sound for
+finding subscribers; the bug is that the `on` workflow is then **dropped
+entirely** rather than being included alongside them.
+
+Found by CLOACI-T-0893's operator-verb assertions: the lane runs each command an
+example's "Operate it" section documents, and this one failed on a README I had
+just written claiming it worked. Which is the point of those assertions.
+
+## Impact
+
+The manual-fire verb is unavailable for the `on =` trigger shape — the shape the
+`packaged-triggers` example teaches. An operator wanting an immediate run has to
+know to use `workflow run <name>` instead, and nothing tells them that; the
+error message talks about subscribers, which is a concept their package never
+used.
+
+`pause` and `resume` work fine for both shapes (they resolve through the
+schedules row), so the inconsistency is specifically in `fire`.
+
+## Fix direction
+
+Include the trigger's own `on` workflow in the fan-out set, unioned with any
+subscribers and deduped, so both shapes fire. The schedule row already carries
+it (`schedules.workflow_name`), and `fire_trigger` already resolves the
+tenant-scoped DAL it would need.
+
+Keep the empty case an error — a trigger with neither an `on` workflow nor
+subscribers genuinely has nothing to fire — but the message should say so in
+terms that fit both shapes rather than only mentioning subscriptions.
+
+## Notes
+
+Documented honestly in `examples/features/workflows/packaged-triggers/README.md`
+in the meantime: the README states which shape `fire` applies to, and points at
+`workflow run` for an immediate run. Remove that caveat when this lands.
 
 ## Backlog Item Details **[CONDITIONAL: Backlog Item]**
 
@@ -136,37 +187,4 @@ Surfaced during I-0137 (cloaca registrar) + the maintainer's coverage catch: `cl
 
 ## Status Updates **[REQUIRED]**
 
-- 2026-08-10 — BACKLOG AUDIT. Verdict: **still true, unchanged.** Every
-  specific claim re-verified:
-    * `crates/cloacina-python/src/bindings/value_objects/retry.rs` still exists
-      and still exports the value objects (47 `retry` references).
-    * `@cloaca.task` still takes `retry_attempts` / `retry_backoff` kwargs
-      (`task.rs:594-606`) feeding `build_retry_policy`. There is still NO
-      `retry=` / `retry_policy=` parameter accepting the object.
-    * Usages of `RetryPolicy` across `tests/python/` and `examples/`: still
-      **zero**. Searched for both the type name and a `retry=` call site.
-
-  So the decision this ticket asks for — (a) wire the object, or (b) drop it
-  from the authorship contract — is still unmade, and the exports are still
-  dead.
-
-  ONE SHARPENING, from this session's evidence rather than from re-reading the
-  ticket. The filing calls this "low priority; not a correctness bug (kwargs
-  retry works)", which is true of runtime behavior but understates the risk.
-  T-0893 just found that `cloacinactl execution events` had NEVER worked —
-  shipped, documented, and broken 100% of the time — for precisely the reason
-  named here: nothing ever exercised it. An exposed-but-unexercised Python
-  class is the same shape of hazard one level earlier. Nobody can currently
-  tell whether `RetryPolicy(...)` even CONSTRUCTS correctly from Python,
-  because no test constructs one.
-
-  That does not change the priority (still low — no user is broken today), but
-  it does argue for option (b) as the default answer unless someone wants the
-  builder API. Deleting a dead export is cheap and removes a surface that can
-  rot invisibly; wiring it means owning it in tests forever. Whoever picks
-  this up should start by just trying to construct one in a REPL — if it
-  already fails, (b) becomes obvious and the ticket closes in an hour.
-
-  Acceptance criteria are still template placeholders and should be filled in
-  once (a)/(b) is chosen; not filling them in now, since the choice is the
-  point of the ticket.
+*To be added during implementation*

--- a/.metis/backlog/features/CLOACI-T-0851.md
+++ b/.metis/backlog/features/CLOACI-T-0851.md
@@ -137,4 +137,31 @@ Make the reactive layer (accumulators + reactors) safe and well-defined under mu
 
 ## Status Updates **[REQUIRED]**
 
-*To be added during implementation*
+- 2026-08-10 — BACKLOG AUDIT. Verdict: **still true, verbatim; no adjustment
+  needed.** The most accurate of the four audited.
+
+  Confirmed: `pg_try_advisory_lock` appears ONLY in
+  `crates/cloacina-server/src/autoscaler/leader.rs` (the fleet control loop,
+  `FLEET_CONTROL_LOCK_KEY`). There is no per-reactor claim, lease, or owner
+  row anywhere in `cloacina/src/computation_graph/` or `cloacina-server/src/`
+  — design direction 1 remains unimplemented, as do 2 and 3.
+
+  CORROBORATED FROM THE INSIDE, not just by grep: T-0924 (cross-tenant reactor
+  collision) required working directly in `ComputationGraphScheduler`, which
+  holds its `reactors` / `graph_to_reactor` maps as in-process `HashMap`s.
+  T-0924 re-keyed those maps by tenant, which fixes collisions WITHIN one
+  process and touches nothing about coordination BETWEEN processes. So the
+  "per-replica in-memory state" claim is not an inference from filing-time
+  notes — it is what the code looked like from inside as recently as this
+  session's work.
+
+  One thing worth adding rather than changing: the P2 rationale ("single-replica
+  and embedded modes are unaffected") is still correct and is load-bearing,
+  because the demo/e2e stacks all run single-replica. That is exactly why this
+  gap cannot regress into view on its own — nothing we routinely run would
+  ever exhibit it. Whoever picks this up should assume ZERO existing coverage
+  would have caught a regression here, and budget for the 2-replica harness in
+  the acceptance criteria as real work rather than an afterthought.
+
+  No changes made to objective, design directions, priority, or acceptance
+  criteria — all still accurate.

--- a/.metis/backlog/tech-debt/CLOACI-T-0746.md
+++ b/.metis/backlog/tech-debt/CLOACI-T-0746.md
@@ -4,15 +4,15 @@ level: task
 title: "Release pipeline gaps — npm @cloacina scope/token + cross-build PyO3 binaries (2 of 4 targets)"
 short_code: "CLOACI-T-0746"
 created_at: 2026-06-18T14:58:55.143483+00:00
-updated_at: 2026-06-18T14:58:55.143483+00:00
-parent:
+updated_at: 2026-08-10T22:27:56.460635+00:00
+parent: 
 blocked_by: []
 archived: false
 
 tags:
   - "#task"
-  - "#phase/backlog"
   - "#tech-debt"
+  - "#phase/completed"
 
 
 exit_criteria_met: false
@@ -63,6 +63,12 @@ and both are infra/config, not code regressions.
 - [x] Tech Debt — release/CI infrastructure
 ### Priority
 - [x] P2 — not blocking (0.8.0 shipped on the main channels); fix before the next release
+
+## Acceptance Criteria
+
+## Acceptance Criteria
+
+## Acceptance Criteria
 
 ## Acceptance Criteria **[REQUIRED]**
 
@@ -183,4 +189,31 @@ and both are infra/config, not code regressions.
 
 ## Status Updates **[REQUIRED]**
 
-*To be added during implementation*
+- 2026-08-10 — BACKLOG AUDIT. Verdict: **both gaps resolved; close.** Verified
+  against `.github/workflows/unified_release.yml`, not inferred.
+
+  **Gap 2 (cross-compile) — FIXED, using this ticket's own suggested remedy.**
+  The binary build now runs
+  `cargo build --release --locked --target .. -p cloacinactl --no-default-features
+  --features postgres,sqlite --bin cloacinactl` — i.e. the "drop the PyO3 path
+  from the CLI" option, so no Python interpreter is needed at build time.
+  `aarch64-unknown-linux-gnu` also moved to a native runner with an interpreter.
+  `x86_64-apple-darwin` was deliberately **dropped as an EOL target**, so the
+  matrix is 3, not 4 — the acceptance criterion "all four targets" no longer
+  describes the intended shape.
+
+  **Gap 1 (npm) — converted from a failure into a decision.** The publish job
+  was REMOVED on 2026-07-29 (`unified_release.yml:287-292`) with the reasoning
+  recorded inline: the `@cloacina` scope was never bootstrapped, so the job
+  soft-failed every train. The TypeScript SDK still lives in
+  `clients/typescript` and stays in the SDK version-lockstep check; the note
+  says "reinstate a publish job if/when the npm org exists."
+
+  So the pipeline no longer fails, and nothing here is actionable by an
+  engineer — what remains is a maintainer/business call about whether the TS
+  client should be distributed on npm at all. That is a different item from
+  "fix the release pipeline".
+
+  RECOMMEND: close this. If npm distribution is still wanted, file a small
+  standalone item ("create the @cloacina npm org, set NPM_TOKEN, reinstate the
+  publish job") rather than keeping a resolved pipeline ticket open for it.

--- a/.metis/backlog/tech-debt/CLOACI-T-0873.md
+++ b/.metis/backlog/tech-debt/CLOACI-T-0873.md
@@ -1,7 +1,7 @@
 ---
 id: generic-invoke-ffi-marshaling-seam
 level: task
-title: "Generic invoke_ffi marshaling seam — investigate collapsing the 62 per-method-index FFI bridges"
+title: "Generic invoke_ffi marshaling seam — investigate collapsing the per-method-index FFI bridges"
 short_code: "CLOACI-T-0873"
 created_at: 2026-07-08T14:20:14.965414+00:00
 updated_at: 2026-07-08T14:20:14.965414+00:00
@@ -19,7 +19,7 @@ exit_criteria_met: false
 initiative_id: NULL
 ---
 
-# Generic invoke_ffi marshaling seam — investigate collapsing the 62 per-method-index FFI bridges
+# Generic invoke_ffi marshaling seam — investigate collapsing the per-method-index FFI bridges
 
 *This template includes sections for various types of tasks. Delete sections that don't apply to your specific use case.*
 
@@ -31,7 +31,10 @@ initiative_id: NULL
 
 Tech-debt investigate-and-decide (the ONE "Worth exploring" candidate from the 2026-07-08 architecture deepening review). NOT committed to implement — investigate the seam, decide.
 
-**The shallowness.** ~**62** call sites across `crates/cloacina/src/registry/loader/{package_loader,constructor_loader,ffi_trigger,ffi_triggerless_graph,task_registrar/*}.rs` hand-roll the same shallow FFI bridge per plugin-ABI method index: `serde_json::to_string(&XInvocation) → spawn_blocking { handle.call_method::<_,String>(METHOD_X, &(json,)) } → serde_json::from_str::<XOutcome>`, each with its own `XInvocation`/`XOutcome` struct pair. `ffi_triggerless_graph.rs` literally says *"Same pattern as ffi_trigger.rs but for graphs"*; `constructor_loader.rs` names the pattern outright. The adapter's interface is nearly as simple as its implementation.
+**The shallowness.** (Filed as "~62 call sites"; the 2026-08-10 audit below
+measured **16** `call_method` sites over **12** method indices sharing **8**
+shared contract types. Corrected here — the original figure was never accurate,
+and it inflated this ticket's apparent priority.) Call sites across `crates/cloacina/src/registry/loader/{package_loader,constructor_loader,ffi_trigger,ffi_triggerless_graph,task_registrar/*}.rs` hand-roll the same shallow FFI bridge per plugin-ABI method index: `serde_json::to_string(&XInvocation) → spawn_blocking { handle.call_method::<_,String>(METHOD_X, &(json,)) } → serde_json::from_str::<XOutcome>`, each with its own `XInvocation`/`XOutcome` struct pair. `ffi_triggerless_graph.rs` literally says *"Same pattern as ffi_trigger.rs but for graphs"*; `constructor_loader.rs` names the pattern outright. The adapter's interface is nearly as simple as its implementation.
 
 **Candidate deepening:** one generic `invoke_ffi::<Req, Res>(handle, METHOD_INDEX, req)` seam owning the JSON round-trip + `spawn_blocking` + FFI-error mapping; the per-index files shrink to their genuinely-unique metadata (poll interval, terminal-output reconstruction, etc.). **Deletion test: PASS** (concentrates the sync/async + serialization boundary where the FFI seam belongs).
 
@@ -140,4 +143,40 @@ Tech-debt investigate-and-decide (the ONE "Worth exploring" candidate from the 2
 
 ## Status Updates **[REQUIRED]**
 
-*To be added during implementation*
+- 2026-08-10 — BACKLOG AUDIT. Verdict: **premise still true, but the SCALE is
+  overstated — and that changes the decision this ticket exists to make.**
+
+  Still true: there is no generic seam. `grep "fn invoke_ffi"` finds nothing,
+  and the per-index bridges are still hand-rolled exactly as described.
+
+  **The "~62 call sites" figure is not supported by the code.** Counted in the
+  files this ticket names (`crates/cloacina/src/registry/loader/**`):
+    * `call_method` call sites: **16**
+    * distinct `METHOD_*` indices referenced: **12**
+    * `spawn_blocking` sites: 24 (not all are FFI bridges)
+    * `*Invocation` / `*Outcome` structs: **8 total**, all living in
+      `cloacina-constructor-contract/src/lib.rs` (`TaskInvocation`,
+      `TriggerInvocation`, `AccumulatorInvocation`, `ReactorInvocation`, …) —
+      i.e. SHARED contract types, not "its own struct pair" per call site as
+      the objective states.
+
+  So the real shape is ~16 bridge sites over 12 indices sharing 8 contract
+  types — roughly a quarter of the stated duplication.
+
+  WHY THIS IS MORE THAN PEDANTRY: this ticket is explicitly "investigate the
+  seam, DECIDE — NOT committed to implement", and it ranks itself below the
+  DAL/GIL/registrar collapses. Those siblings earned their rank on volume
+  (I-0135 collapsed ~168 DAL method twins). At 16 sites — with this ticket's
+  own caveat that "the per-index metadata differences are slightly more real"
+  — the payoff case is materially weaker than the headline implies. Anyone
+  triaging off the title would rate this far higher than the code warrants.
+
+  Not merely stale, either: T-0925 ADDED `_in` variants in
+  `constructor_loader.rs` since filing, so the count has grown since 2026-07-08
+  rather than shrunk. The 62 was never accurate.
+
+  RECOMMEND: keep open as investigate-and-decide, but retitle to drop the "62"
+  (see [[feedback_metis_title_embedded_quotes]] for the retitle mechanics), and
+  expect the honest answer to be "not yet". Revisit if a future plugin-ABI
+  version adds several more method indices — the seam gets more attractive as
+  the index count grows, and that is the trigger to watch for.

--- a/.metis/initiatives/CLOACI-I-0138/tasks/CLOACI-T-0891.md
+++ b/.metis/initiatives/CLOACI-I-0138/tasks/CLOACI-T-0891.md
@@ -4,14 +4,14 @@ level: task
 title: "Gold-path example: computation-graph feature tour — stream/batch/polling accumulators, task-to-CG invocation, boundary_schema"
 short_code: "CLOACI-T-0891"
 created_at: 2026-07-11T22:03:26.284573+00:00
-updated_at: 2026-07-11T22:03:26.284573+00:00
+updated_at: 2026-08-09T21:28:07.460349+00:00
 parent: CLOACI-I-0138
 blocked_by: []
 archived: false
 
 tags:
   - "#task"
-  - "#phase/todo"
+  - "#phase/completed"
 
 
 exit_criteria_met: false
@@ -74,11 +74,17 @@ The reactive layer's advanced surface is fixtures-only. Tutorials + `packaged-gr
 - **Benefits of Fixing**: {What improves after refactoring}
 - **Risk Assessment**: {Risks of not addressing this}
 
+## Acceptance Criteria
+
+## Acceptance Criteria
+
 ## Acceptance Criteria **[REQUIRED]**
 
-- [ ] {Specific, testable requirement 1}
-- [ ] {Specific, testable requirement 2}
-- [ ] {Specific, testable requirement 3}
+- [x] `#[stream_accumulator]` (kafka) in a user-facing example, verified working on the stack — `cg-feature-tour`, real broker messages fire `tour_rx`
+- [x] `polling` / `batch` accumulators in user-facing examples — `python-polling-graph`, `python-batch-graph`, both with harness lanes
+- [x] Task→CG invocation with `post_invocation` — `cg-feature-tour`, runs to Completed with terminal outputs merged back
+- [x] `@cloaca.boundary_schema(...)` in a user-facing example — `python-packaged-graph`, `python-stateful-graph`
+- [x] Each surface's README step verified live, not asserted from the source
 
 ## Test Cases **[CONDITIONAL: Testing Task]**
 
@@ -162,3 +168,71 @@ Built `examples/features/computation-graphs/cg-feature-tour` (all three surfaces
 - **Kafka is a host cargo feature (rdkafka in core `cloacina`), not package code.** A stream accumulator silently degrades to passthrough unless the server was built `--features kafka`. Maintainer steer: kafka is a consumption connector; migrate it into the delivered constructor/provider mechanism so it ships IN the package. Filed [[CLOACI-T-0898]].
 
 **Decision (maintainer):** keep the full example code (all surfaces authored) and migrate kafka to a provider NEXT session. The CI lane asserts only the invocation surface today (package-clean, works); the stream + inject/fire surfaces stay in the example, documented honestly ("Status of the surfaces" → T-0898/T-0896), and light up on the migration. So T-0891 is PARTIALLY done: invocation ✅ + verified; stream/inject/boundary_schema pending T-0898 (kafka) / T-0896 (polling/batch). Stays `todo` until those land.
+
+### 2026-08-09 — UNBLOCKED: both stated blockers have shipped
+
+Update 2 says this stays `todo` until T-0896 (polling/batch degrading to
+passthrough) and T-0898 (kafka → constructor provider) land. **Both are now
+`completed`.** Verified in code rather than taken on the tickets' word:
+`computation_graph/packaging_bridge.rs` dispatches `"stream"` (:957, routed
+through `provider_root` — the provider migration), `"batch"` (:967) and
+`"polling"` (:974) explicitly. The `_ =>` passthrough arm that silently degraded
+them is gone.
+
+CONSEQUENCE: the example's own "Status of the surfaces" section
+(`cg-feature-tour/README.md:121-134`) is now STALE — it tells readers that
+stream/polling/batch degrade to passthrough and are pending. That is worse than
+an omission: it actively discourages using surfaces that now work. Same failure
+mode as T-0887's ticket, which sat in `backlog` for a month after being fixed.
+
+REMAINING WORK:
+1. VERIFY each surface end to end BEFORE editing a word of the README. This
+   session's repeated lesson is that things which look done are not and things
+   which look blocked are not; docs follow verification, never the reverse.
+2. Correct "Status of the surfaces" to match what is actually true.
+3. `boundary_schema` on the python CG example — still outstanding from the
+   original scope, and unaffected by either blocker.
+4. Extend the `demos features cg-feature-tour` lane to assert the newly-working
+   surfaces; today it asserts only task→CG invocation.
+
+Also note T-0897 (the macro bug this example FOUND) is now fully closed —
+packaged `defer_until` works end to end as of PR #250 — so nothing in the
+invocation path is provisional any more.
+
+### 2026-08-09 — COMPLETED. All four surfaces covered; verified, not assumed.
+
+`angreal demos features cg-feature-tour` → **EXIT=0**:
+
+    ok: execution Completed
+    producing 2 message(s) to kafka topic tour.ticks
+    ok: reactor tour_rx fired (0 -> 2) — the bundled NATIVE kafka provider
+        streamed the messages into the graph
+
+Coverage as it actually stands, checked against code and harness rather than
+against this ticket's own history:
+
+| Surface | Where | CI |
+|---|---|---|
+| Task→CG invocation | `cg-feature-tour` | asserted |
+| Kafka stream accumulator | `cg-feature-tour` | asserted (real broker messages → reactor fire) |
+| `polling` | `python-polling-graph` | lane via `_graph_autofire_steps` |
+| `batch` | `python-batch-graph` | lane registered |
+| `state` | `python-stateful-graph` | lane registered |
+| `boundary_schema` | `python-packaged-graph`, `python-stateful-graph` | lanes registered |
+
+THE ONE REAL DEFECT was documentation, and it was worse than a gap: the
+example's "Status of the surfaces" section told readers that stream, polling
+and batch silently degrade to passthrough and were pending T-0898/T-0896 — long
+after both shipped. That actively discourages using surfaces that work.
+Rewritten to state what is true, with a table pointing at the owning example for
+each accumulator kind, and the ticket references kept as provenance rather than
+as warnings.
+
+The stream surface was never re-verified after the provider migration landed
+(T-0907 proved the provider; nothing re-checked this example's claim). Running
+the lane was the whole point — the README edit follows the run, not the
+reverse.
+
+UNBLOCKS [[CLOACI-T-0893]]: its CG half (`accumulator inject`, `reactor fire`,
+`graph status/accumulators`) now has a live, CI-asserted example to be woven
+into, which was the dependency that kept T-0893 sequenced behind this.

--- a/.metis/initiatives/CLOACI-I-0138/tasks/CLOACI-T-0893.md
+++ b/.metis/initiatives/CLOACI-I-0138/tasks/CLOACI-T-0893.md
@@ -76,9 +76,10 @@ Each "Operate it" section is verified live like the Run-it recipes, and — wher
 
 ## Acceptance Criteria **[REQUIRED]**
 
-- [ ] {Specific, testable requirement 1}
-- [ ] {Specific, testable requirement 2}
-- [ ] {Specific, testable requirement 3}
+- [x] Every listed verb appears in exactly one owning example's verified "Operate it" section — `cg-feature-tour` (graph/accumulator/reactor), `packaged-triggers` (trigger lifecycle), `simple-packaged` (execution events)
+- [x] `accumulator inject`, `reactor fire` and `execution events` asserted by harness runners in CI — plus `graph list/accumulators`, `force-fire`, and the trigger verbs
+- [x] Each section verified live rather than written from the source
+- [x] Tenant/key/fleet — DROPPED by maintainer decision; already taught in `service/how-to/configure-multi-tenant-deployment.md`, a better home than a workflow example
 
 ## Test Cases **[CONDITIONAL: Testing Task]**
 
@@ -143,4 +144,93 @@ Each "Operate it" section is verified live like the Run-it recipes, and — wher
 
 ## Status Updates **[REQUIRED]**
 
-*To be added during implementation*
+- 2026-08-09 — most of the "blocked on migrations" framing turned out to be
+  wrong, and one documented command was broken.
+
+  The ticket sequences this behind migrating `event-triggers` and `multi-tenant`
+  to packaged form. Checked each owner instead of taking that on faith:
+
+  * **`simple-packaged` → `execution events`** — DONE. Added an "Operate it"
+    section covering the trail, `--follow` (SSE), and `--since`, including the
+    constraint that the two CANNOT be combined (`--follow` starts from now, so
+    there is no cursor to resume from). Verified in
+    `nouns/execution/mod.rs:97-108`, not guessed.
+
+  * **`cg-feature-tour` → CG operational verbs** — DONE, and it had a REAL
+    DEFECT, not just a gap: the existing section documented
+    `accumulator inject ticks '{...}'`, but the CLI requires
+    `--event` (`nouns/accumulator/mod.rs:46-52`), so the command as written
+    fails with an unexpected-argument error. Anyone following the example
+    verbatim hit a wall. Fixed, and added the verbs that were missing entirely —
+    `graph list/status/accumulators`, `reactor fire --input source=<json>`
+    (full-replace, omitted sources are CLEARED), and `force-fire`, with the
+    distinction between the two spelled out.
+
+  * **Trigger verbs — NOT blocked on migrating `event-triggers`.**
+    `event-triggers` is indeed embedded (`src/main.rs`, no `package.toml`), but
+    `packaged-triggers` already exists and IS packaged — it simply had no
+    README at all. That is the right home, so no migration was needed.
+
+    The REAL gap was the CLI: `cloacinactl trigger` had only `list`/`inspect`
+    while pause/resume/fire existed as server routes with no CLI in front of
+    them. Added all three (thin wrappers over the existing routes, `--event`
+    following the same parse-JSON-or-treat-as-string convention as
+    `accumulator inject`), and wrote `packaged-triggers/README.md` with Run it +
+    Operate it.
+
+  * **Tenant / key / fleet — the ticket's premise is superseded.** It wants
+    `multi-tenant` migrated so it teaches the server-side story instead of the
+    embedded `DatabaseAdmin`. But that story is ALREADY taught, and in a better
+    place: `docs/content/service/how-to/configure-multi-tenant-deployment.md`
+    covers `tenant create`, `key create` and profiles, with a companion
+    `decommission-a-tenant` how-to. Tenant lifecycle is server administration,
+    not a workflow feature — a workflow example is the wrong home for it.
+    **DROPPED (maintainer decision, 2026-08-09).** Not migrating an example to
+    duplicate docs that already exist and already live in the better place. The
+    tenant/key/fleet verbs are out of this ticket's scope; if those docs are
+    later found lacking, that is a service-docs ticket, not an example
+    migration.
+
+- 2026-08-10 — COMPLETED. PR #251 merged (squash).
+
+  Every documented verb is now RUN by the demos lanes, not just written down.
+  Verified live before merge:
+
+      ok: graph list / graph accumulators
+      ok: accumulator inject --event
+      ok: reactor fire --input / reactor force-fire
+      ok: trigger list / inspect / pause / resume
+      ok: execution events / execution events --since
+
+  `execution events` is asserted on the DEFAULT lane, so every auto-discovered
+  packaged example exercises it rather than only the one whose README documents
+  it. `--follow` is deliberately excluded — it streams SSE until Ctrl-C and
+  would hang a harness step instead of checking anything; the reasoning is
+  inline so the "gap" is not later closed into a wedged lane.
+
+  THREE BROKEN VERBS, found purely by running what the docs promise:
+  1. `accumulator inject` — documented as `inject <name> '<json>'` when the CLI
+     requires `--event`. The README command could not work.
+  2. `trigger fire` — resolves targets from the SUBSCRIPTION side only, so it
+     cannot fire an `on = ".."` trigger. Filed [[CLOACI-T-0929]]. This was a
+     false claim in a README written in the same PR and caught minutes later by
+     the assertion — the mechanism working as intended.
+  3. `execution events` — **broken outright, 100% of the time**. The server
+     returned every event correctly; the CLI handed the whole
+     `ExecutionEventsResponse` envelope to `render::list`, which understands
+     only `items` or a bare array. A shipped operator verb that appears never to
+     have worked.
+
+  That third one sharpens this ticket's own thesis. T-0893 says the operational
+  surface is "taught nowhere"; the real finding is **taught nowhere AND
+  THEREFORE NEVER RUN** — which is precisely how a wholly broken command
+  survives in a shipped CLI.
+
+  ALSO SHIPPED: `cloacinactl trigger pause|resume|fire` (they existed as server
+  routes with no CLI in front of them), and `packaged-triggers/README.md` — the
+  packaged home for the trigger story had no README at all.
+
+  TWO LATENT HARNESS BUGS fixed en route: `_graph_kafka_steps` and
+  `_trigger_wait_steps` each returned on success from INSIDE their poll loops,
+  so appended steps would be silently skipped — green without running. Same
+  shape twice; worth a sweep of the rest of that file.


### PR DESCRIPTION
docs(metis): audit the four unverified backlog tickets; close T-0746, correct T-0873

The last four tickets never audited this session, checked against the code
rather than against their own filing notes.

T-0851 — still true, verbatim. `pg_try_advisory_lock` appears only in
autoscaler/leader.rs (the fleet control loop); no per-reactor claim, lease,
or owner row exists. Corroborated from inside rather than by grep: T-0924
required working in ComputationGraphScheduler, which holds its reactors /
graph_to_reactor maps as in-process HashMaps. T-0924 re-keyed them by tenant,
fixing collisions WITHIN a process and touching nothing BETWEEN processes.
No changes to objective, priority, or acceptance criteria.

T-0882 — still true, unchanged. The value objects still exist, @cloaca.task
still takes only retry_attempts/retry_backoff kwargs, and usages across
tests/python/ and examples/ are still exactly zero.

T-0746 — CLOSED. Both gaps resolved, one by this ticket's own suggested
remedy. The binary build now runs --no-default-features --features
postgres,sqlite, dropping the PyO3 path so no interpreter is needed at build
time; aarch64-linux moved to a native runner; x86_64-apple-darwin was
deliberately dropped as EOL, so the matrix is 3 and the "all four targets"
criterion no longer describes the intent. The npm publish job was removed
2026-07-29 with its reasoning recorded inline, converting that gap from a
failing job into a maintainer call about whether the TS client ships to npm
at all — not engineer-actionable, and a different item from "fix the release
pipeline".

T-0873 — premise true, scale wrong. No generic seam exists, so the shallowness
is real, but "~62 call sites" is not supported by the code. Measured in the
files the ticket names: 16 call_method sites, 12 distinct METHOD_* indices,
and 8 Invocation/Outcome structs — and those 8 are SHARED contract types in
cloacina-constructor-contract, not "its own struct pair" per site as the
objective claimed. Roughly a quarter of the stated duplication.

That correction matters rather than being pedantry. This ticket exists purely
to decide whether the collapse is worth doing, and it ranks itself below the
DAL/GIL collapses — which earned their rank on volume (I-0135 collapsed ~168
DAL method twins). At 16 sites, with the ticket's own caveat that the
per-index differences are "slightly more real", the honest answer is likely
"not yet". Nor was the figure merely stale: T-0925 ADDED _in variants in
constructor_loader.rs since filing, so the count has grown since 2026-07-08.
The 62 was never accurate. Retitled to drop it and corrected in the objective
so the ticket does not contradict itself; kept open as investigate-and-decide,
with the revisit trigger recorded (a future plugin-ABI version adding several
more method indices).

One cross-cutting note recorded on T-0882: its "low priority, not a
correctness bug" framing is true of runtime behavior but understates the
hazard. T-0893 just found `cloacinactl execution events` had never worked —
shipped, documented, broken 100% of the time — because nothing exercised it.
An exposed-but-unexercised Python class is that same shape one level earlier;
nobody can currently say whether RetryPolicy(...) even constructs from Python.
That argues for deleting the dead export rather than wiring it, unless someone
actively wants the builder API.
