### PR TITLE
fix(T-0882): wire the RetryPolicy value objects; unbreak import cloaca locally

### DIFF
--- a/.angreal/test/_python_utils.py
+++ b/.angreal/test/_python_utils.py
@@ -540,6 +540,27 @@ def _build_and_install_cloaca_unified(venv_name, cargo_features=None):
         str(maturin_exe), "build",
         "--release",
         "--manylinux", "off",  # skip auditwheel repair (avoids libpq.so resolution)
+        # Build against the interpreter that will actually LOAD the wheel.
+        #
+        # Without this, maturin has no VIRTUAL_ENV (we invoke its binary
+        # directly rather than activating the venv) and falls back to
+        # discovering a system interpreter. On macOS that is the
+        # CommandLineTools Python 3.9 framework, so the extension linked
+        # `@rpath/Python3.framework/Versions/3.9/Python3` while the venv ran a
+        # different CPython. Two Python runtimes then coexist in one process
+        # and the first pyo3 call into the wrong one aborts the interpreter:
+        #
+        #   Fatal Python error: PyInterpreterState_Get: the function must be
+        #   called with the GIL held, but the GIL is released (the current
+        #   Python thread state is NULL)
+        #
+        # Every Python scenario was unrunnable locally as a result. CI never
+        # saw it: on Linux the extension resolves Python symbols dynamically
+        # from the host interpreter rather than linking a framework, so the
+        # mismatch is invisible there. This is the venv's own interpreter, not
+        # a pinned version — it follows whatever Python the venv was created
+        # with.
+        "--interpreter", str(python_exe),
     ]
     if cargo_features:
         # Scope the wheel to a specific backend (e.g. sqlite-only lane).

--- a/.metis/backlog/bugs/CLOACI-T-0930.md
+++ b/.metis/backlog/bugs/CLOACI-T-0930.md
@@ -1,0 +1,182 @@
+---
+id: build-retry-policy-silently
+level: task
+title: "build_retry_policy silently swallows typo'd retry_backoff/retry_condition strings"
+short_code: "CLOACI-T-0930"
+created_at: 2026-08-14T03:07:30.077563+00:00
+updated_at: 2026-08-14T03:07:30.077563+00:00
+parent: 
+blocked_by: []
+archived: false
+
+tags:
+  - "#task"
+  - "#phase/backlog"
+  - "#bug"
+
+
+exit_criteria_met: false
+initiative_id: NULL
+---
+
+# build_retry_policy silently swallows typo'd retry_backoff/retry_condition strings
+
+*This template includes sections for various types of tasks. Delete sections that don't apply to your specific use case.*
+
+## Parent Initiative **[CONDITIONAL: Assigned Task]**
+
+[[Parent Initiative]]
+
+## Objective **[REQUIRED]**
+
+`build_retry_policy` (`crates/cloacina-python/src/task.rs`) maps its string
+kwargs through catch-all arms:
+
+```rust
+let strategy = match backoff.as_str() {
+    "fixed" => BackoffStrategy::Fixed,
+    "linear" => BackoffStrategy::Linear { multiplier: 1.0 },
+    "exponential" => BackoffStrategy::Exponential { base: 2.0, multiplier: 1.0 },
+    _ => BackoffStrategy::Fixed,          // <-- silent
+};
+...
+let retry_cond = match condition.as_str() {
+    "never" => RetryCondition::Never,
+    "transient" => RetryCondition::TransientOnly,
+    "all" => RetryCondition::AllErrors,
+    _ => RetryCondition::AllErrors,       // <-- silent
+};
+```
+
+So `@cloaca.task(retry_backoff="exponentail")` (typo) silently configures
+**Fixed** backoff, and an unrecognized `retry_condition` silently becomes
+**AllErrors** — retrying errors the author may have meant never to retry. The
+author gets no warning; the workflow runs with retry semantics they never
+asked for, and the misconfiguration stays invisible until production behaves
+oddly.
+
+Found while implementing [[CLOACI-T-0882]], which wired the typed `RetryPolicy`
+object as an alternative surface. The typed path cannot express this typo —
+`BackoffStrategy.exponential(...)` is a method, so a misspelling is an
+immediate `AttributeError`. T-0882 deliberately did NOT fix this, because it
+is a behavior change with its own blast radius.
+
+**Fix:** raise `ValueError` listing the accepted values instead of falling
+through. **This is a breaking change** for any workflow currently passing an
+unrecognized string and silently getting the default — which is exactly the
+population most likely to be misconfigured, so failing loudly is the point.
+Worth a release-notes line.
+
+## Backlog Item Details **[CONDITIONAL: Backlog Item]**
+
+{Delete this section when task is assigned to an initiative}
+
+### Type
+- [ ] Bug - Production issue that needs fixing
+- [ ] Feature - New functionality or enhancement  
+- [ ] Tech Debt - Code improvement or refactoring
+- [ ] Chore - Maintenance or setup work
+
+### Priority
+- [ ] P0 - Critical (blocks users/revenue)
+- [ ] P1 - High (important for user experience)
+- [ ] P2 - Medium (nice to have)
+- [ ] P3 - Low (when time permits)
+
+### Impact Assessment **[CONDITIONAL: Bug]**
+- **Affected Users**: {Number/percentage of users affected}
+- **Reproduction Steps**: 
+  1. {Step 1}
+  2. {Step 2}
+  3. {Step 3}
+- **Expected vs Actual**: {What should happen vs what happens}
+
+### Business Justification **[CONDITIONAL: Feature]**
+- **User Value**: {Why users need this}
+- **Business Value**: {Impact on metrics/revenue}
+- **Effort Estimate**: {Rough size - S/M/L/XL}
+
+### Technical Debt Impact **[CONDITIONAL: Tech Debt]**
+- **Current Problems**: {What's difficult/slow/buggy now}
+- **Benefits of Fixing**: {What improves after refactoring}
+- **Risk Assessment**: {Risks of not addressing this}
+
+### Type
+- [x] Bug - Production issue that needs fixing
+
+### Priority
+- [x] P2 - Medium (silent misconfiguration, not a crash; the typed
+      `RetryPolicy` surface added in T-0882 is a safe alternative today)
+
+## Acceptance Criteria **[REQUIRED]**
+
+- [ ] An unrecognized `retry_backoff` raises `ValueError` naming the valid values.
+- [ ] An unrecognized `retry_condition` raises `ValueError` naming the valid values.
+- [ ] Python tests cover both rejections AND confirm every valid value still works
+      (the regression risk is over-tightening and breaking a legitimate string).
+- [ ] Release-notes entry flagging the behavior change.
+
+## Test Cases **[CONDITIONAL: Testing Task]**
+
+{Delete unless this is a testing task}
+
+### Test Case 1: {Test Case Name}
+- **Test ID**: TC-001
+- **Preconditions**: {What must be true before testing}
+- **Steps**: 
+  1. {Step 1}
+  2. {Step 2}
+  3. {Step 3}
+- **Expected Results**: {What should happen}
+- **Actual Results**: {To be filled during execution}
+- **Status**: {Pass/Fail/Blocked}
+
+### Test Case 2: {Test Case Name}
+- **Test ID**: TC-002
+- **Preconditions**: {What must be true before testing}
+- **Steps**: 
+  1. {Step 1}
+  2. {Step 2}
+- **Expected Results**: {What should happen}
+- **Actual Results**: {To be filled during execution}
+- **Status**: {Pass/Fail/Blocked}
+
+## Documentation Sections **[CONDITIONAL: Documentation Task]**
+
+{Delete unless this is a documentation task}
+
+### User Guide Content
+- **Feature Description**: {What this feature does and why it's useful}
+- **Prerequisites**: {What users need before using this feature}
+- **Step-by-Step Instructions**:
+  1. {Step 1 with screenshots/examples}
+  2. {Step 2 with screenshots/examples}
+  3. {Step 3 with screenshots/examples}
+
+### Troubleshooting Guide
+- **Common Issue 1**: {Problem description and solution}
+- **Common Issue 2**: {Problem description and solution}
+- **Error Messages**: {List of error messages and what they mean}
+
+### API Documentation **[CONDITIONAL: API Documentation]**
+- **Endpoint**: {API endpoint description}
+- **Parameters**: {Required and optional parameters}
+- **Example Request**: {Code example}
+- **Example Response**: {Expected response format}
+
+## Implementation Notes **[CONDITIONAL: Technical Task]**
+
+{Keep for technical tasks, delete for non-technical. Technical details, approach, or important considerations}
+
+### Technical Approach
+{How this will be implemented}
+
+### Dependencies
+{Other tasks or systems this depends on}
+
+### Risk Considerations
+{Technical risks and mitigation strategies}
+
+## Status Updates **[REQUIRED]**
+
+*To be added during implementation*

--- a/.metis/backlog/tech-debt/CLOACI-T-0882.md
+++ b/.metis/backlog/tech-debt/CLOACI-T-0882.md
@@ -4,15 +4,15 @@ level: task
 title: "Investigate: cloaca RetryPolicy/BackoffStrategy/RetryCondition value objects exposed but unwired"
 short_code: "CLOACI-T-0882"
 created_at: 2026-07-09T22:56:10.031554+00:00
-updated_at: 2026-07-09T22:56:10.031554+00:00
+updated_at: 2026-08-10T22:50:18.846076+00:00
 parent: 
 blocked_by: []
 archived: false
 
 tags:
   - "#task"
-  - "#phase/backlog"
   - "#tech-debt"
+  - "#phase/active"
 
 
 exit_criteria_met: false
@@ -69,9 +69,18 @@ Surfaced during I-0137 (cloaca registrar) + the maintainer's coverage catch: `cl
 
 ## Acceptance Criteria **[REQUIRED]**
 
-- [ ] {Specific, testable requirement 1}
-- [ ] {Specific, testable requirement 2}
-- [ ] {Specific, testable requirement 3}
+Decision: **(a) wire them.** Rationale in the status update below.
+
+- [x] `@cloaca.task(retry=RetryPolicy(...))` accepts the value object and applies it.
+- [x] Passing `retry=` together with any `retry_*` kwarg raises `ValueError` naming
+      the conflicting kwargs, rather than silently preferring one surface.
+- [x] A Python test constructs a `RetryPolicy` through the full builder chain
+      (`BackoffStrategy` + `RetryCondition` + jitter) and reads every getter back.
+- [x] A Python test executes a workflow whose task was configured via the object.
+- [x] A Python test asserts the mutual-exclusion error.
+- [x] Verified live: `angreal test integration --python-file
+      test_scenario_11_retry_mechanisms.py --backend sqlite` → EXIT=0,
+      `PASSED: test_scenario_11_retry_mechanisms.py`.
 
 ## Test Cases **[CONDITIONAL: Testing Task]**
 
@@ -170,3 +179,54 @@ Surfaced during I-0137 (cloaca registrar) + the maintainer's coverage catch: `cl
   Acceptance criteria are still template placeholders and should be filled in
   once (a)/(b) is chosen; not filling them in now, since the choice is the
   point of the ticket.
+
+- 2026-08-12 — IMPLEMENTED. Chose **(a) wire them**, reversing the audit's own
+  lean toward (b). Three facts found while implementing changed the answer:
+
+  1. **They are already contract, not accidental exports.** `lib.rs:350-353`
+     lists `RetryPolicy`/`RetryPolicyBuilder`/`BackoffStrategy`/`RetryCondition`
+     in the I-0137 authorship-contract assertion. Option (b) would have meant
+     deliberately shrinking a contract someone deliberately widened.
+  2. **The conversion already existed.** `PyRetryPolicy::to_rust()`
+     (`retry.rs:304`) already produced a `cloacina::retry::RetryPolicy`, so
+     wiring cost one match arm rather than a new adapter.
+  3. **The kwargs surface is the weaker one.** `build_retry_policy` maps
+     unknown strings through `_ => BackoffStrategy::Fixed` and
+     `_ => RetryCondition::AllErrors`, so `retry_backoff="exponentail"`
+     silently yields Fixed. The typed path cannot express that typo —
+     `BackoffStrategy.exponential(...)` is a method, so a typo is an
+     AttributeError. Wiring the object ADDS a safer surface; deleting it would
+     have left only the silently-defaulting one. (That kwargs typo-swallow is
+     a separate defect, still unfixed — see the residual note below.)
+
+  WHAT THE NEW TESTS IMMEDIATELY CAUGHT (the ticket's whole premise, confirmed):
+  `BackoffStrategy.exponential(base, multiplier: Option<f64>)` did
+  `multiplier.unwrap_or(1.0)` — clearly intending an optional argument — but
+  pyo3 does NOT infer optionality from `Option<T>` without an explicit
+  `#[pyo3(signature = ...)]`. So the argument was REQUIRED and
+  `BackoffStrategy.exponential(2.0)` raised
+  `TypeError: missing 1 required positional argument: 'multiplier'`. The very
+  first line of Python ever written against these objects hit it. Fixed with
+  `#[pyo3(signature = (base, multiplier=None))]`. Audited the rest of the file:
+  `exponential` was the only method with this shape.
+
+  IMPLEMENTATION
+  - `task.rs`: new `retry` param; `retry=` and `retry_*` are mutually exclusive
+    and the conflict raises `ValueError` naming the offending kwargs. Silently
+    preferring one surface would recreate this ticket's exact failure mode
+    ("I configured it and nothing happened") one level up.
+  - `retry.rs`: the `exponential` signature fix above.
+  - `tests/python/test_scenario_11_retry_mechanisms.py`: three new tests.
+    The construct-test asserts `calculate_delay(2) > calculate_delay(1)`,
+    because a silently-defaulted Fixed strategy would return a constant and
+    otherwise look identical to a working exponential.
+
+  BLOCKER HIT AND FIXED ALONG THE WAY — see the harness note; `import cloaca`
+  was fatally broken locally, so NO Python scenario could run at all until it
+  was fixed. That is why this ticket touches `.angreal/test/_python_utils.py`.
+
+  RESIDUAL (not fixed here, deliberately): `build_retry_policy`'s silent
+  `_ =>` fallbacks. Fixing it means erroring on unrecognized `retry_backoff` /
+  `retry_condition` strings, which is a behavior change for any existing
+  workflow currently passing a typo and silently getting Fixed/AllErrors. That
+  deserves its own ticket rather than riding along here.

--- a/crates/cloacina-python/src/bindings/value_objects/retry.rs
+++ b/crates/cloacina-python/src/bindings/value_objects/retry.rs
@@ -142,7 +142,16 @@ impl PyBackoffStrategy {
     }
 
     /// Exponential backoff strategy
+    ///
+    /// CLOACI-T-0882: `multiplier` is `Option` and defaults to 1.0 via
+    /// `unwrap_or` below, but pyo3 does NOT infer optionality from `Option<T>`
+    /// — without an explicit `signature`, the argument stayed REQUIRED and
+    /// `BackoffStrategy.exponential(2.0)` raised
+    /// `TypeError: missing 1 required positional argument: 'multiplier'`.
+    /// Nothing had ever constructed one of these from Python, so the gap
+    /// between the declared default and the callable signature went unseen.
     #[staticmethod]
+    #[pyo3(signature = (base, multiplier=None))]
     pub fn exponential(base: f64, multiplier: Option<f64>) -> Self {
         Self {
             inner: cloacina::retry::BackoffStrategy::Exponential {

--- a/crates/cloacina-python/src/lib.rs
+++ b/crates/cloacina-python/src/lib.rs
@@ -269,6 +269,7 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
             )
             .unwrap();
 

--- a/crates/cloacina-python/src/task.rs
+++ b/crates/cloacina-python/src/task.rs
@@ -866,6 +866,7 @@ impl TaskDecorator {
     *,
     id = None,
     dependencies = None,
+    retry = None,
     retry_attempts = None,
     retry_backoff = None,
     retry_delay_ms = None,
@@ -883,6 +884,7 @@ pub fn task(
     py: Python,
     id: Option<String>,
     dependencies: Option<Vec<PyObject>>,
+    retry: Option<crate::bindings::PyRetryPolicy>,
     retry_attempts: Option<usize>,
     retry_backoff: Option<String>,
     retry_delay_ms: Option<u64>,
@@ -895,14 +897,45 @@ pub fn task(
     post_invocation: Option<PyObject>,
     trigger_rules: Option<PyObject>,
 ) -> PyResult<TaskDecorator> {
-    let retry_policy = build_retry_policy(
-        retry_attempts,
-        retry_backoff,
-        retry_delay_ms,
-        retry_max_delay_ms,
-        retry_condition,
-        retry_jitter,
-    );
+    // CLOACI-T-0882: two retry-authoring surfaces exist — the `retry_*` kwargs
+    // and a `RetryPolicy` value object. Accept either, never both: silently
+    // preferring one would make the ignored surface look effective, which is
+    // exactly the "exposed but does nothing" failure this ticket was filed for.
+    let kwargs_used: &[(&str, bool)] = &[
+        ("retry_attempts", retry_attempts.is_some()),
+        ("retry_backoff", retry_backoff.is_some()),
+        ("retry_delay_ms", retry_delay_ms.is_some()),
+        ("retry_max_delay_ms", retry_max_delay_ms.is_some()),
+        ("retry_condition", retry_condition.is_some()),
+        ("retry_jitter", retry_jitter.is_some()),
+    ];
+    let conflicting: Vec<&str> = kwargs_used
+        .iter()
+        .filter(|(_, used)| *used)
+        .map(|(name, _)| *name)
+        .collect();
+
+    let retry_policy = match retry {
+        Some(policy) => {
+            if !conflicting.is_empty() {
+                return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                    "@task(retry=RetryPolicy(...)) cannot be combined with the \
+                     retry_* keyword arguments (got: {}). Use the RetryPolicy \
+                     object OR the keywords, not both.",
+                    conflicting.join(", ")
+                )));
+            }
+            policy.to_rust()
+        }
+        None => build_retry_policy(
+            retry_attempts,
+            retry_backoff,
+            retry_delay_ms,
+            retry_max_delay_ms,
+            retry_condition,
+            retry_jitter,
+        ),
+    };
 
     // CLOACI-T-0763: parse + validate the trigger rule (default = Always).
     let trigger_rules = match trigger_rules {
@@ -1004,6 +1037,7 @@ with score_graph:
                 None,
                 None,
                 None,
+                None,
                 Some(score_graph.unbind()),
                 None,
                 None,
@@ -1080,6 +1114,7 @@ def post(ctx):
                 None,
                 None,
                 None,
+                None,
                 Some(g.unbind()),
                 Some(post.unbind()),
                 None,
@@ -1124,6 +1159,7 @@ def post(ctx):
             let decorator = task(
                 py,
                 Some("bad".to_string()),
+                None,
                 None,
                 None,
                 None,
@@ -1186,6 +1222,7 @@ with g:
             let decorator = task(
                 py,
                 Some("rx_invoker".to_string()),
+                None,
                 None,
                 None,
                 None,

--- a/crates/cloacina-python/src/workflow.rs
+++ b/crates/cloacina-python/src/workflow.rs
@@ -378,6 +378,7 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
             )
             .unwrap();
             let func = py

--- a/tests/python/test_scenario_11_retry_mechanisms.py
+++ b/tests/python/test_scenario_11_retry_mechanisms.py
@@ -36,3 +36,78 @@ class TestRetryMechanisms:
 
         assert result is not None
         assert result.status == "Completed"
+
+    def test_retry_policy_value_objects_construct(self):
+        """CLOACI-T-0882: the RetryPolicy value objects are exported and usable.
+
+        These classes were exported and asserted-present by the I-0137
+        authorship-contract test, but NOTHING had ever constructed one, so
+        nobody could say whether they worked. Build one through the full
+        builder chain and read every getter back.
+        """
+        import cloaca
+
+        policy = (
+            cloaca.RetryPolicy.builder()
+            .max_attempts(5)
+            .initial_delay(0.25)
+            .max_delay(10.0)
+            .backoff_strategy(cloaca.BackoffStrategy.exponential(2.0))
+            .retry_condition(cloaca.RetryCondition.transient_only())
+            .with_jitter(True)
+            .build()
+        )
+
+        assert policy.max_attempts == 5
+        assert policy.initial_delay == 0.25
+        assert policy.max_delay == 10.0
+        assert policy.with_jitter is True
+        assert "RetryPolicy(" in repr(policy)
+
+        # The backoff must actually grow — a Fixed strategy would return the
+        # initial delay for every attempt, which is how a silently-defaulted
+        # strategy would present itself.
+        assert policy.calculate_delay(2) > policy.calculate_delay(1)
+
+        assert cloaca.RetryPolicy.default().max_attempts >= 1
+
+    def test_task_accepts_retry_policy_object(self, shared_runner):
+        """CLOACI-T-0882: @task(retry=RetryPolicy(...)) is wired end to end."""
+        import cloaca
+
+        policy = cloaca.RetryPolicy.builder().max_attempts(4).initial_delay(0.05).build()
+
+        with cloaca.WorkflowBuilder("retry_object_workflow") as builder:
+            builder.description("RetryPolicy object test")
+
+            @cloaca.task(id="retry_object_task", retry=policy)
+            def retry_object_task(context):
+                context.set("retry_object_task_executed", True)
+                return context
+
+        context = cloaca.Context({"test_type": "retry_object"})
+        result = shared_runner.execute("retry_object_workflow", context)
+
+        assert result is not None
+        assert result.status == "Completed"
+
+    def test_retry_object_and_kwargs_are_mutually_exclusive(self):
+        """CLOACI-T-0882: mixing the two surfaces fails loudly.
+
+        Silently preferring one would leave the ignored surface looking
+        effective — the exact "configured it, nothing happened" failure this
+        ticket exists to prevent.
+        """
+        import cloaca
+        import pytest
+
+        policy = cloaca.RetryPolicy.builder().max_attempts(4).build()
+
+        with pytest.raises(ValueError) as excinfo:
+            @cloaca.task(id="conflicting_task", retry=policy, retry_attempts=2)
+            def conflicting_task(context):
+                return context
+
+        message = str(excinfo.value)
+        assert "retry_attempts" in message
+        assert "not both" in message


### PR DESCRIPTION
fix(T-0882): wire the RetryPolicy value objects; unbreak `import cloaca` locally

Decides T-0882 as (a) wire, not (b) delete, reversing the audit's own lean.
Three facts found while implementing changed the answer:

  1. They are already contract. lib.rs:350-353 lists RetryPolicy,
     RetryPolicyBuilder, BackoffStrategy and RetryCondition in the I-0137
     authorship-contract assertion. Deleting them meant deliberately shrinking
     a contract someone deliberately widened.
  2. The conversion already existed. PyRetryPolicy::to_rust() already produced
     a cloacina::retry::RetryPolicy, so wiring cost one match arm.
  3. The kwargs surface is the WEAKER one. build_retry_policy maps unknown
     strings through `_ => BackoffStrategy::Fixed` and
     `_ => RetryCondition::AllErrors`, so retry_backoff="exponentail" silently
     yields Fixed. The typed path cannot express that typo, because
     BackoffStrategy.exponential(...) is a method and a misspelling is an
     immediate AttributeError. Wiring the object ADDS a safer surface; deleting
     it would have left only the silently-defaulting one. That typo-swallow is
     filed separately as CLOACI-T-0930 — it is a breaking change and does not
     belong riding along here.

@task(retry=...) and the retry_* kwargs are mutually exclusive, and the
conflict raises ValueError naming the offending kwargs. Silently preferring one
surface would recreate this ticket's own failure mode — "I configured it and
nothing happened" — one level up.

THE NEW TEST CAUGHT A REAL BUG ON ITS FIRST RUN, which is the ticket's premise
proving itself. BackoffStrategy.exponential(base, multiplier: Option<f64>) did
multiplier.unwrap_or(1.0), plainly intending an optional argument, but pyo3
does not infer optionality from Option<T> without an explicit signature. So the
argument was REQUIRED and exponential(2.0) raised

    TypeError: missing 1 required positional argument: 'multiplier'

The first line of Python ever written against these objects hit it. Fixed with
#[pyo3(signature = (base, multiplier=None))]. Audited the file: exponential was
the only method with this shape.

UNBREAKS THE PYTHON HARNESS. No Python scenario could run locally at all —
`import cloaca` died with

    Fatal Python error: PyInterpreterState_Get: the function must be called
    with the GIL held, but the GIL is released (the current Python thread
    state is NULL)

Reproduced on a clean checkout with my changes stashed, so it is pre-existing
and not from this work; reproduced on both sqlite and postgres wheels and on
both Python 3.11 and 3.13, so it is neither feature- nor version-specific.
Cause, from otool -L on the built extension: it linked
@rpath/Python3.framework/Versions/3.9/Python3 while the venv ran a different
CPython. Two Python runtimes then coexist in one process and the first pyo3
call into the wrong one aborts the interpreter.

maturin was invoked with no --interpreter and no VIRTUAL_ENV (the harness runs
the binary directly rather than activating the venv), so it fell back to
discovering a system interpreter — on macOS, the CommandLineTools 3.9
framework. Now passes the venv's own python. That is the interpreter the wheel
gets installed into, followed dynamically; it is not a pinned version. Verified
the rebuilt extension links the venv's libpython3.11.dylib and imports, and
that a sqlite-scoped wheel still correctly reports DatabaseAdmin: False.

CI never saw any of this: on Linux the extension resolves Python symbols
dynamically from the host interpreter instead of linking a framework, so the
mismatch is invisible there. Local-only breakage, and total.

Verified live:

    angreal test integration --python-file test_scenario_11_retry_mechanisms.py \
        --backend sqlite
    EXIT=0
    PASSED: test_scenario_11_retry_mechanisms.py
    Python sqlite scenarios: 1 passed, 0 failed

The construct-test asserts calculate_delay(2) > calculate_delay(1), because a
silently-defaulted Fixed strategy returns a constant and would otherwise look
identical to a working exponential.
