### PR TITLE
docs(metis): decide T-0873 (don't build the seam); close T-0882; file T-0930/T-0931

### DIFF
--- a/.metis/adrs/CLOACI-A-0012.md
+++ b/.metis/adrs/CLOACI-A-0012.md
@@ -1,0 +1,184 @@
+---
+id: 001-reactive-layer-ha-per-reactor
+level: adr
+title: "Reactive-layer HA — per-reactor leadership with durable accumulator state"
+number: 1
+short_code: "CLOACI-A-0012"
+created_at: 2026-08-16T14:45:32.910934+00:00
+updated_at: 2026-08-16T14:47:12.603232+00:00
+decision_date: 
+decision_maker: 
+parent: 
+archived: false
+
+tags:
+  - "#adr"
+  - "#phase/decided"
+
+
+exit_criteria_met: false
+initiative_id: NULL
+---
+
+# ADR-1: Reactive-layer HA — per-reactor leadership with durable accumulator state
+
+*This template includes sections for various types of architectural decisions. Delete sections that don't apply to your specific use case.*
+
+## Context **[REQUIRED]**
+
+Filed from the 2026-07-06 HA review ([[CLOACI-T-0851]]). Everything else in
+cloacina-server is HA-proven — task/cron scheduling is active-active via atomic
+claiming, the fleet control loop is per-tick leader-elected with validated
+failover ([[CLOACI-A-0008]]), login state is in Postgres. The reactive layer is
+the remaining gap.
+
+**Verified against the code (2026-08-16), not inferred:**
+
+1. **Reactor and accumulator state is per-replica, in-process.**
+   `ComputationGraphScheduler` holds its `reactors` / `graph_to_reactor` maps as
+   in-memory `HashMap`s. [[CLOACI-T-0924]] re-keyed those by tenant, which fixes
+   collisions WITHIN one process and does nothing about coordination BETWEEN
+   processes.
+2. **An event lands on exactly one replica** (whichever terminates the WS/REST
+   inject), so with N replicas a stream's events split across N independent
+   buffers. A `state` accumulator's window or a `when_all` criteria set may
+   never assemble on any single replica.
+3. **Half the state is already durable; the other half is not.**
+   `persist_reactor_state` (`reactor.rs:1180`) snapshots the reactor's
+   `InputCache`, `DirtyFlags` and `SeqQueue` through
+   `save_reactor_state(graph_name, ..)`, with failure counters and a `Degraded`
+   health transition already wired. **Accumulator buffers are persisted
+   nowhere** — there is no `save_accumulator*` / `persist_accumulator` anywhere
+   in the tree.
+
+Point 3 is the one that shapes this decision, and it is not in the original
+ticket. Reactor leadership ALONE would give failover in which the reactor
+resumes from its snapshot while every accumulator restarts empty — a
+half-filled window silently gone. Maintainer decision (2026-08-16): that loss
+is **not acceptable**; accumulator buffers must survive failover.
+
+Single-replica and embedded deployments are unaffected by any of this and must
+stay byte-for-byte unchanged.
+
+## Decision **[REQUIRED]**
+
+**Per-reactor leadership, plus accumulator buffers folded into the existing
+reactor checkpoint.**
+
+1. **Ownership.** Each reactor instance is claimed by exactly one replica via a
+   per-reactor lease, using the `pg_try_advisory_lock` pattern already proven
+   in `autoscaler/leader.rs` (`FLEET_CONTROL_LOCK_KEY`) — a distinct lock key
+   per reactor rather than one global key.
+2. **Routing.** A replica that receives a reactive event for a reactor it does
+   not own forwards it to the owner over the existing delivery
+   substrate/outbox, which already provides an at-least-once inter-replica
+   channel. Non-owners run no accumulators and no reactor state machine.
+3. **Durability.** `persist_reactor_state` is extended to include accumulator
+   buffers alongside `InputCache`/`DirtyFlags`/`SeqQueue`, written in the same
+   checkpoint.
+4. **Failover.** Lease expiry → another replica claims the reactor and restores
+   BOTH the reactor snapshot and the accumulator buffers before accepting
+   forwarded events.
+5. **Unchanged paths.** Single-replica and embedded modes keep today's
+   behavior; with one replica the lease is always acquired locally and routing
+   never engages.
+
+**The load-bearing consequence of ordering (1) before (3):** because leadership
+guarantees a SINGLE WRITER per reactor, accumulator durability needs no
+concurrency protocol, no locking, and no shared mutable store. It is strictly
+"more bytes in a checkpoint only one process is allowed to write." This is why
+the maintainer's "accumulators must survive" requirement does NOT force the
+externalized-state alternative: that option's cost lives almost entirely in
+making buffers safe for CONCURRENT access, which leadership makes unnecessary.
+
+## Alternatives Analysis **[CONDITIONAL: Complex Decision]**
+
+{Delete if there's only one obvious solution}
+
+| Option | Pros | Cons | Risk Level | Implementation Cost |
+|--------|------|------|------------|-------------------|
+| **Reactor leadership (CHOSEN)** | Reuses the A-0008 advisory-lock pattern already proven in production; reactor state machine needs no redesign; single-writer makes accumulator durability trivial; routing rides the existing delivery substrate | Adds a lease/routing hop; events for a non-owned reactor pay one forward; lock-key allocation per reactor needs care | Medium | M |
+| Sticky routing only | Cheapest — mostly docs plus an ingress/chart affinity change | A deployment constraint, not a fix: reactor state still lost on replica death, and a misconfigured LB silently splits streams with no in-code defense. Fails the maintainer's durability requirement outright | Low to build, **High in production** | S |
+| Externalized accumulator state | Best semantics; no reactive state in process memory at all | Touches the accumulator hot path, so it carries real throughput risk on high-rate streams; most of its cost buys concurrent-access safety that leadership renders unnecessary | High | L |
+
+## Rationale **[REQUIRED]**
+
+**Why leadership over sticky routing.** Sticky routing cannot satisfy the
+maintainer's requirement that accumulator buffers survive failover — replica
+death loses them by construction. It also relocates a correctness property into
+LB configuration, where nothing in the codebase can enforce or even detect a
+misconfiguration. Silent stream-splitting with no in-code defense is precisely
+the failure mode this ADR exists to remove.
+
+**Why leadership over externalized state.** These were framed as competing
+options, but they are not symmetric once ordering is considered. Externalized
+state is expensive mainly because concurrent access to accumulator buffers has
+to be made safe on the hot path. Establishing single-ownership FIRST deletes
+that requirement: with one writer per reactor, "durable" collapses to "write
+more bytes into the checkpoint that already exists." We get the durability the
+maintainer asked for at a fraction of the cost, and the hot path is untouched.
+
+**Why extend `persist_reactor_state` rather than add a parallel mechanism.**
+That function already owns checkpointing for this exact reactor, already has
+failure counters, a bounded failure streak, and a `Degraded` health transition
+attributing failures per branch (`cache_serialize`, `dirty_serialize`,
+`seq_serialize`, `save`). A second persistence path would duplicate all of it
+and introduce the possibility of the two halves of one reactor's state being
+checkpointed at different instants — i.e. a torn snapshot. One checkpoint, one
+consistency point.
+
+## Consequences **[REQUIRED]**
+
+### Positive
+- Multi-replica reactive deployments become correct rather than
+  accidentally-correct-if-the-LB-is-configured-right.
+- Accumulator buffers become durable for the first time — this is a gap that
+  exists TODAY even on a single replica: a process restart currently loses
+  every accumulator window silently. Leadership is the motivation, but
+  single-replica restarts benefit immediately.
+- One coordination pattern across the codebase (fleet control and reactors both
+  use advisory locks), so there is one thing to understand and one to operate.
+- The accumulator hot path is unchanged, so no throughput risk on high-rate
+  streams.
+
+### Negative
+- Events arriving at a non-owner replica pay a forwarding hop; latency under
+  multi-replica is no longer uniform.
+- Checkpoints grow by the size of the accumulator buffers. A large `state`
+  window makes each checkpoint materially bigger, and the write is synchronous
+  with respect to the persist cadence. Buffer size may need a bound, or the
+  cadence may need tuning — to be measured, not guessed.
+- Per-reactor advisory lock keys must be allocated collision-free across
+  tenants. `save_reactor_state` keys by `graph_name` alone and relies on
+  schema-per-tenant isolation for separation; the lock-key space has no such
+  schema boundary, so this needs explicit design. **Flagged as the most likely
+  source of a subtle cross-tenant bug in the implementation.**
+- Takeover is not instantaneous: there is a lease-expiry window during which a
+  reactor processes nothing.
+
+### Neutral
+- Single-replica and embedded behavior is unchanged; the lease is always
+  acquired locally and routing never engages.
+- Nothing in existing CI would catch a regression here — every demo and e2e
+  stack runs single-replica. The 2-replica harness is required work, not a
+  nice-to-have.
+
+## Review Schedule **[CONDITIONAL: Temporary Decision]**
+
+Permanent as a direction, but two triggers would reopen the durability half:
+
+### Review Triggers
+- **Checkpoint size or persist latency becomes a problem on high-rate streams.**
+  Folding accumulator buffers into the checkpoint trades write size for
+  simplicity. If a `state` window grows large enough that checkpointing becomes
+  a bottleneck, the externalized-state option comes back on the table for
+  accumulators specifically — leadership stays either way.
+- **A reactive workload needs sub-lease-expiry takeover.** The lease window is
+  acceptable for the current model; a latency-sensitive consumer would need
+  hand-off rather than expiry-based failover.
+
+### Open Question For Implementation
+Per-reactor advisory lock-key allocation across tenants (see Consequences →
+Negative). This ADR fixes the direction, not the key scheme; resolve that in
+[[CLOACI-T-0851]] before writing the lease code, since getting it wrong is a
+cross-tenant bug and those are the expensive kind here.

--- a/.metis/backlog/features/CLOACI-T-0851.md
+++ b/.metis/backlog/features/CLOACI-T-0851.md
@@ -68,9 +68,26 @@ Make the reactive layer (accumulators + reactors) safe and well-defined under mu
 
 ## Acceptance Criteria **[REQUIRED]**
 
-- [ ] A chosen coordination model (leadership / routing / externalized state) recorded as an ADR with maintainer sign-off.
+- [x] A chosen coordination model (leadership / routing / externalized state) recorded as an ADR with maintainer sign-off.
+      → **[[CLOACI-A-0012]]**, maintainer sign-off 2026-08-16: reactor
+      leadership (per-reactor advisory-lock lease, mirroring [[CLOACI-A-0008]]),
+      PLUS accumulator buffers folded into the existing `persist_reactor_state`
+      checkpoint. Accumulator loss on failover was explicitly ruled
+      UNACCEPTABLE, so durability is in v1 scope — but single-ownership makes it
+      cheap (single writer ⇒ no concurrency protocol, accumulator hot path
+      untouched).
+- [ ] **Per-reactor advisory lock keys are collision-free ACROSS TENANTS.**
+      `save_reactor_state` keys by `graph_name` alone and leans on
+      schema-per-tenant isolation for separation; the advisory-lock key space
+      has NO schema boundary, so two tenants running a same-named graph would
+      contend for one lock and silently serialize each other. Resolve before
+      writing the lease code — see A-0012 "Open Question For Implementation".
+      This is the most likely place to introduce a subtle cross-tenant bug.
+- [ ] Accumulator buffers are persisted AND restored on takeover. Restore is
+      the half that can be quietly skipped: a snapshot nothing reads back looks
+      complete and buys nothing.
 - [ ] Under a 2-replica postgres deployment: events injected round-robin across replicas assemble correctly (a `when_all` reactor fires; a `state` window fills) with no split-brain buffers.
-- [ ] Replica death while owning a reactor → another replica resumes it from the persisted snapshot (bounded takeover time; no lost checkpointed state).
+- [ ] Replica death while owning a reactor → another replica resumes it from the persisted snapshot (bounded takeover time; no lost checkpointed state), **with a partially-filled accumulator window intact across the failover** — this is the criterion that distinguishes the chosen design from leadership alone.
 - [ ] Multi-replica reactive validation added to the k8s-leader e2e lane (extends T-0818's harness).
 - [ ] Single-replica + embedded behavior byte-for-byte unchanged.
 

--- a/.metis/backlog/tech-debt/CLOACI-T-0873.md
+++ b/.metis/backlog/tech-debt/CLOACI-T-0873.md
@@ -4,15 +4,15 @@ level: task
 title: "Generic invoke_ffi marshaling seam — investigate collapsing the per-method-index FFI bridges"
 short_code: "CLOACI-T-0873"
 created_at: 2026-07-08T14:20:14.965414+00:00
-updated_at: 2026-07-08T14:20:14.965414+00:00
+updated_at: 2026-08-16T14:33:24.380501+00:00
 parent: 
 blocked_by: []
 archived: false
 
 tags:
   - "#task"
-  - "#phase/backlog"
   - "#tech-debt"
+  - "#phase/completed"
 
 
 exit_criteria_met: false
@@ -73,6 +73,12 @@ and it inflated this ticket's apparent priority.) Call sites across `crates/cloa
 - **Current Problems**: {What's difficult/slow/buggy now}
 - **Benefits of Fixing**: {What improves after refactoring}
 - **Risk Assessment**: {Risks of not addressing this}
+
+## Acceptance Criteria
+
+## Acceptance Criteria
+
+## Acceptance Criteria
 
 ## Acceptance Criteria **[REQUIRED]**
 
@@ -180,3 +186,57 @@ and it inflated this ticket's apparent priority.) Call sites across `crates/cloa
   expect the honest answer to be "not yet". Revisit if a future plugin-ABI
   version adds several more method indices — the seam gets more attractive as
   the index count grows, and that is the trigger to watch for.
+
+- 2026-08-16 — INVESTIGATED AND DECIDED: **do not build the proposed seam.**
+  Closing. The reason is not "too small" — it is that the premise does not
+  survive reading the call sites instead of counting them.
+
+  **The bridges are TWO families, not one.**
+
+  *Family A — typed `call_method`; fidius owns serialization. No JSON at all:*
+    * `ffi_trigger.rs` — `call_method(METHOD_INVOKE_TRIGGER_POLL, &request)`,
+      `TriggerInvokeRequest` → `TriggerInvokeResult`
+    * `ffi_triggerless_graph.rs` — same, `TriggerlessGraphInvokeRequest`
+    * `task_registrar/dynamic_task.rs` — `call_method(METHOD_EXECUTE_TASK, &(request,))`
+    * `package_loader.rs` (×3) and `task_registrar/extraction.rs` — typed,
+      e.g. `call_method::<(), GraphPackageMetadata>(..)`
+    ≈ 8 sites.
+
+  *Family B — manual `serde_json` string round-trip.* `constructor_loader.rs`
+  ONLY: `METHOD_EXECUTE`, `METHOD_POLL`, `METHOD_INGEST`, `METHOD_EVALUATE`.
+  4 sites.
+
+  The objective presents
+  `to_string(&XInvocation) → call_method::<_,String> → from_str::<XOutcome>`
+  as the universal pattern. It is family B only. **Family A already has the
+  generic marshaling seam this ticket proposes building — it is fidius's typed
+  `call_method`.** Wrapping that would add a layer, not remove one.
+
+  **So the seam serves 4 sites, and those 4 disagree with each other:**
+    * `METHOD_EXECUTE` — async, fails as `TaskError` (via `exec_err`)
+    * `METHOD_POLL` — async, fails as `TriggerError::PollError`
+    * `METHOD_EVALUATE` — async, fails as `LoaderError::Validation`
+    * `METHOD_INGEST` — **synchronous**, no `spawn_blocking` at all (`process`
+      is sync), and returns `Option`: `tracing::error!` + `return None` rather
+      than propagating an error
+
+  Three error types across three sites, and the fourth has a different control
+  shape entirely. A generic `invoke_ffi::<Req, Res>` would cover 3 sites and
+  each would still need its own `map_err`. This is precisely the ticket's own
+  stated fear — "the per-index metadata differences are slightly more real" —
+  confirmed by reading rather than assumed.
+
+  **THE REAL DEEPENING IS A DIFFERENT ONE.** The interesting question is not
+  "how do we wrap constructor_loader's JSON round-trip?" but "why does
+  constructor_loader hand-roll JSON strings when every other bridge passes
+  typed values and lets fidius serialize?" Converting family B to typed calls
+  DELETES the manual serialization layer rather than wrapping it — strictly
+  better, and it makes the loader internally consistent. It is also a bigger
+  job: the guest exports these methods taking `(String,)`, so it changes the
+  plugin ABI and needs an interface-version bump. Filed as [[CLOACI-T-0931]]
+  rather than smuggled in here.
+
+  DECISION: close. Not "deferred with a trigger" — the proposed design is
+  superseded, because T-0931 reaches the same goal by removing the duplication
+  instead of centralizing it. No code changed under this ticket; the
+  deliverable is the decision and its evidence.

--- a/.metis/backlog/tech-debt/CLOACI-T-0882.md
+++ b/.metis/backlog/tech-debt/CLOACI-T-0882.md
@@ -4,7 +4,7 @@ level: task
 title: "Investigate: cloaca RetryPolicy/BackoffStrategy/RetryCondition value objects exposed but unwired"
 short_code: "CLOACI-T-0882"
 created_at: 2026-07-09T22:56:10.031554+00:00
-updated_at: 2026-08-10T22:50:18.846076+00:00
+updated_at: 2026-08-14T03:08:55.881063+00:00
 parent: 
 blocked_by: []
 archived: false
@@ -12,7 +12,7 @@ archived: false
 tags:
   - "#task"
   - "#tech-debt"
-  - "#phase/active"
+  - "#phase/completed"
 
 
 exit_criteria_met: false
@@ -66,6 +66,8 @@ Surfaced during I-0137 (cloaca registrar) + the maintainer's coverage catch: `cl
 - **Current Problems**: {What's difficult/slow/buggy now}
 - **Benefits of Fixing**: {What improves after refactoring}
 - **Risk Assessment**: {Risks of not addressing this}
+
+## Acceptance Criteria
 
 ## Acceptance Criteria **[REQUIRED]**
 

--- a/.metis/backlog/tech-debt/CLOACI-T-0931.md
+++ b/.metis/backlog/tech-debt/CLOACI-T-0931.md
@@ -1,0 +1,190 @@
+---
+id: constructor-loader-hand-rolls-json
+level: task
+title: "constructor_loader hand-rolls JSON marshaling while every other FFI bridge passes typed values"
+short_code: "CLOACI-T-0931"
+created_at: 2026-08-16T14:32:50.577879+00:00
+updated_at: 2026-08-16T14:32:50.577879+00:00
+parent: 
+blocked_by: []
+archived: false
+
+tags:
+  - "#task"
+  - "#phase/backlog"
+  - "#tech-debt"
+
+
+exit_criteria_met: false
+initiative_id: NULL
+---
+
+# constructor_loader hand-rolls JSON marshaling while every other FFI bridge passes typed values
+
+*This template includes sections for various types of tasks. Delete sections that don't apply to your specific use case.*
+
+## Parent Initiative **[CONDITIONAL: Assigned Task]**
+
+[[Parent Initiative]]
+
+## Objective **[REQUIRED]**
+
+Successor to [[CLOACI-T-0873]], which asked whether to build a generic
+`invoke_ffi::<Req,Res>` seam and concluded **no** — because investigating it
+surfaced a better question. Read T-0873's 2026-08-16 status update for the full
+evidence; the short version:
+
+The loader's FFI bridges are **two families**, not one.
+
+* **Family A — typed `call_method`; fidius owns serialization.** No JSON.
+  `ffi_trigger.rs`, `ffi_triggerless_graph.rs`,
+  `task_registrar/dynamic_task.rs`, `package_loader.rs` (×3),
+  `task_registrar/extraction.rs`. ≈ 8 sites.
+* **Family B — manual `serde_json` string round-trip.** `constructor_loader.rs`
+  only: `METHOD_EXECUTE`, `METHOD_POLL`, `METHOD_INGEST`, `METHOD_EVALUATE`.
+  4 sites. Each does
+  `to_string(&XInvocation)` → `call_method::<_, String>(M, &(json,))` →
+  `from_str::<XOutcome>`.
+
+Family A already has the generic marshaling seam — it is fidius's typed
+`call_method`. Family B re-implements by hand, per method index, what the rest
+of the loader gets for free.
+
+**The work:** convert family B to typed calls, DELETING the manual
+serialization layer rather than wrapping it. This is the deepening T-0873 was
+reaching for; wrapping would have added a layer, removing subtracts one, and it
+makes the loader internally consistent so there is one way to cross the FFI
+boundary instead of two.
+
+**Why this is bigger than it looks (the reason it is its own ticket):** the
+guest side exports these four methods taking `(String,)`. Changing the host to
+pass typed values requires changing the guest signatures too — a plugin **ABI
+change** needing an interface-version bump in
+`crates/cloacina-workflow-plugin`, plus the usual rebuild-every-fixture
+consequences. Not a refactor that stays inside one crate.
+
+**Watch out for `METHOD_INGEST`:** unlike its three siblings it is
+*synchronous* (`process` is sync — no `spawn_blocking`) and returns `Option`,
+logging via `tracing::error!` + `return None` instead of propagating an error.
+Any uniform treatment has to accommodate that or deliberately leave it alone.
+
+### Type
+- [x] Tech Debt - Code improvement or refactoring
+
+### Priority
+- [x] P3 - Low (no user-visible defect; consistency + one-way-to-do-it. The ABI
+      bump means it is best bundled with another interface-version change
+      rather than spent on its own.)
+
+## Backlog Item Details **[CONDITIONAL: Backlog Item]**
+
+{Delete this section when task is assigned to an initiative}
+
+### Type
+- [ ] Bug - Production issue that needs fixing
+- [ ] Feature - New functionality or enhancement  
+- [ ] Tech Debt - Code improvement or refactoring
+- [ ] Chore - Maintenance or setup work
+
+### Priority
+- [ ] P0 - Critical (blocks users/revenue)
+- [ ] P1 - High (important for user experience)
+- [ ] P2 - Medium (nice to have)
+- [ ] P3 - Low (when time permits)
+
+### Impact Assessment **[CONDITIONAL: Bug]**
+- **Affected Users**: {Number/percentage of users affected}
+- **Reproduction Steps**: 
+  1. {Step 1}
+  2. {Step 2}
+  3. {Step 3}
+- **Expected vs Actual**: {What should happen vs what happens}
+
+### Business Justification **[CONDITIONAL: Feature]**
+- **User Value**: {Why users need this}
+- **Business Value**: {Impact on metrics/revenue}
+- **Effort Estimate**: {Rough size - S/M/L/XL}
+
+### Technical Debt Impact **[CONDITIONAL: Tech Debt]**
+- **Current Problems**: {What's difficult/slow/buggy now}
+- **Benefits of Fixing**: {What improves after refactoring}
+- **Risk Assessment**: {Risks of not addressing this}
+
+## Acceptance Criteria **[REQUIRED]**
+
+- [ ] `constructor_loader.rs` contains no `serde_json::to_string` /
+      `from_str` around a `call_method` — the four bridges pass typed values.
+- [ ] Guest-side signatures updated to match, with the plugin interface version
+      bumped and the version check rejecting stale packages.
+- [ ] `METHOD_INGEST`'s sync/`Option` shape either accommodated or explicitly
+      left as-is with the reason recorded in-code.
+- [ ] All packaged fixtures rebuilt and the packaged e2e lane green
+      (`angreal test e2e compiler`) — this is an ABI change, so a passing
+      `cargo check` proves nothing about whether real packages still load.
+- [ ] Verified against a live server, not just unit tests: a constructor-backed
+      workflow executes end to end (constructors are the surface T-0925 touched).
+
+## Test Cases **[CONDITIONAL: Testing Task]**
+
+{Delete unless this is a testing task}
+
+### Test Case 1: {Test Case Name}
+- **Test ID**: TC-001
+- **Preconditions**: {What must be true before testing}
+- **Steps**: 
+  1. {Step 1}
+  2. {Step 2}
+  3. {Step 3}
+- **Expected Results**: {What should happen}
+- **Actual Results**: {To be filled during execution}
+- **Status**: {Pass/Fail/Blocked}
+
+### Test Case 2: {Test Case Name}
+- **Test ID**: TC-002
+- **Preconditions**: {What must be true before testing}
+- **Steps**: 
+  1. {Step 1}
+  2. {Step 2}
+- **Expected Results**: {What should happen}
+- **Actual Results**: {To be filled during execution}
+- **Status**: {Pass/Fail/Blocked}
+
+## Documentation Sections **[CONDITIONAL: Documentation Task]**
+
+{Delete unless this is a documentation task}
+
+### User Guide Content
+- **Feature Description**: {What this feature does and why it's useful}
+- **Prerequisites**: {What users need before using this feature}
+- **Step-by-Step Instructions**:
+  1. {Step 1 with screenshots/examples}
+  2. {Step 2 with screenshots/examples}
+  3. {Step 3 with screenshots/examples}
+
+### Troubleshooting Guide
+- **Common Issue 1**: {Problem description and solution}
+- **Common Issue 2**: {Problem description and solution}
+- **Error Messages**: {List of error messages and what they mean}
+
+### API Documentation **[CONDITIONAL: API Documentation]**
+- **Endpoint**: {API endpoint description}
+- **Parameters**: {Required and optional parameters}
+- **Example Request**: {Code example}
+- **Example Response**: {Expected response format}
+
+## Implementation Notes **[CONDITIONAL: Technical Task]**
+
+{Keep for technical tasks, delete for non-technical. Technical details, approach, or important considerations}
+
+### Technical Approach
+{How this will be implemented}
+
+### Dependencies
+{Other tasks or systems this depends on}
+
+### Risk Considerations
+{Technical risks and mitigation strategies}
+
+## Status Updates **[REQUIRED]**
+
+*To be added during implementation*


### PR DESCRIPTION
docs(metis): decide T-0873 (don't build the seam); close T-0882; file T-0930/T-0931

T-0873 was an explicit investigate-and-decide: build a generic
invoke_ffi::<Req,Res> marshaling seam, or close. Decided: DO NOT build it. The
reason is not "too small" — the premise does not survive reading the call sites
instead of counting them.

The loader's FFI bridges are two families, not one.

  Family A — typed call_method; fidius owns serialization. No JSON anywhere:
  ffi_trigger.rs (TriggerInvokeRequest -> TriggerInvokeResult),
  ffi_triggerless_graph.rs, task_registrar/dynamic_task.rs, package_loader.rs
  (x3), task_registrar/extraction.rs. Roughly 8 sites.

  Family B — manual serde_json string round-trip. constructor_loader.rs ONLY:
  METHOD_EXECUTE, METHOD_POLL, METHOD_INGEST, METHOD_EVALUATE. 4 sites.

The ticket presents to_string(&XInvocation) -> call_method::<_,String> ->
from_str::<XOutcome> as the universal pattern. It is family B only. Family A
already HAS the generic marshaling seam this ticket proposed building — it is
fidius's typed call_method. Wrapping it would add a layer, not remove one.

So the seam would serve 4 sites, and those 4 disagree with each other:
METHOD_EXECUTE fails as TaskError, METHOD_POLL as TriggerError::PollError,
METHOD_EVALUATE as LoaderError::Validation, and METHOD_INGEST is synchronous
(no spawn_blocking at all) returning Option via tracing::error! + return None.
Three error types across three sites, and the fourth has a different control
shape entirely. A generic seam would cover 3 sites and each would still need
its own map_err — precisely the ticket's own stated fear, confirmed by reading
rather than assumed.

The investigation surfaced the better question, filed as T-0931: why does
constructor_loader hand-roll JSON when every other bridge passes typed values?
Converting family B to typed calls DELETES the manual serialization layer
instead of wrapping it. That is ABI-affecting (the guest exports these methods
taking (String,)), so it needs an interface-version bump and does not belong
smuggled into a decide-only ticket.

No code changed for T-0873. The deliverable is the decision and its evidence.

Also in this commit:

  - T-0882 transitioned to completed (implementation merged in #253).
  - T-0930 filed: build_retry_policy silently maps unrecognized
    retry_backoff/retry_condition strings to Fixed/AllErrors, so a typo like
    retry_backoff="exponentail" quietly yields Fixed. Found while implementing
    T-0882 and deliberately left out of it, since erroring instead is a
    breaking change for anyone currently relying on the silent default.
