### PR TITLE
feat(T-0851): reactor leadership foundation — tenant-safe lock keys, ownership session, k8s-leader unflake

### DIFF
--- a/.angreal/test/e2e/k8s_leader.py
+++ b/.angreal/test/e2e/k8s_leader.py
@@ -407,12 +407,16 @@ def _catch_lock_holder_sql(key, *, exclude_addr=None, poll_ms=10, timeout_s=20):
         "CREATE TEMP TABLE IF NOT EXISTS _holder_catch(addr text, pid int); "
         "DELETE FROM _holder_catch; "
         "DO $do$ DECLARE v_addr text; v_pid int; i int := 0; BEGIN LOOP "
+        # host(): client_addr is `inet`, and casting it to text can carry the
+        # netmask ("10.42.0.3/32"), which does NOT match the bare IPs in
+        # _server_pod_ips. The lookup then misses and the caller's fallback
+        # hands the ADDRESS back as if it were a pod name — observed for real:
+        # `kubectl delete pod 10.42.0.3/32`. host() yields the bare address.
+        #
         # coalesce: client_addr is NULL for a local (unix-socket) connection, and
         # NULL || '|' || pid is NULL — the holder row would exist but render as
-        # nothing, so the catcher would silently report "no holder found". Server
-        # pods connect over TCP so this is belt-and-braces in the cluster, but it
-        # is exactly the kind of quiet miss this helper exists to eliminate.
-        "SELECT coalesce(a.client_addr::text, 'local'), a.pid INTO v_addr, v_pid "
+        # nothing, so the catcher would silently report "no holder found".
+        "SELECT coalesce(host(a.client_addr), 'local'), a.pid INTO v_addr, v_pid "
         "FROM pg_locks l JOIN pg_stat_activity a ON l.pid = a.pid "
         f"WHERE l.locktype='advisory' AND l.classid={classid} AND l.objid={objid} "
         f"AND l.objsubid={objsubid} AND l.granted{exclude} LIMIT 1; "
@@ -447,7 +451,18 @@ def _catch_lock_holder(kubeconfig, target, *, key=FLEET_LOCK_KEY, exclude_pod=No
     addr, _, pid = row.strip().partition("|")
     # Re-resolve: the pod set may have changed while we waited.
     ip_to_pod = _server_pod_ips(kubeconfig)
-    return (ip_to_pod.get(addr, addr), addr, pid)
+    pod = ip_to_pod.get(addr)
+    if pod is None:
+        # Do NOT fall back to returning the address as the pod name. The caller
+        # feeds this straight to `kubectl delete pod`, and an unresolved address
+        # then becomes a delete against a nonexistent pod that crashes the lane
+        # with a confusing CalledProcessError. Observed for real when the address
+        # carried a /32 suffix. Report it as "no usable holder" instead, which
+        # blocks the assertion honestly and prints what could not be resolved.
+        print(f"  WARN: lock holder addr={addr} pid={pid} did not resolve to a "
+              f"server pod (known: {sorted(ip_to_pod)}); treating as no holder")
+        return None
+    return (pod, addr, pid)
 
 
 def _wait_lock_holder(kubeconfig, target, want_pod=None, not_pod=None, timeout_s=40):

--- a/.angreal/test/e2e/k8s_leader.py
+++ b/.angreal/test/e2e/k8s_leader.py
@@ -113,12 +113,57 @@ REPLICAS = 2
 # (crates/cloacina-server/src/autoscaler/leader.rs::FLEET_CONTROL_LOCK_KEY).
 FLEET_LOCK_KEY = 8110127
 
+
+def lock_query(key):
+    """psql for 'who currently holds advisory lock `key`', as (client_addr, pid).
+
+    Parameterized by key because CLOACI-T-0851 adds per-reactor ownership locks
+    alongside the fleet control lock, and those assertions want this lane's
+    existing machinery — `_wait_lock_holder`'s "never two simultaneous holders"
+    invariant and `_sample_lock`'s high-frequency sampling — rather than a
+    second, subtly-different copy of it.
+
+    Matches on the FULL key (classid + objid + objsubid), not `objid` alone —
+    see `advisory_lock_parts` for why matching a partial key is a correctness
+    bug in a test rather than a rounding error.
+    """
+    classid, objid, objsubid = advisory_lock_parts(key)
+    return (
+        "SELECT a.client_addr, a.pid FROM pg_locks l "
+        "JOIN pg_stat_activity a ON l.pid=a.pid "
+        f"WHERE l.locktype='advisory' AND l.classid={classid} AND l.objid={objid} "
+        f"AND l.objsubid={objsubid} AND l.granted;"
+    )
+
+
+def advisory_lock_parts(key):
+    """Split a 64-bit advisory key the way `pg_locks` reports it.
+
+    Postgres does not store a bigint advisory key in one column. For the
+    single-argument `pg_advisory_lock(bigint)` form it reports
+    `classid` = high 32 bits, `objid` = low 32 bits, `objsubid` = 1. (The
+    two-int4 form uses objsubid = 2, which we do not use.)
+
+    Matching on `objid` alone is wrong in BOTH directions and both failures are
+    quiet:
+
+      * Under-match — a full i64 compared against the 32-bit `objid` column
+        matches nothing. A lock query that matches nothing PASSES a "never two
+        simultaneous holders" assertion, so the test goes green while proving
+        the absence of the thing it was meant to observe.
+      * Over-match — two distinct keys sharing their low 32 bits look like the
+        same lock. Reactor keys have the sign bit forced, so every one of them
+        shares its high bits with the others; the low word is all that
+        distinguishes them, and a partial match would happily conflate a
+        reactor lock with the fleet lock.
+
+    Returned as unsigned, which is how `pg_locks` exposes them.
+    """
+    return ((key >> 32) & 0xFFFF_FFFF, key & 0xFFFF_FFFF, 1)
+
+
 # The exact psql query used for assertion 2 (single leader). Reported verbatim.
-LOCK_QUERY = (
-    "SELECT a.client_addr, a.pid FROM pg_locks l "
-    "JOIN pg_stat_activity a ON l.pid=a.pid "
-    f"WHERE l.locktype='advisory' AND l.objid={FLEET_LOCK_KEY} AND l.granted;"
-)
+LOCK_QUERY = lock_query(FLEET_LOCK_KEY)
 
 SERVER_SELECTOR = "app.kubernetes.io/name=cloacina-server"
 
@@ -230,9 +275,13 @@ def _psql(kubeconfig, target, sql, capture=True):
     return (r.stdout or "").strip()
 
 
-def _lock_holders(kubeconfig, target):
-    """Return list of (client_addr, pid) currently granted the fleet advisory lock."""
-    out = _psql(kubeconfig, target, LOCK_QUERY)
+def _lock_holders(kubeconfig, target, query=None):
+    """Return list of (client_addr, pid) currently granted an advisory lock.
+
+    Defaults to the fleet control lock. Pass `query=lock_query(k)` to assert on
+    a different key — e.g. a per-reactor ownership lock (CLOACI-T-0851).
+    """
+    out = _psql(kubeconfig, target, query or LOCK_QUERY)
     rows = []
     for line in out.splitlines():
         line = line.strip()

--- a/.angreal/test/e2e/k8s_leader.py
+++ b/.angreal/test/e2e/k8s_leader.py
@@ -374,6 +374,82 @@ def _sample_lock(kubeconfig, target, window_s, base=None, churn_n=0):
     return max_simul, observed, catches
 
 
+def _catch_lock_holder_sql(key, *, exclude_addr=None, poll_ms=10, timeout_s=20):
+    """SQL that waits INSIDE Postgres for a holder of advisory lock `key`.
+
+    Why this exists: the fleet lock is taken and released within a single
+    control-loop tick, so it is held for a brief instant. Polling it from
+    Python cost TWO subprocess spawns per sample (`kubectl get pods` +
+    `kubectl exec … psql`), hundreds of milliseconds each, so the sample rate
+    was latency-bound and the observed hit rate was ~6 catches per window.
+    Assertion 5 has to pin the holder at one instant before killing it, and it
+    lost that race often enough to block the lane — a CORE assertion failing
+    the run for reasons unrelated to anything under test.
+
+    Moving the loop server-side turns one exec into thousands of samples at
+    `poll_ms`, returning the instant a holder appears. Same observation, same
+    `pg_locks` predicate, ~1000x the sampling density.
+
+    `exclude_addr` skips a specific `client_addr` — used post-kill to wait for a
+    holder that is NOT the replica we just deleted, which is otherwise the same
+    race in the other direction.
+
+    NOTE: still matches the FULL key (classid + objid + objsubid). See
+    `advisory_lock_parts` for why a partial match is a silent failure.
+    """
+    classid, objid, objsubid = advisory_lock_parts(key)
+    iterations = max(1, int((timeout_s * 1000) // poll_ms))
+    exclude = ""
+    if exclude_addr:
+        # client_addr is inet; compare as text so a NULL addr cannot swallow it.
+        exclude = f" AND a.client_addr::text <> '{exclude_addr}'"
+    return (
+        "CREATE TEMP TABLE IF NOT EXISTS _holder_catch(addr text, pid int); "
+        "DELETE FROM _holder_catch; "
+        "DO $do$ DECLARE v_addr text; v_pid int; i int := 0; BEGIN LOOP "
+        # coalesce: client_addr is NULL for a local (unix-socket) connection, and
+        # NULL || '|' || pid is NULL — the holder row would exist but render as
+        # nothing, so the catcher would silently report "no holder found". Server
+        # pods connect over TCP so this is belt-and-braces in the cluster, but it
+        # is exactly the kind of quiet miss this helper exists to eliminate.
+        "SELECT coalesce(a.client_addr::text, 'local'), a.pid INTO v_addr, v_pid "
+        "FROM pg_locks l JOIN pg_stat_activity a ON l.pid = a.pid "
+        f"WHERE l.locktype='advisory' AND l.classid={classid} AND l.objid={objid} "
+        f"AND l.objsubid={objsubid} AND l.granted{exclude} LIMIT 1; "
+        "IF v_pid IS NOT NULL THEN INSERT INTO _holder_catch VALUES (v_addr, v_pid); RETURN; END IF; "
+        f"i := i + 1; EXIT WHEN i >= {iterations}; PERFORM pg_sleep({poll_ms / 1000.0}); "
+        "END LOOP; END $do$; "
+        "SELECT addr || '|' || pid FROM _holder_catch LIMIT 1;"
+    )
+
+
+def _catch_lock_holder(kubeconfig, target, *, key=FLEET_LOCK_KEY, exclude_pod=None,
+                       timeout_s=20):
+    """Wait (server-side) for a lock holder and resolve it to a pod.
+
+    Returns (pod, addr, pid) or None if none appeared within `timeout_s`.
+    `exclude_pod` resolves to that pod's IP and excludes it in SQL.
+    """
+    ip_to_pod = _server_pod_ips(kubeconfig)
+    exclude_addr = None
+    if exclude_pod is not None:
+        for ip, pod in ip_to_pod.items():
+            if pod == exclude_pod:
+                exclude_addr = ip
+                break
+    sql = _catch_lock_holder_sql(key, exclude_addr=exclude_addr, timeout_s=timeout_s)
+    out = _psql(kubeconfig, target, sql).strip()
+    # psql echoes CREATE TABLE / DELETE / DO before the final SELECT; the holder
+    # row is the only line containing our '|' separator.
+    row = next((l for l in out.splitlines() if "|" in l), None)
+    if not row:
+        return None
+    addr, _, pid = row.strip().partition("|")
+    # Re-resolve: the pod set may have changed while we waited.
+    ip_to_pod = _server_pod_ips(kubeconfig)
+    return (ip_to_pod.get(addr, addr), addr, pid)
+
+
 def _wait_lock_holder(kubeconfig, target, want_pod=None, not_pod=None, timeout_s=40):
     """Poll until a single lock holder is observed that matches the predicate.
 
@@ -734,7 +810,10 @@ def k8s_leader(no_cleanup=False, skip_build=False, claiming=False, agents="3", t
         for _ in range(2):
             _api("POST", f"/v1/tenants/{TENANT}/fleet/provision", expect=None, base=base)
         # Identify the current lock holder (the leader for the tick we catch).
-        holder = _wait_lock_holder(kubeconfig, postgres, timeout_s=40)
+        # Server-side wait: the lock lives for an instant per tick, so polling
+        # from here lost the race often enough to block this assertion. See
+        # _catch_lock_holder_sql.
+        holder = _catch_lock_holder(kubeconfig, postgres, timeout_s=40)
         if holder is None:
             results["5. leader failover"] = (
                 "BLOCKED: could not catch a lock holder to target for the kill")
@@ -744,7 +823,11 @@ def k8s_leader(no_cleanup=False, skip_build=False, claiming=False, agents="3", t
             print(f"  current lock holder: pod={old_pod} addr={old_addr} pid={old_pid} — deleting it")
             _kubectl(["delete", "pod", old_pod, "-n", NS, "--wait=false"], kubeconfig)
             # The surviving replica must acquire the lock (different pod than killed).
-            survivor = _wait_lock_holder(kubeconfig, postgres, not_pod=old_pod, timeout_s=60)
+            # Same instant-lifetime race as the pre-kill catch, but this one
+            # HARD-FAILS the lane rather than blocking, so it needs the
+            # server-side wait at least as much.
+            survivor = _catch_lock_holder(
+                kubeconfig, postgres, exclude_pod=old_pod, timeout_s=60)
             if survivor is None:
                 _dump_diag(kubeconfig, "no survivor acquired the lock")
                 raise AssertionError("after killing the leader, NO surviving replica acquired the "

--- a/.metis/adrs/CLOACI-A-0012.md
+++ b/.metis/adrs/CLOACI-A-0012.md
@@ -177,8 +177,90 @@ Permanent as a direction, but two triggers would reopen the durability half:
   acceptable for the current model; a latency-sensitive consumer would need
   hand-off rather than expiry-based failover.
 
-### Open Question For Implementation
+### Open Question For Implementation — RESOLVED 2026-08-16
 Per-reactor advisory lock-key allocation across tenants (see Consequences →
-Negative). This ADR fixes the direction, not the key scheme; resolve that in
-[[CLOACI-T-0851]] before writing the lease code, since getting it wrong is a
-cross-tenant bug and those are the expensive kind here.
+Negative). Resolved in `computation_graph::reactor_lock_key`: a fixed-constant
+FNV-1a over a length-delimited `(tenant, reactor)` encoding, sign bit forced so
+reactor keys occupy the negative i64 half and cannot collide with hand-picked
+small positive keys like `FLEET_CONTROL_LOCK_KEY`. The hazard was real —
+tenants are isolated by SCHEMA within one database, while advisory locks are
+database-wide.
+
+Note for anyone extending this: a seeded hasher (`DefaultHasher`/`RandomState`)
+would have been a split-brain bug, since it is seeded PER PROCESS — every
+replica would compute a different key, every replica would win "the lock", and
+all of them would run the reactor. The stability test pins exact key literals
+for that reason.
+
+---
+
+## AMENDMENT 1 (2026-08-16) — long-held ownership DOES need a liveness check
+
+**What this amends:** the Decision's reliance on the A-0008 property that
+session-scoped advisory locks need no lease or heartbeat bookkeeping, because a
+dead replica's locks auto-release. That reasoning is sound for FAILOVER and it
+is NOT sufficient for ownership held across many ticks. This was found while
+implementing [[CLOACI-T-0851]]; it does not change the chosen design, but the
+original text would lead an implementer to omit something load-bearing.
+
+**The gap.** The fleet control loop re-acquires its lock EVERY TICK, so a
+dropped connection simply means it stops being leader — self-correcting. Reactor
+ownership is acquired once and then assumed. That admits a failure the fleet
+loop cannot have:
+
+> The ownership connection drops (network blip, PgBouncer recycle, database
+> restart) while the replica keeps running. Postgres releases every lock that
+> session held. Another replica legitimately claims the reactor. **The original
+> replica never notices and keeps running it.** Two replicas, one reactor, no
+> error raised anywhere.
+
+That is the exact split-brain this ADR exists to prevent, re-entering through
+the side door — and presenting as intermittent duplicate work rather than as an
+error.
+
+**Amended decision (maintainer, 2026-08-16): self-check and halt.** The
+ownership session periodically re-asserts that Postgres still reports every lock
+it believes it holds (`SESSION_HELD_LOCKS_SQL`, scoped by
+`pid = pg_backend_pid()` so another replica's lock cannot read as our own). On
+loss, the affected reactors are stopped locally BEFORE any re-claim is
+attempted.
+
+This is loss DETECTION, not lease renewal. There is still no TTL, no clock
+assumption, and no bookkeeping row; Postgres remains the single source of truth
+and we only ask whether what we believe is still true. The "no lease/heartbeat
+bookkeeping" property survives in substance — what does not survive is the
+inference that *nothing* need be checked.
+
+A three-state result is required, not a boolean: "we lost locks" and "the check
+could not run" are different situations, and conflating them yields either
+needless stops of healthy reactors or confident operation of unowned ones. An
+indeterminate check must be treated as UNKNOWN, never as healthy.
+
+**Considered and deferred: fencing tokens.** A monotonic token per claim,
+carried on every checkpoint write and rejected when stale, is strictly safer —
+a zombie replica could not corrupt state even inside the detection window. It
+needs a schema change and touches the checkpoint write path, so it is not in
+v1. Revisit if the detection window proves too wide in practice.
+
+## AMENDMENT 2 (2026-08-16) — ownership is ONE session holding many locks
+
+**What this amends:** an unstated assumption that reactor locks would be taken
+the way `autoscaler/leader.rs` takes its lock. They cannot be, and the reason is
+resource exhaustion rather than correctness.
+
+`with_fleet_leadership` holds one pooled connection for the duration of ONE
+TICK — lock, work, unlock, return to pool. Advisory locks are session-scoped, so
+a lock survives only while its connection is held. Reactor ownership must
+persist for as long as the replica runs the reactor, so the same shape would pin
+one pooled connection PER OWNED REACTOR for the process lifetime, exhausting the
+pool as reactor count grows.
+
+**Amended decision:** ONE dedicated ownership session per replica, carrying ALL
+of that replica's reactor locks — a Postgres session may hold many. Connection
+cost is O(1) in reactor count instead of O(reactors), and replica death still
+ends the session and releases every reactor lock at once, which is exactly the
+failover behaviour the Decision relies on.
+
+Operator-visible consequence (maintainer chose "take one and document it" over
+raising the default): each replica permanently reserves one connection from the
+pool. Pool sizing must account for it.

--- a/.metis/backlog/features/CLOACI-T-0851.md
+++ b/.metis/backlog/features/CLOACI-T-0851.md
@@ -273,7 +273,66 @@ Make the reactive layer (accumulators + reactors) safe and well-defined under mu
   recorded at the call site. Any future reactor-lock assertion MUST go through
   it.
 
-  NOT YET VERIFIED: the harness edit has not been syntax-checked or run (tooling
-  was unavailable at the time of writing). Do that before trusting it — it is a
-  pure-Python change to a lane that takes many minutes to execute, so a syntax
-  error would otherwise surface deep into a k3s deploy.
+  RESOLVED: the harness edit is now syntax-checked and its output verified.
+  `advisory_lock_parts(8110127)` → `(0, 8110127, 1)`, so the tightened fleet
+  query matches the identical row set — no behavior change to T-0818's existing
+  assertions. Reactor keys split to distinct `(classid, objid)` pairs.
+
+  While verifying, tightened it further: the query now matches the FULL key
+  (`classid` + `objid` + `objsubid`), not `objid` alone. Partial matching is
+  wrong in both directions and both are quiet — under-match returns no rows (and
+  a lock query returning no rows PASSES a "never two holders" assertion, going
+  green while proving the absence of what it should observe); over-match
+  conflates two keys sharing their low 32 bits, which matters here because every
+  reactor key shares its high bits by construction (forced sign bit), leaving
+  the low word as the only discriminator.
+
+- 2026-08-16 (cont.) — OWNERSHIP SESSION.
+  `crates/cloacina/src/computation_graph/reactor_ownership.rs`: `ReactorId`
+  (tenant + name, mirroring the scheduler's own map key so a claim and the
+  reactor it guards cannot drift), `OwnershipState` (what this replica BELIEVES
+  it owns), `OwnershipCheck`, and `SESSION_HELD_LOCKS_SQL`. 7 tests; full crate
+  check green on `postgres,macros --all-targets`.
+
+  **MAINTAINER DECISION 2026-08-16 — A-0012 NEEDS AMENDING.** A-0012 states
+  session-scoped locks need "no lease/heartbeat bookkeeping." True for failover,
+  NOT sufficient for long-held ownership. New failure mode, absent from the ADR:
+
+  > The ownership connection drops (network blip, PgBouncer recycle, DB
+  > restart) while the replica keeps running. Postgres releases every lock the
+  > session held. Another replica legitimately claims the reactor. The original
+  > replica NEVER NOTICES and keeps running it. Two replicas, one reactor, no
+  > error raised anywhere.
+
+  The fleet loop is immune only because it re-acquires every tick — a dropped
+  connection just means it stops leading. Ownership that is ASSUMED rather than
+  re-established must be re-verified.
+
+  Decision: **self-check + halt.** The session periodically re-asserts its locks
+  via `SESSION_HELD_LOCKS_SQL`; on loss the affected reactors are stopped
+  locally BEFORE any re-claim. This is loss DETECTION, not lease renewal — no
+  TTL, no clock assumption, no bookkeeping row, Postgres still the sole source
+  of truth. (Fencing tokens were considered and deferred: strictly safer, but
+  they need a schema change and touch the checkpoint write path.)
+
+  Design details worth keeping:
+    * `OwnershipCheck` is a 3-state enum, not a bool. "We lost locks" and "the
+      check could not run" are different situations; conflating them yields
+      either needless stops of healthy reactors or confident operation of
+      unowned ones. `Indeterminate` must be treated as UNKNOWN, never healthy.
+    * `SESSION_HELD_LOCKS_SQL` is scoped by `pid = pg_backend_pid()`, with a
+      test asserting that predicate is present. Without it, ANOTHER replica's
+      lock reads as our own and every liveness check passes while split-brained.
+    * `diff_against_held_keys` is a pure function so the logic deciding whether
+      reactors get stopped is testable with no database, including the
+      everything-lost case (dropped session must report ALL reactors lost, not
+      silently none).
+
+  Pool: one dedicated connection per replica carrying ALL its reactor locks —
+  O(1) in reactor count, documented as an operator-visible reservation
+  (maintainer chose "take one and document it" over raising the default).
+
+  NEXT: the async claim/release calls on the held connection (mirroring
+  `with_fleet_leadership`'s `interact` pattern), then the periodic verify task,
+  then wiring into `ComputationGraphScheduler`, then routing, then accumulator
+  persist + restore.

--- a/.metis/backlog/features/CLOACI-T-0851.md
+++ b/.metis/backlog/features/CLOACI-T-0851.md
@@ -332,7 +332,109 @@ Make the reactive layer (accumulators + reactors) safe and well-defined under mu
   O(1) in reactor count, documented as an operator-visible reservation
   (maintainer chose "take one and document it" over raising the default).
 
-  NEXT: the async claim/release calls on the held connection (mirroring
-  `with_fleet_leadership`'s `interact` pattern), then the periodic verify task,
-  then wiring into `ComputationGraphScheduler`, then routing, then accumulator
+- 2026-08-16 (cont.) — `OwnershipSession` IMPLEMENTED (postgres-gated).
+  `connect` / `claim` / `release` / `verify_owned`, holding the dedicated
+  connection and driving `pg_try_advisory_lock` / `pg_advisory_unlock` /
+  `SESSION_HELD_LOCKS_SQL` through deadpool's `interact`, mirroring
+  `with_fleet_leadership`. Both feature builds green
+  (`postgres,macros` and `sqlite,macros`, `--all-targets`); 14 unit tests pass.
+
+  Three deliberate behaviours, each chosen because the alternative fails quietly:
+    * A failed `claim` is NOT recorded as owned. `Ok(false)` means another
+      replica owns it — an ordinary outcome, not an error — and recording it
+      would make us believe we hold a lock we never got.
+    * `release` forgets the reactor locally EVEN IF the unlock returns false.
+      False means the lock was not held on this session, i.e. we had already
+      lost it; continuing to believe we own it is strictly the more dangerous
+      of the two options.
+    * `verify_owned` forgets lost reactors immediately, before returning. The
+      caller still has to stop them, but from that moment nothing in this
+      process believes it owns them, whatever the caller does next.
+
+  NEXT: periodic verify task + halt-on-loss wiring into
+  `ComputationGraphScheduler`, then event routing to the owner, then accumulator
   persist + restore.
+
+  GATE RESULT — `angreal test e2e k8s-leader`, real 2-replica k3s, **exit 1**,
+  `3/5 green; blocked: ['4','5']`.
+
+  **My lock-helper change is NOT the cause, and the evidence is specific.** The
+  worry was the exact trap documented above: if the tightened query matched
+  nothing, assertion 2 ("single fleet-lock holder") would still PASS, because
+  zero holders satisfies "at most one" — a vacuous green. The log rules that
+  out:
+
+      samples with a holder: 6; max simultaneous holders: 1;
+      holders observed: {…-nsp62: 3, …-dr8fs: 3}
+
+  Six real catches across both pods, never simultaneous. The full-key query
+  (`classid=0 AND objid=8110127 AND objsubid=1`) returns rows against a live
+  Postgres, so `objsubid = 1` is confirmed correct for the
+  `pg_try_advisory_lock(bigint)` form — which also validates the same assumption
+  baked into `SESSION_HELD_LOCKS_SQL`.
+
+  * Assertion 4 blocked BY DESIGN — it needs `--claiming`, which was not passed.
+  * Assertion 5 blocked: `never caught the lock holder pre-kill`. **Pre-existing
+    flakiness, not a regression.** The fleet lock is taken and released within a
+    single control tick, so it is only briefly held; the whole sampling window
+    caught it just 6 times. Assertion 5 must identify the holding pod at one
+    specific instant before killing it, and it loses that race often.
+
+  **THIS MATTERS FOR T-0851 IN A GOOD WAY.** Reactor ownership locks are held
+  CONTINUOUSLY, not per-tick. The reactor failover assertion therefore does not
+  inherit assertion 5's race at all: the holder is always there to be caught, so
+  "kill the owner, watch the survivor claim it" should be reliable where the
+  fleet equivalent is flaky. The reactor assertions should NOT copy assertion
+  5's sampling approach — they can simply read the holder directly.
+
+  Worth filing separately: assertion 5 is a CORE assertion that fails the lane
+  (exit 1) yet cannot run reliably, so `k8s-leader` is red for reasons unrelated
+  to any change under test. That is a trust problem for a gate — it trains
+  people to ignore the result.
+
+- 2026-08-17 — FLAKE FIXED AND VERIFIED. `angreal test e2e k8s-leader` now
+  **exits 0, 4/5 green, failed: []**. Assertion 5 passes on a real 2-replica
+  cluster:
+
+      current lock holder: pod=…-m2nrl addr=10.42.0.3 pid=160 — deleting it
+      failover: lock re-acquired by pod=…-wpb8c addr=10.42.0.6 pid=64
+
+  (Assertion 4 still blocked purely because `--claiming` was not passed.)
+
+  ROOT CAUSE was latency, not logic. Polling spawned TWO subprocesses per sample
+  (`kubectl get pods` + `kubectl exec … psql`), hundreds of ms each, while the
+  fleet lock is taken and released WITHIN one control tick — so the sample rate
+  was latency-bound and the whole window caught it 6 times. Fix: move the poll
+  inside Postgres. One exec runs a plpgsql loop sampling `pg_locks` every 10ms
+  and returns the instant a holder appears — same predicate, ~1000x the density.
+  Applied to BOTH the pre-kill catch and the post-kill survivor wait; the latter
+  has the identical race and HARD-FAILS rather than blocking.
+
+  TWO REAL BUGS IN MY OWN FIX, both found by running it, both the same family —
+  a quiet fallback turning a missing observation into a WRONG one:
+
+    1. **`::text` on inet appends the netmask.** Verified against live Postgres:
+       `'10.42.0.3'::inet::text` → `10.42.0.3/32`, while `host(...)` → `10.42.0.3`.
+       The `/32` form matches no key in `_server_pod_ips`. This is why the
+       ORIGINAL code worked and my rewrite broke it — plain display omits the
+       mask, the cast does not. Now uses `host()`.
+    2. **`ip_to_pod.get(addr, addr)` returned the ADDRESS as a pod name** when
+       resolution failed, which went straight to `kubectl delete pod
+       10.42.0.3/32` and crashed the lane with a confusing
+       `CalledProcessError`. This fallback PREDATES my change and would convert
+       any future resolution failure into the same confusing crash. Now prints
+       what failed to resolve and reports "no holder" instead of deleting
+       something that does not exist.
+
+  Also caught before the first cluster run, by testing the SQL against
+  `cloacina-postgres:15432`: `client_addr` is NULL for unix-socket connections
+  and `NULL || '|' || pid` is NULL, so a holder would have existed but rendered
+  as nothing and the catcher would have reported "no holder found". Fixed with
+  `coalesce` before it ever reached a cluster.
+
+  BEARING ON T-0851: reactor ownership locks are held CONTINUOUSLY, so the
+  reactor failover assertions do not inherit this race at all — the holder is
+  always there to be caught. They should read the holder directly rather than
+  copying assertion 5's sampling. The server-side catcher is still the right
+  tool for the post-kill wait, since "wait until someone OTHER than the killed
+  replica holds it" is inherently a wait.

--- a/.metis/backlog/features/CLOACI-T-0851.md
+++ b/.metis/backlog/features/CLOACI-T-0851.md
@@ -234,3 +234,46 @@ Make the reactive layer (accumulators + reactors) safe and well-defined under mu
   that killing the session really does release EVERY lock it held, which is the
   assumption the whole failover story rests on. Then the claim/release API,
   then routing, then accumulator persist + restore.
+
+  **VERIFICATION PLAN — use `angreal test e2e k8s-leader`, do not build
+  anything new.** I initially wrote "needs a live postgres" as though that were
+  an obstacle; the harness already provides the entire interruption apparatus
+  (maintainer correction, 2026-08-16). `.angreal/test/e2e/k8s_leader.py`
+  (T-0818) already runs a REAL 2-replica k3s deployment and already has:
+
+    * `_psql(kubeconfig, target, sql)` — arbitrary SQL into the cluster's postgres
+    * `_lock_holders()` — who currently holds an advisory lock, via `pg_locks`
+      joined to `pg_stat_activity`, resolving `client_addr` → owning pod
+    * `_wait_lock_holder(want_pod=/not_pod=)` — polls for a holder matching a
+      predicate AND asserts we never observe >1 simultaneous holder
+    * `_sample_lock(window_s)` — high-frequency sampling returning
+      `(max_simultaneous, observed_holders)`
+    * **assertion 5 is already the interruption test**: delete the lock-holding
+      replica, assert the survivor acquires the lock and the killed replica
+      reschedules and rejoins as a follower
+
+  That is exactly the shape T-0851 needs; the acceptance criterion "multi-replica
+  reactive validation added to the k8s-leader e2e lane" was always pointing here.
+  The reactor assertions become: own N reactors on one replica → kill it → assert
+  ALL N locks release and the survivor claims them, with a partially-filled
+  accumulator window intact on the other side.
+
+  **DONE toward that:** parameterized the lane's lock helpers by key —
+  `lock_query(key)` + `_lock_holders(..., query=)` — so reactor-lock assertions
+  reuse the existing "never two simultaneous holders" invariant instead of a
+  second, subtly-different copy. `LOCK_QUERY` is now `lock_query(FLEET_LOCK_KEY)`,
+  so the existing fleet assertions are unchanged.
+
+  **TRAP FOUND WHILE DOING IT, worth its own note.** `pg_locks.objid` holds only
+  the LOW 32 BITS of a 64-bit advisory key. Reactor keys are full-width i64 with
+  the sign bit forced, so matching a raw i64 against `objid` matches NOTHING —
+  and a lock query that matches nothing PASSES a "no two holders" assertion. The
+  failure mode is a green test proving the absence of the thing it was meant to
+  observe. Added `advisory_objid(key)` (`key & 0xFFFF_FFFF`) with that reasoning
+  recorded at the call site. Any future reactor-lock assertion MUST go through
+  it.
+
+  NOT YET VERIFIED: the harness edit has not been syntax-checked or run (tooling
+  was unavailable at the time of writing). Do that before trusting it — it is a
+  pure-Python change to a lane that takes many minutes to execute, so a syntax
+  error would otherwise surface deep into a k3s deploy.

--- a/.metis/backlog/features/CLOACI-T-0851.md
+++ b/.metis/backlog/features/CLOACI-T-0851.md
@@ -182,3 +182,55 @@ Make the reactive layer (accumulators + reactors) safe and well-defined under mu
 
   No changes made to objective, design directions, priority, or acceptance
   criteria — all still accurate.
+
+- 2026-08-16 — STARTED. [[CLOACI-A-0012]] signed off. First deliverable: the
+  tenant-safe lock-key scheme, which A-0012 named as the blocker to resolve
+  BEFORE any lease code.
+
+  **DONE:** `crates/cloacina/src/computation_graph/reactor_lock_key.rs` —
+  `reactor_lock_key(tenant: Option<&str>, reactor_name: &str) -> i64`, with 7
+  unit tests, all passing (`cargo test -p cloacina --lib --features sqlite
+  reactor_lock_key` → 7 passed).
+
+  Confirmed the hazard is real, not theoretical: tenants are isolated by
+  **schema within one database** (`SET LOCAL search_path TO <tenant>`,
+  `database/admin.rs`) and advisory locks are **database-wide**, not
+  schema-scoped. Name-only keying would have made two tenants' same-named
+  reactors contend for one lock, with exactly one silently never running.
+
+  Two traps found, each defended with a test rather than a comment:
+    * **A seeded hasher would be a split-brain bug.** `DefaultHasher` /
+      `RandomState` is seeded per PROCESS, so each replica computes a different
+      key, every replica wins "the lock", and all of them run the reactor —
+      presenting as an intermittent duplicate rather than an error. Used
+      hand-rolled FNV-1a with fixed constants; the stability test pins exact
+      literals so a change to the encoding fails loudly instead of splitting
+      brains during a rolling deploy.
+    * **`save_reactor_state` is a misleading precedent.** It keys checkpoints
+      by graph name alone and is CORRECT to do so, because the DAL is
+      schema-scoped. Locks are not. Documented in the module so the next reader
+      does not copy the wrong pattern.
+    Also length-delimited the encoding so `("a","bc")` and `("ab","c")` cannot
+    collide, and forced the sign bit so reactor keys occupy the negative i64
+    half — disjoint from hand-picked small positive keys like
+    `FLEET_CONTROL_LOCK_KEY` (8_110_127).
+
+  **DESIGN FINDING THAT CHANGES THE IMPLEMENTATION SHAPE (not in A-0012).**
+  From `autoscaler/leader.rs`: advisory locks are **session-scoped**, and the
+  fleet loop holds a pooled connection for ONE BRIEF TICK — lock, work, unlock,
+  return to pool. Reactor ownership is not tick-shaped; it must persist as long
+  as the replica runs the reactor. Copying the fleet pattern naively would hold
+  one pooled connection PER OWNED REACTOR for the process lifetime, exhausting
+  the pool as reactor count grows.
+
+  Proposed resolution, to validate next: ONE dedicated "ownership session"
+  connection per replica holding N advisory locks — a Postgres session can hold
+  many. Crash → session ends → ALL that replica's reactor locks release at
+  once, which is exactly the failover semantics wanted, at O(1) connections
+  instead of O(reactors). Preserves A-0012's "no lease/heartbeat bookkeeping"
+  property, since session-scoped locks auto-release on connection loss.
+
+  NEXT: validate one-session-many-locks against a live postgres — specifically
+  that killing the session really does release EVERY lock it held, which is the
+  assumption the whole failover story rests on. Then the claim/release API,
+  then routing, then accumulator persist + restore.

--- a/.metis/backlog/features/CLOACI-T-0851.md
+++ b/.metis/backlog/features/CLOACI-T-0851.md
@@ -438,3 +438,67 @@ Make the reactive layer (accumulators + reactors) safe and well-defined under mu
   copying assertion 5's sampling. The server-side catcher is still the right
   tool for the post-kill wait, since "wait until someone OTHER than the killed
   replica holds it" is inherently a wait.
+
+- 2026-08-17 — OWNERSHIP IS NOW ENFORCED IN THE SCHEDULER. PR #255 (draft),
+  11 commits. 90 `computation_graph` tests pass; both feature builds green.
+
+  **`ReactorOwnership` trait + `Option<Arc<dyn …>>` on the scheduler.** `None`
+  is the embedded / sqlite / single-replica path and runs NONE of this code —
+  which is how A-0012's "byte-for-byte unchanged" requirement is actually
+  guaranteed rather than merely intended. A trait (not the concrete
+  `OwnershipSession`) so the scheduler is not postgres-gated and the loss paths
+  are testable with a fake; the real failure modes — connection dropped, lock
+  stolen, verification unavailable — cannot be produced on demand against a
+  live database.
+
+  **`ownership_watchdog_tick`** — verify → watchdog verdict → halt. A single
+  tick, not a loop, so cadence stays with the caller and the test does not
+  depend on timing.
+
+  **`halt_unowned_reactors`** deliberately bypasses `unload_reactor`'s
+  subscriber guard. That guard is right for an operator unload and wrong here:
+  having lost the lock, another replica may already be running this reactor, so
+  refusing to stop because a subscriber remains leaves two copies
+  double-processing. Shares ONE `teardown_running` with the unload path — a
+  second copy would drift by forgetting a deregistration, leaving a stopped
+  reactor still advertised in the endpoint registry.
+
+  **Claim at load.** Placed with the other "resolve what can fail before we
+  spawn" work: losing a claim after the reactor and accumulators are live would
+  mean tearing down a running reactor, and a partial teardown is how endpoints
+  get orphaned. NOT winning is a normal outcome and the load still SUCCEEDS —
+  erroring would report a correctly-functioning multi-replica deployment as a
+  failed load on every replica but the owner. A claim ERROR does fail the load:
+  if we cannot reach Postgres to claim, we equally cannot know nobody else
+  holds it.
+
+  **`foreign_reactors` set**, found by a test rather than by design. The first
+  version returned `Ok(())` on claim loss and `load_graph` then tried to bind a
+  graph to a reactor that was never started — `reactor 'rx' is not loaded`.
+  Loaded-but-not-owned is a THIRD state, distinct from both loaded and absent,
+  and it needs to be explicit. This set is also where routing will look:
+  "where should this event go" begins with "is this reactor foreign to me".
+
+  `ReactorId` now converts to/from `TenantKey` instead of paralleling it —
+  `TenantKey`'s docs warn a deployment must never hold "two spellings of the
+  same scope", and an ownership claim keyed differently from the scheduler's
+  map would take a lock for one reactor while guarding another.
+
+  **REMAINING — this is NOT nearly done. Honest estimate: multiple sessions.**
+    1. **Server wiring.** Nothing constructs `PostgresOwnership` or calls
+       `set_ownership`, and nothing drives `ownership_watchdog_tick` on a timer.
+       Until that lands the feature is dormant everywhere — which is why it is
+       safe to have merged this far, and also why none of it is proven in situ.
+    2. **Event routing to the owner.** The largest remaining piece. Events
+       landing on a non-owner currently go nowhere: today that replica does not
+       run the reactor at all. Needs the delivery-substrate/outbox integration
+       A-0012 assumes. Start from `foreign_reactors`.
+    3. **Accumulator persist + restore** — the maintainer's hard requirement,
+       and untouched so far. Extend `persist_reactor_state` (one checkpoint,
+       one consistency point) and restore on takeover. Restore is the half that
+       gets quietly skipped; a snapshot nothing reads back buys nothing.
+    4. **k8s-leader reactor assertions** — own N reactors on one replica, kill
+       it, assert all N release, the survivor claims them, AND a partially
+       filled accumulator window survives. Read the holder directly (reactor
+       locks are held continuously); use the server-side catcher only for the
+       post-kill wait.

--- a/crates/cloacina-server/src/lib.rs
+++ b/crates/cloacina-server/src/lib.rs
@@ -128,6 +128,20 @@ use cloacina::database::Database;
 use cloacina::runner::{DefaultRunner, DefaultRunnerConfig};
 use cloacina::security::SecurityConfig;
 
+/// How often the reactor-ownership watchdog re-asserts this replica's locks
+/// (CLOACI-T-0851 / ADR CLOACI-A-0012 Amendment 1).
+const REACTOR_OWNERSHIP_CHECK_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// Consecutive unverifiable checks tolerated before ownership is PRESUMED LOST
+/// and the affected reactors are halted.
+///
+/// The product of these two constants is the worst-case window in which a
+/// replica that has silently lost its locks could still be running a reactor
+/// another replica now owns (~15s). Lowering the tolerance shortens that window
+/// but makes ordinary transient database errors stop healthy reactors; raising
+/// it does the reverse. Change them together and with that trade in mind.
+const REACTOR_OWNERSHIP_INDETERMINATE_TOLERANCE: u32 = 3;
+
 /// Cached per-tenant database connections for schema isolation.
 ///
 /// Each tenant gets a small connection pool scoped to their PostgreSQL schema.
@@ -736,10 +750,47 @@ pub async fn run(
 
     let endpoint_registry = EndpointRegistry::new();
     let unified_dal = cloacina::dal::unified::DAL::new(runner.database().clone());
-    let graph_scheduler = Arc::new(ComputationGraphScheduler::with_dal(
-        endpoint_registry.clone(),
-        unified_dal.clone(),
-    ));
+    let mut graph_scheduler_inner =
+        ComputationGraphScheduler::with_dal(endpoint_registry.clone(), unified_dal.clone());
+
+    // CLOACI-T-0851 / ADR CLOACI-A-0012: install cross-replica reactor
+    // ownership. Every server replica takes ONE dedicated pooled connection —
+    // the "ownership session" — which carries all of this replica's reactor
+    // advisory locks. Operators sizing the pool must account for that one
+    // reserved connection per replica.
+    //
+    // Installed unconditionally on Postgres, not only when multi-replica:
+    // with a single replica every claim simply succeeds locally and the
+    // watchdog always confirms, so behaviour is unchanged. There is no reliable
+    // way for a replica to know how many peers exist, and a coordination
+    // mechanism that is only switched on when someone remembers to is one that
+    // will be off during the incident.
+    //
+    // A failure here FAILS STARTUP rather than degrading quietly. Running the
+    // reactive layer without coordination is precisely the split-brain this
+    // exists to prevent, and it is invisible from the outside — a replica would
+    // happily process a stream that another replica also owns. Refusing to
+    // start is loud, recoverable, and honest about what is wrong.
+    #[cfg(feature = "postgres")]
+    {
+        use cloacina::computation_graph::reactor_ownership::{OwnershipSession, PostgresOwnership};
+
+        let session = OwnershipSession::connect(runner.database())
+            .await
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "failed to establish the reactor-ownership session: {e}. This connection \
+                     carries this replica's reactor advisory locks; without it the reactive \
+                     layer cannot guarantee that only one replica runs a given reactor, so \
+                     the server refuses to start rather than risk two replicas processing \
+                     the same stream."
+                )
+            })?;
+        graph_scheduler_inner.set_ownership(Arc::new(PostgresOwnership::new(session)));
+        info!("reactor ownership session established (one pooled connection reserved)");
+    }
+
+    let graph_scheduler = Arc::new(graph_scheduler_inner);
 
     // Substrate startup (CLOACI-I-0115, tasks T-0626/T-0627): construct the
     // WS delivery sink and the per-replica DeliveryRelay; spawn the relay's
@@ -766,6 +817,51 @@ pub async fn run(
     let delivery_sweeper =
         cloacina::delivery::DeliverySweeper::new(unified_dal.clone(), delivery_wake.clone());
     tokio::spawn(delivery_sweeper.run(substrate_shutdown_rx.clone()));
+
+    // CLOACI-T-0851 / A-0012 Amendment 1: reactor-ownership watchdog.
+    //
+    // Advisory locks auto-release when a replica DIES, which handles failover.
+    // They do not help when the ownership connection drops while the replica
+    // keeps running: Postgres frees the locks, another replica claims the
+    // reactor, and this one would carry on running it unaware. This loop
+    // re-asserts what we believe we own and halts anything we have lost.
+    //
+    // Cadence: with the default tolerance of 3 consecutive unverifiable checks,
+    // a total loss of database contact is acted on after roughly
+    // REACTOR_OWNERSHIP_CHECK_INTERVAL * 3. Short enough to bound
+    // double-processing, long enough that an ordinary blip does not stop
+    // healthy reactors — a reactive workload that flaps on every transient
+    // error is worse than one that takes ~15s to notice a real partition.
+    if graph_scheduler.has_ownership_coordination() {
+        let scheduler_for_watchdog = graph_scheduler.clone();
+        let mut watchdog_shutdown = substrate_shutdown_rx.clone();
+        tokio::spawn(async move {
+            use cloacina::computation_graph::reactor_ownership::OwnershipWatchdog;
+            let mut watchdog = OwnershipWatchdog::new(REACTOR_OWNERSHIP_INDETERMINATE_TOLERANCE);
+            let mut ticker = tokio::time::interval(REACTOR_OWNERSHIP_CHECK_INTERVAL);
+            ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            loop {
+                tokio::select! {
+                    _ = ticker.tick() => {
+                        let halted = scheduler_for_watchdog
+                            .ownership_watchdog_tick(&mut watchdog)
+                            .await;
+                        if !halted.is_empty() {
+                            warn!(
+                                count = halted.len(),
+                                "reactor-ownership watchdog halted reactors this replica no \
+                                 longer owns"
+                            );
+                        }
+                    }
+                    _ = watchdog_shutdown.changed() => {
+                        info!("reactor-ownership watchdog shutting down");
+                        break;
+                    }
+                }
+            }
+        });
+    }
 
     // Wire graph scheduler into the runner so the reconciler can route CG packages
     runner.set_graph_scheduler(graph_scheduler.clone()).await;

--- a/crates/cloacina/src/computation_graph/mod.rs
+++ b/crates/cloacina/src/computation_graph/mod.rs
@@ -30,6 +30,7 @@ pub mod graph_executor;
 pub mod packaging_bridge;
 pub mod reactor;
 pub mod reactor_lock_key;
+pub mod reactor_ownership;
 pub mod registry;
 pub mod scheduler;
 pub mod stream_backend;

--- a/crates/cloacina/src/computation_graph/mod.rs
+++ b/crates/cloacina/src/computation_graph/mod.rs
@@ -29,6 +29,7 @@ pub mod global_registry;
 pub mod graph_executor;
 pub mod packaging_bridge;
 pub mod reactor;
+pub mod reactor_lock_key;
 pub mod registry;
 pub mod scheduler;
 pub mod stream_backend;

--- a/crates/cloacina/src/computation_graph/reactor_lock_key.rs
+++ b/crates/cloacina/src/computation_graph/reactor_lock_key.rs
@@ -1,0 +1,222 @@
+/*
+ *  Copyright 2025 Colliery Software
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+//! Advisory-lock key derivation for per-reactor leadership (CLOACI-T-0851,
+//! [`ADR CLOACI-A-0012`]).
+//!
+//! # Why this needs its own module and its own tests
+//!
+//! Reactor ownership is claimed with a Postgres **session-level advisory
+//! lock**, mirroring the fleet control loop
+//! (`cloacina-server::autoscaler::leader`). Advisory locks live in a single
+//! **database-wide** key space: they are NOT scoped by schema.
+//!
+//! Cloacina isolates tenants by **schema within one database**
+//! (`SET LOCAL search_path TO <tenant>`; see `database::admin`). Every DAL
+//! table is therefore tenant-separated for free — but advisory locks are not.
+//! Deriving a reactor's lock key from the graph name alone would mean two
+//! tenants running a same-named graph contend for one lock, and exactly one of
+//! them would silently never run its reactor. That is a cross-tenant
+//! correctness bug that no single-tenant test could ever surface, which is why
+//! the key derivation is isolated here with tests rather than inlined at the
+//! lock call site.
+//!
+//! Note that `save_reactor_state` keys checkpoints by graph name alone and is
+//! safe precisely BECAUSE the DAL is schema-scoped. That asymmetry is the trap:
+//! the neighbouring persistence code looks like a precedent for
+//! name-only keying, and it is not one for locks.
+//!
+//! # Why not `DefaultHasher`
+//!
+//! `std::collections::hash_map::DefaultHasher` (and anything built on
+//! `RandomState`) is seeded randomly **per process**. Two replicas hashing the
+//! same `(tenant, reactor)` would compute DIFFERENT keys, so both would acquire
+//! "the lock" and both would run the reactor — the precise split-brain this
+//! mechanism exists to prevent, presenting as an intermittent duplicate rather
+//! than an error. The hash here is therefore a hand-rolled FNV-1a over a
+//! delimited encoding: fixed constants, no seed, stable across processes,
+//! releases, and architectures.
+
+/// Reserved high bit pattern distinguishing reactor-ownership keys from other
+/// subsystems' advisory locks in the same database-wide key space.
+///
+/// `cloacina-server::autoscaler::leader::FLEET_CONTROL_LOCK_KEY` is the small
+/// positive integer `8_110_127`. Reactor keys are forced negative so they can
+/// never collide with that key, nor with any other small-integer key a future
+/// subsystem picks by hand.
+const REACTOR_LOCK_KEY_SIGN_BIT: u64 = 1 << 63;
+
+/// FNV-1a 64-bit offset basis and prime. Fixed constants — see the module note
+/// on why a seeded hasher would be a correctness bug.
+const FNV_OFFSET_BASIS: u64 = 0xcbf2_9ce4_8422_2325;
+const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
+
+fn fnv1a(bytes: &[u8]) -> u64 {
+    let mut hash = FNV_OFFSET_BASIS;
+    for byte in bytes {
+        hash ^= *byte as u64;
+        hash = hash.wrapping_mul(FNV_PRIME);
+    }
+    hash
+}
+
+/// Derive the advisory-lock key identifying ownership of `reactor_name` within
+/// `tenant`.
+///
+/// `tenant` is the tenant scope as the scheduler keys it — `None` for
+/// single-tenant / admin-owned reactors, which is a distinct namespace from any
+/// named tenant (see the `none_tenant_is_distinct_from_named_tenant` test).
+///
+/// The encoding is length-delimited rather than concatenated so that
+/// `(tenant="a", reactor="bc")` and `(tenant="ab", reactor="c")` cannot collide.
+/// Plain concatenation with a separator is not enough either, since a tenant or
+/// reactor name may itself contain the separator.
+pub fn reactor_lock_key(tenant: Option<&str>, reactor_name: &str) -> i64 {
+    let mut buf = Vec::with_capacity(reactor_name.len() + 32);
+
+    // Domain tag: keeps this hash space distinct from any other FNV use.
+    buf.extend_from_slice(b"cloacina.reactor.ownership.v1\0");
+
+    match tenant {
+        // A named tenant is encoded with its length; `None` uses a marker that
+        // no length-prefixed string can produce.
+        Some(t) => {
+            buf.push(1);
+            buf.extend_from_slice(&(t.len() as u64).to_be_bytes());
+            buf.extend_from_slice(t.as_bytes());
+        }
+        None => buf.push(0),
+    }
+
+    buf.extend_from_slice(&(reactor_name.len() as u64).to_be_bytes());
+    buf.extend_from_slice(reactor_name.as_bytes());
+
+    // Force the sign bit so reactor keys occupy the negative half of the i64
+    // space, disjoint from hand-picked small positive keys like
+    // FLEET_CONTROL_LOCK_KEY.
+    (fnv1a(&buf) | REACTOR_LOCK_KEY_SIGN_BIT) as i64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The whole point of the module: two tenants running a same-named reactor
+    /// must not contend for one lock.
+    #[test]
+    fn same_reactor_in_different_tenants_gets_different_keys() {
+        let a = reactor_lock_key(Some("tenant_a"), "orders_reactor");
+        let b = reactor_lock_key(Some("tenant_b"), "orders_reactor");
+        assert_ne!(
+            a, b,
+            "same-named reactors in different tenants must not share a lock key"
+        );
+    }
+
+    #[test]
+    fn different_reactors_in_same_tenant_get_different_keys() {
+        let a = reactor_lock_key(Some("tenant_a"), "orders_reactor");
+        let b = reactor_lock_key(Some("tenant_a"), "billing_reactor");
+        assert_ne!(a, b);
+    }
+
+    /// Stability is a correctness requirement, not a nicety: replicas are
+    /// separate processes, so a per-process seed would give each its own key and
+    /// every replica would win "the lock" simultaneously. These literals are
+    /// pinned so a change to the hash constants or the encoding fails loudly
+    /// rather than silently splitting brains in production.
+    #[test]
+    fn keys_are_stable_across_processes() {
+        assert_eq!(
+            reactor_lock_key(Some("public"), "orders_reactor"),
+            reactor_lock_key(Some("public"), "orders_reactor"),
+        );
+        // Pinned expectations — update ONLY with a deliberate migration plan,
+        // since changing them means old and new replicas disagree about
+        // ownership during a rolling deploy.
+        assert_eq!(
+            reactor_lock_key(Some("public"), "orders_reactor"),
+            -798_654_939_832_276_275,
+        );
+        assert_eq!(
+            reactor_lock_key(None, "orders_reactor"),
+            -6_219_432_407_812_253_675,
+        );
+    }
+
+    /// `None` (single-tenant / admin-owned) is its own namespace. If it
+    /// collided with a tenant literally named e.g. "" or "public", an
+    /// admin-owned reactor and a tenant reactor would fight over one lock.
+    #[test]
+    fn none_tenant_is_distinct_from_named_tenant() {
+        let none_key = reactor_lock_key(None, "r");
+        assert_ne!(none_key, reactor_lock_key(Some(""), "r"));
+        assert_ne!(none_key, reactor_lock_key(Some("public"), "r"));
+    }
+
+    /// Length-delimiting matters: without it, ("a","bc") and ("ab","c") hash
+    /// the same bytes and two unrelated reactors silently share ownership.
+    #[test]
+    fn field_boundaries_cannot_be_forged() {
+        assert_ne!(
+            reactor_lock_key(Some("a"), "bc"),
+            reactor_lock_key(Some("ab"), "c"),
+        );
+        // A name containing the kind of separator a naive encoding would use.
+        assert_ne!(
+            reactor_lock_key(Some("a:b"), "c"),
+            reactor_lock_key(Some("a"), "b:c"),
+        );
+    }
+
+    /// Reactor keys must never collide with a hand-picked subsystem key.
+    /// FLEET_CONTROL_LOCK_KEY (8_110_127) is small and positive; every reactor
+    /// key is negative by construction.
+    #[test]
+    fn reactor_keys_never_collide_with_handpicked_subsystem_keys() {
+        const FLEET_CONTROL_LOCK_KEY: i64 = 8_110_127;
+        for name in ["a", "orders_reactor", "", "x".repeat(500).as_str()] {
+            for tenant in [None, Some("public"), Some("tenant_a")] {
+                let key = reactor_lock_key(tenant, name);
+                assert!(
+                    key < 0,
+                    "reactor key must be negative to stay disjoint from small positive subsystem keys, got {key}"
+                );
+                assert_ne!(key, FLEET_CONTROL_LOCK_KEY);
+            }
+        }
+    }
+
+    /// Cheap spread check over a realistic population. Not a proof of
+    /// collision-freedom — 64-bit birthday bounds make collisions negligible at
+    /// this scale — but it catches an encoding bug that funnels many inputs to
+    /// one key.
+    #[test]
+    fn no_collisions_across_a_realistic_population() {
+        let mut keys = std::collections::HashSet::new();
+        for t in 0..200 {
+            for r in 0..50 {
+                let tenant = format!("tenant_{t}");
+                let reactor = format!("reactor_{r}");
+                assert!(
+                    keys.insert(reactor_lock_key(Some(&tenant), &reactor)),
+                    "collision at tenant_{t}/reactor_{r}"
+                );
+            }
+        }
+        assert_eq!(keys.len(), 200 * 50);
+    }
+}

--- a/crates/cloacina/src/computation_graph/reactor_ownership.rs
+++ b/crates/cloacina/src/computation_graph/reactor_ownership.rs
@@ -1,0 +1,301 @@
+/*
+ *  Copyright 2025 Colliery Software
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+//! Per-reactor ownership via a single long-lived advisory-lock session
+//! (CLOACI-T-0851, [`ADR CLOACI-A-0012`]).
+//!
+//! # The shape, and why it differs from the fleet control loop
+//!
+//! `cloacina-server::autoscaler::leader` takes an advisory lock, does one
+//! tick's work, and unlocks — all on one pooled connection held briefly. Reactor
+//! ownership is not tick-shaped: a replica owns a reactor for as long as it runs
+//! it. Copying the fleet pattern per reactor would pin one pooled connection per
+//! owned reactor for the process lifetime and exhaust the pool as reactor count
+//! grows.
+//!
+//! Instead this holds **one dedicated connection per replica** — the *ownership
+//! session* — which carries ALL of that replica's reactor locks. A Postgres
+//! session can hold many advisory locks, so the connection cost is O(1) in
+//! reactor count. If the replica dies, the session ends and Postgres releases
+//! every one of its reactor locks at once, which is exactly the failover
+//! behaviour we want.
+//!
+//! **Operator note:** this permanently reserves one connection per replica from
+//! the pool. Size the pool with that in mind (maintainer decision 2026-08-16:
+//! take one and document it, rather than raising the default).
+//!
+//! # Why there is a liveness check even though locks are session-scoped
+//!
+//! A-0012 records that session-scoped locks need "no lease/heartbeat
+//! bookkeeping" because a crashed replica's locks auto-release. That is true for
+//! *failover*, and it is NOT sufficient here — long-held ownership has a failure
+//! mode the fleet loop cannot have:
+//!
+//! > The ownership connection drops (network blip, PgBouncer recycle, database
+//! > restart) while the replica keeps running. Postgres releases every lock the
+//! > session held. Another replica legitimately claims the reactor. **The
+//! > original replica never notices and keeps running it too.** Two replicas,
+//! > one reactor, no error raised anywhere.
+//!
+//! The fleet loop is immune because it re-acquires every tick, so a dropped
+//! connection simply means it stops being leader. Ownership that is *assumed*
+//! rather than *re-established* has to be re-verified, or the split-brain this
+//! whole mechanism exists to prevent comes back through the side door.
+//!
+//! So [`OwnershipSession::verify_owned`] re-asserts the locks this replica
+//! believes it holds. This is loss DETECTION, not lease renewal: there is no
+//! TTL, no clock assumption, and no bookkeeping row. Postgres stays the single
+//! source of truth; we are only asking it whether what we believe is still true.
+//! Callers must stop the affected reactors on loss before attempting re-claim —
+//! see [`OwnershipSession::verify_owned`]'s contract.
+
+use std::collections::HashSet;
+
+use crate::computation_graph::reactor_lock_key::reactor_lock_key;
+
+/// Identifies a reactor for ownership purposes: the tenant scope it was loaded
+/// under (`None` for single-tenant / admin-owned) plus its name.
+///
+/// This mirrors how `ComputationGraphScheduler` keys its `reactors` map, so an
+/// ownership claim and the in-process reactor it guards cannot drift apart.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ReactorId {
+    pub tenant: Option<String>,
+    pub name: String,
+}
+
+impl ReactorId {
+    pub fn new(tenant: Option<impl Into<String>>, name: impl Into<String>) -> Self {
+        Self {
+            tenant: tenant.map(Into::into),
+            name: name.into(),
+        }
+    }
+
+    /// The database-wide advisory-lock key for this reactor.
+    pub fn lock_key(&self) -> i64 {
+        reactor_lock_key(self.tenant.as_deref(), &self.name)
+    }
+}
+
+/// What a liveness check found. Deliberately not a bool: "we lost some locks" is
+/// a different situation from "the check itself could not run", and conflating
+/// them is how a replica ends up either needlessly stopping healthy reactors or
+/// confidently running unowned ones.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OwnershipCheck {
+    /// Every reactor this session believes it owns is still locked by it.
+    AllHeld,
+    /// These reactors are no longer owned. The caller MUST stop them locally
+    /// before attempting to re-claim — another replica may already be running
+    /// them.
+    Lost(Vec<ReactorId>),
+    /// The check could not be completed (connection down, query failed). The
+    /// caller must treat this as *unknown*, not as healthy: a session that
+    /// cannot reach Postgres cannot know whether it still holds anything.
+    Indeterminate(String),
+}
+
+/// Tracks which reactors this replica believes it owns.
+///
+/// The database is the source of truth; this set is only what we *believe*, and
+/// [`OwnershipCheck`] exists precisely because belief and truth can diverge.
+#[derive(Debug, Default)]
+pub struct OwnershipState {
+    held: HashSet<ReactorId>,
+}
+
+impl OwnershipState {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record a successful claim.
+    pub fn record_claimed(&mut self, id: ReactorId) {
+        self.held.insert(id);
+    }
+
+    /// Forget a reactor — after an explicit release, or after a liveness check
+    /// reported it lost.
+    pub fn record_released(&mut self, id: &ReactorId) {
+        self.held.remove(id);
+    }
+
+    pub fn believes_owned(&self, id: &ReactorId) -> bool {
+        self.held.contains(id)
+    }
+
+    pub fn owned(&self) -> impl Iterator<Item = &ReactorId> {
+        self.held.iter()
+    }
+
+    pub fn len(&self) -> usize {
+        self.held.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.held.is_empty()
+    }
+
+    /// Given the set of keys Postgres reports this session still holds, return
+    /// the reactors we believe we own but do not.
+    ///
+    /// Kept as a pure function so the divergence logic — the part that decides
+    /// whether reactors get stopped — is testable without a database.
+    pub fn diff_against_held_keys(&self, held_keys: &HashSet<i64>) -> Vec<ReactorId> {
+        let mut lost: Vec<ReactorId> = self
+            .held
+            .iter()
+            .filter(|id| !held_keys.contains(&id.lock_key()))
+            .cloned()
+            .collect();
+        // Deterministic order so logs and tests do not depend on HashSet
+        // iteration order.
+        lost.sort_by(|a, b| (&a.tenant, &a.name).cmp(&(&b.tenant, &b.name)));
+        lost
+    }
+}
+
+/// SQL asking Postgres which advisory locks the CURRENT session holds.
+///
+/// `pg_locks.pid = pg_backend_pid()` restricts to this session, which is the
+/// whole point: another replica holding the same lock must NOT read as "we
+/// still own it". The 64-bit key is reassembled from the split
+/// `classid`/`objid` columns (see `reactor_lock_key` and the k8s-leader lane's
+/// `advisory_lock_parts` for the same split on the test side).
+pub const SESSION_HELD_LOCKS_SQL: &str = "SELECT (classid::bigint << 32) | objid::bigint AS key \
+     FROM pg_locks \
+     WHERE locktype = 'advisory' AND objsubid = 1 AND granted AND pid = pg_backend_pid()";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn id(tenant: Option<&str>, name: &str) -> ReactorId {
+        ReactorId::new(tenant, name)
+    }
+
+    #[test]
+    fn believed_ownership_tracks_claim_and_release() {
+        let mut state = OwnershipState::new();
+        let a = id(Some("t1"), "r1");
+        assert!(!state.believes_owned(&a));
+
+        state.record_claimed(a.clone());
+        assert!(state.believes_owned(&a));
+        assert_eq!(state.len(), 1);
+
+        state.record_released(&a);
+        assert!(!state.believes_owned(&a));
+        assert!(state.is_empty());
+    }
+
+    #[test]
+    fn diff_reports_nothing_lost_when_all_keys_still_held() {
+        let mut state = OwnershipState::new();
+        let a = id(Some("t1"), "r1");
+        let b = id(Some("t2"), "r1");
+        state.record_claimed(a.clone());
+        state.record_claimed(b.clone());
+
+        let held: HashSet<i64> = [a.lock_key(), b.lock_key()].into_iter().collect();
+        assert!(state.diff_against_held_keys(&held).is_empty());
+    }
+
+    /// The failure this module exists for: the session dropped its locks while
+    /// the replica kept believing it owned them.
+    #[test]
+    fn diff_reports_reactors_whose_locks_vanished() {
+        let mut state = OwnershipState::new();
+        let a = id(Some("t1"), "r1");
+        let b = id(Some("t2"), "r1");
+        state.record_claimed(a.clone());
+        state.record_claimed(b.clone());
+
+        // Postgres reports only `a` — `b`'s lock is gone.
+        let held: HashSet<i64> = [a.lock_key()].into_iter().collect();
+        assert_eq!(state.diff_against_held_keys(&held), vec![b]);
+    }
+
+    /// A totally dropped session (no locks at all) must report EVERY reactor as
+    /// lost, not silently report none.
+    #[test]
+    fn diff_reports_everything_lost_when_session_holds_nothing() {
+        let mut state = OwnershipState::new();
+        let a = id(Some("t1"), "r1");
+        let b = id(None, "r2");
+        state.record_claimed(a.clone());
+        state.record_claimed(b.clone());
+
+        let lost = state.diff_against_held_keys(&HashSet::new());
+        assert_eq!(
+            lost.len(),
+            2,
+            "a dropped session loses everything: {lost:?}"
+        );
+    }
+
+    /// Same-named reactors in different tenants are distinct ownership units.
+    /// If they collapsed, losing one would look like losing both — or worse,
+    /// holding one would mask the loss of the other.
+    #[test]
+    fn tenants_are_independent_ownership_units() {
+        let mut state = OwnershipState::new();
+        let t1 = id(Some("t1"), "orders");
+        let t2 = id(Some("t2"), "orders");
+        state.record_claimed(t1.clone());
+        state.record_claimed(t2.clone());
+        assert_eq!(state.len(), 2, "same name in two tenants must be two units");
+
+        let held: HashSet<i64> = [t1.lock_key()].into_iter().collect();
+        assert_eq!(state.diff_against_held_keys(&held), vec![t2]);
+    }
+
+    #[test]
+    fn lost_ordering_is_deterministic() {
+        let mut state = OwnershipState::new();
+        for (t, n) in [
+            (Some("t2"), "b"),
+            (Some("t1"), "b"),
+            (Some("t1"), "a"),
+            (None, "z"),
+        ] {
+            state.record_claimed(id(t, n));
+        }
+        let lost = state.diff_against_held_keys(&HashSet::new());
+        let seen: Vec<(Option<String>, String)> = lost
+            .iter()
+            .map(|r| (r.tenant.clone(), r.name.clone()))
+            .collect();
+        let mut expected = seen.clone();
+        expected.sort();
+        assert_eq!(seen, expected, "lost list must be sorted for stable logs");
+    }
+
+    /// The session-scoping predicate is the difference between "we still hold
+    /// it" and "somebody holds it". Losing it would make every liveness check
+    /// pass while another replica owned the reactor.
+    #[test]
+    fn held_locks_sql_is_scoped_to_this_session() {
+        assert!(
+            SESSION_HELD_LOCKS_SQL.contains("pid = pg_backend_pid()"),
+            "liveness check MUST be scoped to this session, else another \
+             replica's lock reads as our own"
+        );
+        assert!(SESSION_HELD_LOCKS_SQL.contains("granted"));
+        assert!(SESSION_HELD_LOCKS_SQL.contains("objsubid = 1"));
+    }
+}

--- a/crates/cloacina/src/computation_graph/reactor_ownership.rs
+++ b/crates/cloacina/src/computation_graph/reactor_ownership.rs
@@ -91,6 +91,29 @@ impl ReactorId {
     }
 }
 
+// `ReactorId` and `TenantKey` are the same `(tenant, name)` pair. Conversions
+// rather than a parallel type: `TenantKey`'s own docs warn that a deployment
+// must never have "two spellings of the same scope", and an ownership claim
+// keyed differently from the scheduler's `reactors` map is precisely that —
+// it would take a lock for one reactor while guarding another.
+impl From<&crate::TenantKey> for ReactorId {
+    fn from(k: &crate::TenantKey) -> Self {
+        Self {
+            tenant: k.tenant_id.clone(),
+            name: k.name.clone(),
+        }
+    }
+}
+
+impl From<&ReactorId> for crate::TenantKey {
+    fn from(id: &ReactorId) -> Self {
+        Self {
+            tenant_id: id.tenant.clone(),
+            name: id.name.clone(),
+        }
+    }
+}
+
 /// What a liveness check found. Deliberately not a bool: "we lost some locks" is
 /// a different situation from "the check itself could not run", and conflating
 /// them is how a replica ends up either needlessly stopping healthy reactors or

--- a/crates/cloacina/src/computation_graph/reactor_ownership.rs
+++ b/crates/cloacina/src/computation_graph/reactor_ownership.rs
@@ -192,6 +192,35 @@ impl OwnershipState {
     }
 }
 
+/// The coordination surface the scheduler needs, independent of Postgres.
+///
+/// The scheduler holds an `Option<Arc<dyn ReactorOwnership>>`. **`None` is the
+/// embedded / single-replica / sqlite path and MUST behave exactly as before
+/// this feature existed** — no claim, no verification, no behaviour change.
+/// That is not merely a convenience: A-0012 requires single-replica and
+/// embedded behaviour to stay byte-for-byte identical, and the only way to be
+/// sure of that is for those deployments to execute none of this code.
+///
+/// A trait rather than a concrete `OwnershipSession` so the scheduler does not
+/// become postgres-gated, and so the claim/loss paths are testable with a fake
+/// instead of a live database. Coordination bugs are exactly the ones you
+/// cannot reproduce on demand against a real cluster.
+#[async_trait::async_trait]
+pub trait ReactorOwnership: Send + Sync {
+    /// Try to take ownership. `Ok(false)` = another replica owns it, which is
+    /// an ordinary outcome and not an error.
+    async fn claim(&self, id: &ReactorId) -> Result<bool, String>;
+
+    /// Give up ownership (normal unload).
+    async fn release(&self, id: &ReactorId) -> Result<(), String>;
+
+    /// Re-assert everything this replica believes it owns.
+    async fn verify(&self) -> OwnershipCheck;
+
+    /// What this replica currently believes it owns.
+    async fn believed_owned(&self) -> Vec<ReactorId>;
+}
+
 /// What the watchdog decided a caller should do after one liveness check.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum WatchdogAction {
@@ -432,6 +461,51 @@ mod session {
 
 #[cfg(feature = "postgres")]
 pub use session::OwnershipSession;
+
+/// [`ReactorOwnership`] over an [`OwnershipSession`].
+///
+/// The session needs `&mut self` (it mutates believed-ownership and drives one
+/// connection), while the trait takes `&self` so the scheduler can hold it
+/// behind an `Arc`. A `tokio::Mutex` bridges that.
+///
+/// Serializing ownership operations is a feature, not a cost: claim, release
+/// and verify all read-modify-write the same believed-ownership set against the
+/// same connection. Letting them interleave is how you get a verify that
+/// observes a half-applied claim and "helpfully" halts a reactor that was just
+/// acquired.
+#[cfg(feature = "postgres")]
+pub struct PostgresOwnership {
+    session: tokio::sync::Mutex<OwnershipSession>,
+}
+
+#[cfg(feature = "postgres")]
+impl PostgresOwnership {
+    pub fn new(session: OwnershipSession) -> Self {
+        Self {
+            session: tokio::sync::Mutex::new(session),
+        }
+    }
+}
+
+#[cfg(feature = "postgres")]
+#[async_trait::async_trait]
+impl ReactorOwnership for PostgresOwnership {
+    async fn claim(&self, id: &ReactorId) -> Result<bool, String> {
+        self.session.lock().await.claim(id).await
+    }
+
+    async fn release(&self, id: &ReactorId) -> Result<(), String> {
+        self.session.lock().await.release(id).await
+    }
+
+    async fn verify(&self) -> OwnershipCheck {
+        self.session.lock().await.verify_owned().await
+    }
+
+    async fn believed_owned(&self) -> Vec<ReactorId> {
+        self.session.lock().await.state().owned().cloned().collect()
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/crates/cloacina/src/computation_graph/reactor_ownership.rs
+++ b/crates/cloacina/src/computation_graph/reactor_ownership.rs
@@ -180,6 +180,150 @@ pub const SESSION_HELD_LOCKS_SQL: &str = "SELECT (classid::bigint << 32) | objid
      FROM pg_locks \
      WHERE locktype = 'advisory' AND objsubid = 1 AND granted AND pid = pg_backend_pid()";
 
+#[cfg(feature = "postgres")]
+mod session {
+    use super::*;
+    use deadpool_diesel::postgres::Manager as PgManager;
+    use tracing::warn;
+
+    #[derive(diesel::QueryableByName)]
+    struct AdvisoryLockRow {
+        #[diesel(sql_type = diesel::sql_types::Bool)]
+        locked: bool,
+    }
+
+    #[derive(diesel::QueryableByName)]
+    struct HeldKeyRow {
+        #[diesel(sql_type = diesel::sql_types::BigInt)]
+        key: i64,
+    }
+
+    /// A replica's reactor-ownership session: ONE pooled connection carrying all
+    /// of this replica's reactor advisory locks.
+    ///
+    /// Dropping this returns the connection to the pool, which ends the session
+    /// and releases every lock — so it must outlive the reactors it guards.
+    pub struct OwnershipSession {
+        conn: deadpool::managed::Object<PgManager>,
+        state: OwnershipState,
+    }
+
+    impl OwnershipSession {
+        /// Take the dedicated connection. See the module note on pool sizing:
+        /// this reserves one connection per replica for the process lifetime.
+        pub async fn connect(
+            db: &crate::database::Database,
+        ) -> Result<Self, deadpool::managed::PoolError<deadpool_diesel::Error>> {
+            Ok(Self {
+                conn: db.get_postgres_connection().await?,
+                state: OwnershipState::new(),
+            })
+        }
+
+        pub fn state(&self) -> &OwnershipState {
+            &self.state
+        }
+
+        /// Try to claim `id`. `Ok(false)` means another replica owns it — an
+        /// ordinary outcome, not an error.
+        ///
+        /// A failed claim must NOT be recorded as owned; that is the difference
+        /// between "we did not get it" and believing we did.
+        pub async fn claim(&mut self, id: &ReactorId) -> Result<bool, String> {
+            let sql = format!("SELECT pg_try_advisory_lock({}) AS locked", id.lock_key());
+            let acquired = self.run_lock_sql(sql).await?;
+            if acquired {
+                self.state.record_claimed(id.clone());
+            }
+            Ok(acquired)
+        }
+
+        /// Release `id`, forgetting it locally regardless of what Postgres says.
+        ///
+        /// If the unlock reports false the lock was not held on this session —
+        /// which means we had already lost it, so continuing to believe we own
+        /// it is the dangerous option. We warn and forget either way.
+        pub async fn release(&mut self, id: &ReactorId) -> Result<(), String> {
+            let sql = format!("SELECT pg_advisory_unlock({}) AS locked", id.lock_key());
+            let released = self.run_lock_sql(sql).await;
+            self.state.record_released(id);
+            match released {
+                Ok(true) => Ok(()),
+                Ok(false) => {
+                    warn!(
+                        reactor = %id.name,
+                        tenant = ?id.tenant,
+                        "pg_advisory_unlock returned false — ownership had already been lost; \
+                         forgetting it locally"
+                    );
+                    Ok(())
+                }
+                Err(e) => Err(e),
+            }
+        }
+
+        /// Re-assert that Postgres still reports every lock we believe we hold.
+        ///
+        /// See the module docs for why this exists at all. On
+        /// [`OwnershipCheck::Lost`] the caller MUST stop those reactors locally
+        /// BEFORE attempting to re-claim — another replica may already be
+        /// running them.
+        ///
+        /// [`OwnershipCheck::Indeterminate`] is NOT a pass. A session that
+        /// cannot reach Postgres does not know what it holds; treating that as
+        /// healthy is how a partitioned replica keeps running unowned reactors.
+        pub async fn verify_owned(&mut self) -> OwnershipCheck {
+            if self.state.is_empty() {
+                return OwnershipCheck::AllHeld;
+            }
+
+            let rows = self
+                .conn
+                .interact(|conn| {
+                    use diesel::RunQueryDsl;
+                    diesel::sql_query(SESSION_HELD_LOCKS_SQL).load::<HeldKeyRow>(conn)
+                })
+                .await;
+
+            let held: HashSet<i64> = match rows {
+                Ok(Ok(rows)) => rows.into_iter().map(|r| r.key).collect(),
+                Ok(Err(e)) => return OwnershipCheck::Indeterminate(format!("query failed: {e}")),
+                Err(e) => return OwnershipCheck::Indeterminate(format!("interact failed: {e}")),
+            };
+
+            let lost = self.state.diff_against_held_keys(&held);
+            if lost.is_empty() {
+                OwnershipCheck::AllHeld
+            } else {
+                // Forget them immediately: from here on we must not believe we
+                // own these, whatever the caller does about stopping them.
+                for id in &lost {
+                    self.state.record_released(id);
+                }
+                OwnershipCheck::Lost(lost)
+            }
+        }
+
+        async fn run_lock_sql(&self, sql: String) -> Result<bool, String> {
+            match self
+                .conn
+                .interact(move |conn| {
+                    use diesel::RunQueryDsl;
+                    diesel::sql_query(sql).get_result::<AdvisoryLockRow>(conn)
+                })
+                .await
+            {
+                Ok(Ok(row)) => Ok(row.locked),
+                Ok(Err(e)) => Err(format!("advisory lock query failed: {e}")),
+                Err(e) => Err(format!("interact failed: {e}")),
+            }
+        }
+    }
+}
+
+#[cfg(feature = "postgres")]
+pub use session::OwnershipSession;
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/cloacina/src/computation_graph/reactor_ownership.rs
+++ b/crates/cloacina/src/computation_graph/reactor_ownership.rs
@@ -169,6 +169,92 @@ impl OwnershipState {
     }
 }
 
+/// What the watchdog decided a caller should do after one liveness check.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WatchdogAction {
+    /// Ownership confirmed (or nothing owned). Keep running.
+    Continue,
+    /// These reactors are provably no longer ours. Stop them locally.
+    StopReactors(Vec<ReactorId>),
+    /// We have been unable to verify for too long. Stop everything we believed
+    /// we owned and treat it as lost. See [`OwnershipWatchdog`] for why this is
+    /// the safe direction.
+    StopAllPresumedLost(Vec<ReactorId>),
+}
+
+/// Turns a sequence of [`OwnershipCheck`]s into decisions.
+///
+/// The interesting case is [`OwnershipCheck::Indeterminate`], which the ADR
+/// amendment deliberately leaves as a policy question. Both naive answers are
+/// wrong:
+///
+/// * **Treat it as healthy** → a replica partitioned from Postgres keeps running
+///   its reactors forever. But a partition is exactly what KILLS the ownership
+///   session, and Postgres releases the locks the moment that connection drops,
+///   so another replica will legitimately take over. Optimism here produces the
+///   split-brain in its worst form: indefinite, and invisible.
+/// * **Treat it as loss immediately** → one dropped query, one restarting
+///   connection pool, and healthy reactors stop for no reason. Reactive
+///   workloads would flap on ordinary transient errors.
+///
+/// So indeterminacy is tolerated, but only for a bounded number of consecutive
+/// checks. Cross the threshold and we presume loss and stop, because the longer
+/// we cannot verify, the likelier it is that our session is already gone and
+/// someone else owns these reactors. Fail toward stopping: a stopped reactor is
+/// recoverable by re-claiming, while two live reactors silently double-process.
+#[derive(Debug)]
+pub struct OwnershipWatchdog {
+    consecutive_indeterminate: u32,
+    max_indeterminate: u32,
+}
+
+impl OwnershipWatchdog {
+    /// `max_indeterminate` is how many consecutive unverifiable checks to
+    /// tolerate before presuming loss. Must be >= 1; 0 is clamped to 1 so a
+    /// misconfiguration cannot make every transient blip stop reactors.
+    pub fn new(max_indeterminate: u32) -> Self {
+        Self {
+            consecutive_indeterminate: 0,
+            max_indeterminate: max_indeterminate.max(1),
+        }
+    }
+
+    pub fn consecutive_indeterminate(&self) -> u32 {
+        self.consecutive_indeterminate
+    }
+
+    /// Feed one check result; get the action to take.
+    ///
+    /// `believed_owned` is what we would have to stop if we presume total loss.
+    pub fn observe(
+        &mut self,
+        check: OwnershipCheck,
+        believed_owned: &[ReactorId],
+    ) -> WatchdogAction {
+        match check {
+            OwnershipCheck::AllHeld => {
+                // A successful verification clears the streak — transient
+                // failures must not accumulate across healthy checks.
+                self.consecutive_indeterminate = 0;
+                WatchdogAction::Continue
+            }
+            OwnershipCheck::Lost(lost) => {
+                // We got a definitive answer, so the streak is irrelevant.
+                self.consecutive_indeterminate = 0;
+                WatchdogAction::StopReactors(lost)
+            }
+            OwnershipCheck::Indeterminate(_) => {
+                self.consecutive_indeterminate += 1;
+                if self.consecutive_indeterminate >= self.max_indeterminate {
+                    WatchdogAction::StopAllPresumedLost(believed_owned.to_vec())
+                } else {
+                    WatchdogAction::Continue
+                }
+            }
+        }
+    }
+}
+
 /// SQL asking Postgres which advisory locks the CURRENT session holds.
 ///
 /// `pg_locks.pid = pg_backend_pid()` restricts to this session, which is the
@@ -427,6 +513,113 @@ mod tests {
         let mut expected = seen.clone();
         expected.sort();
         assert_eq!(seen, expected, "lost list must be sorted for stable logs");
+    }
+
+    #[test]
+    fn watchdog_continues_while_ownership_is_confirmed() {
+        let mut w = OwnershipWatchdog::new(3);
+        assert_eq!(
+            w.observe(OwnershipCheck::AllHeld, &[]),
+            WatchdogAction::Continue
+        );
+        assert_eq!(w.consecutive_indeterminate(), 0);
+    }
+
+    #[test]
+    fn watchdog_stops_exactly_the_reactors_reported_lost() {
+        let mut w = OwnershipWatchdog::new(3);
+        let a = id(Some("t1"), "r1");
+        let owned = vec![a.clone(), id(Some("t1"), "r2")];
+        assert_eq!(
+            w.observe(OwnershipCheck::Lost(vec![a.clone()]), &owned),
+            WatchdogAction::StopReactors(vec![a]),
+            "a definitive loss must stop ONLY the lost reactors, not everything"
+        );
+    }
+
+    /// Transient failures must not stop healthy reactors — reactive workloads
+    /// would flap on any ordinary blip.
+    #[test]
+    fn watchdog_tolerates_indeterminate_below_the_threshold() {
+        let mut w = OwnershipWatchdog::new(3);
+        let owned = vec![id(Some("t1"), "r1")];
+        for i in 1..3 {
+            assert_eq!(
+                w.observe(OwnershipCheck::Indeterminate("blip".into()), &owned),
+                WatchdogAction::Continue,
+                "indeterminate #{i} is below the threshold and must be tolerated"
+            );
+        }
+    }
+
+    /// The safety property: sustained inability to verify is PRESUMED LOSS.
+    /// If we cannot reach Postgres, our session is likely already gone — and
+    /// Postgres released our locks the moment it dropped, so another replica
+    /// may already own these. Failing toward "stop" is recoverable; failing
+    /// toward "keep running" is a silent double-processing split-brain.
+    #[test]
+    fn watchdog_presumes_loss_after_sustained_indeterminacy() {
+        let mut w = OwnershipWatchdog::new(3);
+        let owned = vec![id(Some("t1"), "r1"), id(None, "r2")];
+        w.observe(OwnershipCheck::Indeterminate("1".into()), &owned);
+        w.observe(OwnershipCheck::Indeterminate("2".into()), &owned);
+        assert_eq!(
+            w.observe(OwnershipCheck::Indeterminate("3".into()), &owned),
+            WatchdogAction::StopAllPresumedLost(owned.clone()),
+            "crossing the threshold must stop everything we believed we owned"
+        );
+    }
+
+    /// A recovered check clears the streak, so intermittent failures spread
+    /// across healthy checks never accumulate into a spurious stop.
+    #[test]
+    fn watchdog_streak_resets_on_a_successful_check() {
+        let mut w = OwnershipWatchdog::new(3);
+        let owned = vec![id(Some("t1"), "r1")];
+        w.observe(OwnershipCheck::Indeterminate("1".into()), &owned);
+        w.observe(OwnershipCheck::Indeterminate("2".into()), &owned);
+        assert_eq!(w.consecutive_indeterminate(), 2);
+
+        w.observe(OwnershipCheck::AllHeld, &owned);
+        assert_eq!(
+            w.consecutive_indeterminate(),
+            0,
+            "success must clear the streak"
+        );
+
+        // Two more must still be tolerated — proving the reset was real.
+        assert_eq!(
+            w.observe(OwnershipCheck::Indeterminate("3".into()), &owned),
+            WatchdogAction::Continue
+        );
+        assert_eq!(
+            w.observe(OwnershipCheck::Indeterminate("4".into()), &owned),
+            WatchdogAction::Continue
+        );
+    }
+
+    /// A definitive Lost also clears the streak: we got an answer, so prior
+    /// unverifiable checks say nothing about what happens next.
+    #[test]
+    fn watchdog_streak_resets_on_a_definitive_loss() {
+        let mut w = OwnershipWatchdog::new(2);
+        let a = id(Some("t1"), "r1");
+        w.observe(OwnershipCheck::Indeterminate("1".into()), &[a.clone()]);
+        w.observe(OwnershipCheck::Lost(vec![a.clone()]), &[a.clone()]);
+        assert_eq!(w.consecutive_indeterminate(), 0);
+    }
+
+    /// A zero threshold would stop reactors on the very first transient error.
+    #[test]
+    fn watchdog_threshold_is_clamped_to_at_least_one() {
+        let mut w = OwnershipWatchdog::new(0);
+        let owned = vec![id(Some("t1"), "r1")];
+        assert_eq!(
+            w.observe(OwnershipCheck::Indeterminate("x".into()), &owned),
+            WatchdogAction::StopAllPresumedLost(owned),
+            "clamped to 1: still stops, but on a defined threshold rather than \
+             a divide-by-zero-ish 0"
+        );
     }
 
     /// The session-scoping predicate is the difference between "we still hold

--- a/crates/cloacina/src/computation_graph/scheduler.rs
+++ b/crates/cloacina/src/computation_graph/scheduler.rs
@@ -1233,6 +1233,21 @@ impl ComputationGraphScheduler {
                 .ok_or_else(|| format!("reactor '{}' not loaded", reactor_name))?
         };
 
+        self.teardown_running(running, reactor_name).await;
+        Ok(())
+    }
+
+    /// Stop a reactor that has ALREADY been removed from the `reactors` map,
+    /// releasing everything it owned.
+    ///
+    /// Extracted so ownership-loss halts (CLOACI-T-0851) and ordinary unloads
+    /// share ONE teardown. A second copy would be free to drift — and the way
+    /// it would drift is by forgetting a deregistration, leaving a stopped
+    /// reactor still advertised in the endpoint registry.
+    ///
+    /// The caller owns the policy decision (may this reactor be torn down?);
+    /// this performs it unconditionally.
+    async fn teardown_running(&self, running: RunningGraph, reactor_name: &str) {
         // Capture graph names for health-metric "stopped" emission. Use the
         // endpoint-registry keys (which include the reactor's own name and
         // back-compat graph aliases) so every graph the reactor served sees
@@ -1265,7 +1280,53 @@ impl ComputationGraphScheduler {
         }
 
         info!(reactor = %reactor_name, "reactor unloaded");
-        Ok(())
+    }
+
+    /// Stop reactors this replica has lost ownership of (CLOACI-T-0851 /
+    /// [`ADR CLOACI-A-0012`] Amendment 1).
+    ///
+    /// Returns the reactors actually stopped — a subset, because a reactor may
+    /// already have been unloaded between the liveness check and this call.
+    ///
+    /// **Deliberately bypasses `unload_reactor`'s subscriber guard.** That guard
+    /// exists so a reactor never disappears under a graph still declaring it
+    /// upstream, which is right for an operator-initiated unload. It is wrong
+    /// here: having lost the lock, another replica may already be running this
+    /// reactor, and refusing to stop because a subscriber remains would leave
+    /// two live copies double-processing the same stream. A stopped reactor is
+    /// recoverable by re-claiming; silent double-processing is not.
+    pub async fn halt_unowned_reactors(
+        &self,
+        lost: &[super::reactor_ownership::ReactorId],
+    ) -> Vec<super::reactor_ownership::ReactorId> {
+        let mut stopped = Vec::new();
+        for id in lost {
+            let key: crate::TenantKey = id.into();
+            let running = {
+                let mut reactors = self.reactors.write().await;
+                reactors.remove(&key)
+            };
+            match running {
+                Some(running) => {
+                    tracing::warn!(
+                        reactor = %key,
+                        "ownership lost — halting reactor locally; another replica may own it"
+                    );
+                    self.teardown_running(running, &key.name).await;
+                    stopped.push(id.clone());
+                }
+                None => {
+                    // Not an error: it may have been unloaded normally between
+                    // the check and here. Logged so a puzzling "lost ownership
+                    // but nothing stopped" is explicable rather than silent.
+                    tracing::debug!(
+                        reactor = %key,
+                        "ownership lost for a reactor that is no longer loaded here"
+                    );
+                }
+            }
+        }
+        stopped
     }
 
     /// Backward-compat convenience: unbind the graph from its reactor and,
@@ -2315,6 +2376,90 @@ mod tests {
             reactor_name: Some(reactor.to_string()),
             topology: Some(format!("{{\"graph\":\"{}\"}}", graph)),
         }
+    }
+
+    /// CLOACI-T-0851: losing ownership must stop the reactor EVEN THOUGH a
+    /// subscriber still declares it upstream. `unload_reactor` refuses in that
+    /// situation by design; the halt path must not, because the alternative is
+    /// two replicas running the same reactor.
+    #[tokio::test]
+    async fn halt_unowned_stops_a_reactor_that_unload_would_refuse() {
+        use super::super::reactor_ownership::ReactorId;
+
+        let registry = EndpointRegistry::new();
+        let scheduler = ComputationGraphScheduler::new(registry.clone());
+        scheduler
+            .load_graph(tenant_decl("pipeline", "rx", Some("acme")))
+            .await
+            .expect("graph should load");
+        assert_eq!(scheduler.reactors.read().await.len(), 1);
+
+        // Precondition: the ordinary unload path refuses while a subscriber
+        // remains. If this ever stops being true the test below proves less
+        // than it claims, so assert it rather than assume it.
+        let refused = scheduler
+            .unload_reactor("rx", TenantScope::tenant("acme"))
+            .await;
+        assert!(
+            refused.is_err(),
+            "unload_reactor should refuse while a subscriber remains; got {refused:?}"
+        );
+        assert_eq!(scheduler.reactors.read().await.len(), 1, "still loaded");
+
+        let stopped = scheduler
+            .halt_unowned_reactors(&[ReactorId::new(Some("acme"), "rx")])
+            .await;
+
+        assert_eq!(stopped.len(), 1, "the lost reactor must be stopped");
+        assert!(
+            scheduler.reactors.read().await.is_empty(),
+            "halted reactor must be gone from the map"
+        );
+
+        scheduler.shutdown_all().await;
+    }
+
+    /// A reactor may be unloaded normally between the liveness check and the
+    /// halt. That must be a quiet no-op, not a panic or a spurious "stopped".
+    #[tokio::test]
+    async fn halt_unowned_is_a_noop_for_a_reactor_that_is_not_loaded() {
+        use super::super::reactor_ownership::ReactorId;
+
+        let registry = EndpointRegistry::new();
+        let scheduler = ComputationGraphScheduler::new(registry.clone());
+
+        let stopped = scheduler
+            .halt_unowned_reactors(&[ReactorId::new(Some("acme"), "never_loaded")])
+            .await;
+        assert!(stopped.is_empty(), "nothing was loaded, so nothing stopped");
+    }
+
+    /// Halting one tenant's reactor must not touch another tenant's same-named
+    /// one — the ownership key and the scheduler key must agree.
+    #[tokio::test]
+    async fn halt_unowned_is_tenant_scoped() {
+        use super::super::reactor_ownership::ReactorId;
+
+        let registry = EndpointRegistry::new();
+        let scheduler = ComputationGraphScheduler::new(registry.clone());
+        for tenant in ["acme", "globex"] {
+            scheduler
+                .load_graph(tenant_decl("pipeline", "rx", Some(tenant)))
+                .await
+                .unwrap_or_else(|e| panic!("tenant {tenant} should load: {e}"));
+        }
+        assert_eq!(scheduler.reactors.read().await.len(), 2);
+
+        let stopped = scheduler
+            .halt_unowned_reactors(&[ReactorId::new(Some("acme"), "rx")])
+            .await;
+        assert_eq!(stopped.len(), 1);
+
+        let remaining = scheduler.list_reactors().await;
+        assert_eq!(remaining.len(), 1, "globex's reactor must survive");
+        assert_eq!(remaining[0].tenant_id.as_deref(), Some("globex"));
+
+        scheduler.shutdown_all().await;
     }
 
     /// Two tenants load a graph AND a reactor under the SAME names on ONE

--- a/crates/cloacina/src/computation_graph/scheduler.rs
+++ b/crates/cloacina/src/computation_graph/scheduler.rs
@@ -520,6 +520,17 @@ pub struct ComputationGraphScheduler {
     /// to be byte-for-byte unchanged, and the way to guarantee that is for them
     /// to run none of this code rather than to run it and expect it to agree.
     ownership: Option<Arc<dyn super::reactor_ownership::ReactorOwnership>>,
+    /// Reactors this replica has loaded but does NOT own — another replica won
+    /// the claim, so nothing runs here for them.
+    ///
+    /// This is distinct from "not loaded": the package IS present, we simply do
+    /// not host the reactor. Callers need that distinction, because binding a
+    /// graph to a reactor owned elsewhere must be a quiet no-op rather than the
+    /// hard "reactor not loaded" error it would otherwise raise.
+    ///
+    /// This is also where routing will look when it lands: "who should this
+    /// event go to" starts with "is this reactor foreign to me".
+    foreign_reactors: Arc<RwLock<std::collections::HashSet<TenantKey>>>,
     /// Maps graph key → reactor key so external operations that take a
     /// graph_name (`unload_graph`, `list_graphs`) can find the reactor that
     /// hosts it. The *value* is a full key, not a name, so a subscriber in one
@@ -547,6 +558,7 @@ impl ComputationGraphScheduler {
             graph_topologies: Arc::new(RwLock::new(HashMap::new())),
             dal: None,
             ownership: None,
+            foreign_reactors: Arc::new(RwLock::new(std::collections::HashSet::new())),
         }
     }
 
@@ -562,6 +574,7 @@ impl ComputationGraphScheduler {
             graph_topologies: Arc::new(RwLock::new(HashMap::new())),
             dal: Some(dal),
             ownership: None,
+            foreign_reactors: Arc::new(RwLock::new(std::collections::HashSet::new())),
         }
     }
 
@@ -666,6 +679,52 @@ impl ComputationGraphScheduler {
                     ));
                 }
                 return Ok(());
+            }
+        }
+
+        // CLOACI-T-0851: claim cross-replica ownership BEFORE spawning anything.
+        //
+        // Placed here, alongside the other "resolve what can fail before we
+        // spawn" work, for the same reason: losing the claim after the reactor
+        // and its accumulators are running would mean tearing down a live
+        // reactor, and a partially-wired teardown is how endpoints get left
+        // registered for something that is no longer running.
+        //
+        // `ownership == None` — embedded, sqlite, single replica — skips this
+        // entirely and the path below is byte-for-byte what it was.
+        //
+        // NOT acquiring the lock is a normal outcome, not an error: another
+        // replica owns this reactor. The load still SUCCEEDS, because the
+        // package is legitimately present on this replica; it simply does not
+        // run the reactor here. Returning an error instead would make a
+        // correctly-functioning multi-replica deployment look like a failed
+        // deployment on every replica but one.
+        if let Some(ownership) = self.ownership.as_ref() {
+            let id = super::reactor_ownership::ReactorId::from(&reactor_key);
+            match ownership.claim(&id).await {
+                Ok(true) => {
+                    tracing::info!(reactor = %reactor_key, "reactor ownership claimed");
+                }
+                Ok(false) => {
+                    tracing::info!(
+                        reactor = %reactor_key,
+                        "reactor owned by another replica; not starting it here"
+                    );
+                    self.foreign_reactors
+                        .write()
+                        .await
+                        .insert(reactor_key.clone());
+                    return Ok(());
+                }
+                Err(e) => {
+                    // Fail the load rather than starting an unowned reactor. If
+                    // we cannot reach Postgres to claim, we equally cannot know
+                    // that nobody else holds it, and starting anyway is the
+                    // split-brain this mechanism exists to prevent.
+                    return Err(format!(
+                        "reactor '{reactor_key}': could not determine ownership: {e}"
+                    ));
+                }
             }
         }
 
@@ -1084,6 +1143,23 @@ impl ComputationGraphScheduler {
             provider_root,
         )
         .await?;
+
+        // CLOACI-T-0851: if another replica owns this reactor, nothing was
+        // started here, so there is nothing to bind to. Binding would fail with
+        // "reactor not loaded" — technically true, but it would report a
+        // correctly-functioning multi-replica deployment as a broken load on
+        // every replica except the owner.
+        {
+            let key = TenantKey::new(decl.tenant_id.as_deref(), &reactor_name);
+            if self.foreign_reactors.read().await.contains(&key) {
+                tracing::debug!(
+                    reactor = %key,
+                    graph = %name,
+                    "graph loaded but its reactor is owned by another replica; not binding here"
+                );
+                return Ok(());
+            }
+        }
 
         self.bind_graph_to_reactor(name, reactor_name, scope, decl.reactor.graph_fn)
             .await
@@ -2446,6 +2522,48 @@ mod tests {
             reactor_name: Some(reactor.to_string()),
             topology: Some(format!("{{\"graph\":\"{}\"}}", graph)),
         }
+    }
+
+    /// A replica that does not win the claim must NOT start the reactor — that
+    /// is the single-writer guarantee the whole design rests on — but the load
+    /// itself must still succeed, because the package really is present here.
+    #[tokio::test]
+    async fn load_does_not_start_a_reactor_owned_by_another_replica() {
+        let registry = EndpointRegistry::new();
+        let mut scheduler = ComputationGraphScheduler::new(registry.clone());
+        scheduler.set_ownership(Arc::new(FakeOwnership {
+            refuse_claim: true,
+            ..Default::default()
+        }));
+
+        let loaded = scheduler
+            .load_graph(tenant_decl("pipeline", "rx", Some("acme")))
+            .await;
+
+        assert!(
+            loaded.is_ok(),
+            "losing the claim is normal operation, not a load failure: {loaded:?}"
+        );
+        assert!(
+            scheduler.reactors.read().await.is_empty(),
+            "a reactor owned elsewhere must not run here"
+        );
+        scheduler.shutdown_all().await;
+    }
+
+    /// Winning the claim behaves exactly like today.
+    #[tokio::test]
+    async fn load_starts_the_reactor_when_the_claim_is_won() {
+        let registry = EndpointRegistry::new();
+        let mut scheduler = ComputationGraphScheduler::new(registry.clone());
+        scheduler.set_ownership(Arc::new(FakeOwnership::default()));
+
+        scheduler
+            .load_graph(tenant_decl("pipeline", "rx", Some("acme")))
+            .await
+            .expect("claim won → reactor should start");
+        assert_eq!(scheduler.reactors.read().await.len(), 1);
+        scheduler.shutdown_all().await;
     }
 
     /// A scriptable [`ReactorOwnership`] so the ownership-loss paths can be

--- a/crates/cloacina/src/computation_graph/scheduler.rs
+++ b/crates/cloacina/src/computation_graph/scheduler.rs
@@ -512,6 +512,14 @@ pub struct ComputationGraphScheduler {
     /// names let two tenants' same-named reactors collide in-process.
     /// `tenant_id: None` is the embedded/untenanted entry.
     reactors: Arc<RwLock<HashMap<TenantKey, RunningGraph>>>,
+    /// Cross-replica reactor ownership (CLOACI-T-0851 / [`ADR CLOACI-A-0012`]).
+    ///
+    /// `None` — the default, and the ONLY state for embedded, sqlite and
+    /// single-replica deployments — means every code path below behaves exactly
+    /// as it did before this feature existed. A-0012 requires those deployments
+    /// to be byte-for-byte unchanged, and the way to guarantee that is for them
+    /// to run none of this code rather than to run it and expect it to agree.
+    ownership: Option<Arc<dyn super::reactor_ownership::ReactorOwnership>>,
     /// Maps graph key → reactor key so external operations that take a
     /// graph_name (`unload_graph`, `list_graphs`) can find the reactor that
     /// hosts it. The *value* is a full key, not a name, so a subscriber in one
@@ -538,6 +546,7 @@ impl ComputationGraphScheduler {
             graph_to_reactor: Arc::new(RwLock::new(HashMap::new())),
             graph_topologies: Arc::new(RwLock::new(HashMap::new())),
             dal: None,
+            ownership: None,
         }
     }
 
@@ -552,6 +561,7 @@ impl ComputationGraphScheduler {
             graph_to_reactor: Arc::new(RwLock::new(HashMap::new())),
             graph_topologies: Arc::new(RwLock::new(HashMap::new())),
             dal: Some(dal),
+            ownership: None,
         }
     }
 
@@ -1235,6 +1245,66 @@ impl ComputationGraphScheduler {
 
         self.teardown_running(running, reactor_name).await;
         Ok(())
+    }
+
+    /// Install cross-replica reactor ownership (CLOACI-T-0851).
+    ///
+    /// Only `cloacina-server` under multi-replica postgres should call this.
+    /// Leaving it unset keeps embedded/sqlite/single-replica behaviour exactly
+    /// as it was.
+    pub fn set_ownership(
+        &mut self,
+        ownership: Arc<dyn super::reactor_ownership::ReactorOwnership>,
+    ) {
+        self.ownership = Some(ownership);
+    }
+
+    /// Whether cross-replica ownership is in force.
+    pub fn has_ownership_coordination(&self) -> bool {
+        self.ownership.is_some()
+    }
+
+    /// One watchdog tick: verify what we believe we own, and act on the verdict.
+    ///
+    /// Returns the reactors halted (empty when all is well, or when ownership
+    /// coordination is not installed). Callers drive this on a timer; it is a
+    /// single tick rather than a loop so the cadence, and the test, stay in the
+    /// caller's hands.
+    ///
+    /// See [`ADR CLOACI-A-0012`] Amendment 1 for why a long-held lock needs
+    /// verifying at all, and `OwnershipWatchdog` for why sustained inability to
+    /// verify is treated as loss rather than as health.
+    pub async fn ownership_watchdog_tick(
+        &self,
+        watchdog: &mut super::reactor_ownership::OwnershipWatchdog,
+    ) -> Vec<super::reactor_ownership::ReactorId> {
+        use super::reactor_ownership::WatchdogAction;
+
+        let Some(ownership) = self.ownership.as_ref() else {
+            return Vec::new();
+        };
+
+        let check = ownership.verify().await;
+        let believed = ownership.believed_owned().await;
+
+        match watchdog.observe(check, &believed) {
+            WatchdogAction::Continue => Vec::new(),
+            WatchdogAction::StopReactors(lost) => {
+                tracing::warn!(
+                    count = lost.len(),
+                    "ownership lost for reactors; halting them"
+                );
+                self.halt_unowned_reactors(&lost).await
+            }
+            WatchdogAction::StopAllPresumedLost(all) => {
+                tracing::error!(
+                    count = all.len(),
+                    "ownership UNVERIFIABLE for too long — presuming loss and halting every \
+                     reactor this replica believed it owned"
+                );
+                self.halt_unowned_reactors(&all).await
+            }
+        }
     }
 
     /// Stop a reactor that has ALREADY been removed from the `reactors` map,
@@ -2376,6 +2446,177 @@ mod tests {
             reactor_name: Some(reactor.to_string()),
             topology: Some(format!("{{\"graph\":\"{}\"}}", graph)),
         }
+    }
+
+    /// A scriptable [`ReactorOwnership`] so the ownership-loss paths can be
+    /// driven deterministically. The real failure modes (connection dropped,
+    /// lock stolen, verification unavailable) cannot be produced on demand
+    /// against a live database, which is exactly why they need a fake.
+    #[derive(Default)]
+    struct FakeOwnership {
+        owned: std::sync::Mutex<Vec<super::super::reactor_ownership::ReactorId>>,
+        next_check: std::sync::Mutex<Option<super::super::reactor_ownership::OwnershipCheck>>,
+        refuse_claim: bool,
+    }
+
+    #[async_trait::async_trait]
+    impl super::super::reactor_ownership::ReactorOwnership for FakeOwnership {
+        async fn claim(
+            &self,
+            id: &super::super::reactor_ownership::ReactorId,
+        ) -> Result<bool, String> {
+            if self.refuse_claim {
+                return Ok(false);
+            }
+            self.owned.lock().unwrap().push(id.clone());
+            Ok(true)
+        }
+        async fn release(
+            &self,
+            id: &super::super::reactor_ownership::ReactorId,
+        ) -> Result<(), String> {
+            self.owned.lock().unwrap().retain(|o| o != id);
+            Ok(())
+        }
+        async fn verify(&self) -> super::super::reactor_ownership::OwnershipCheck {
+            self.next_check
+                .lock()
+                .unwrap()
+                .clone()
+                .unwrap_or(super::super::reactor_ownership::OwnershipCheck::AllHeld)
+        }
+        async fn believed_owned(&self) -> Vec<super::super::reactor_ownership::ReactorId> {
+            self.owned.lock().unwrap().clone()
+        }
+    }
+
+    /// Without ownership installed (embedded / sqlite / single replica) the
+    /// watchdog must be inert. A-0012 requires those deployments unchanged, and
+    /// a tick that halted anything here would be a regression for every
+    /// existing user.
+    #[tokio::test]
+    async fn watchdog_tick_is_inert_without_ownership_coordination() {
+        use super::super::reactor_ownership::OwnershipWatchdog;
+
+        let registry = EndpointRegistry::new();
+        let scheduler = ComputationGraphScheduler::new(registry.clone());
+        scheduler
+            .load_graph(tenant_decl("pipeline", "rx", Some("acme")))
+            .await
+            .expect("graph should load");
+
+        assert!(!scheduler.has_ownership_coordination());
+        let mut wd = OwnershipWatchdog::new(3);
+        let halted = scheduler.ownership_watchdog_tick(&mut wd).await;
+
+        assert!(halted.is_empty(), "no ownership installed → nothing halted");
+        assert_eq!(
+            scheduler.reactors.read().await.len(),
+            1,
+            "the reactor must still be running"
+        );
+        scheduler.shutdown_all().await;
+    }
+
+    /// A confirmed check must not halt anything.
+    #[tokio::test]
+    async fn watchdog_tick_leaves_confirmed_reactors_running() {
+        use super::super::reactor_ownership::{OwnershipCheck, OwnershipWatchdog, ReactorId};
+
+        let registry = EndpointRegistry::new();
+        let mut scheduler = ComputationGraphScheduler::new(registry.clone());
+        let fake = Arc::new(FakeOwnership::default());
+        fake.owned
+            .lock()
+            .unwrap()
+            .push(ReactorId::new(Some("acme"), "rx"));
+        *fake.next_check.lock().unwrap() = Some(OwnershipCheck::AllHeld);
+        scheduler.set_ownership(fake);
+
+        scheduler
+            .load_graph(tenant_decl("pipeline", "rx", Some("acme")))
+            .await
+            .expect("graph should load");
+
+        let mut wd = OwnershipWatchdog::new(3);
+        assert!(scheduler.ownership_watchdog_tick(&mut wd).await.is_empty());
+        assert_eq!(scheduler.reactors.read().await.len(), 1);
+        scheduler.shutdown_all().await;
+    }
+
+    /// The end-to-end loss path: verify reports a lost lock → the watchdog says
+    /// stop → the reactor is actually torn down.
+    #[tokio::test]
+    async fn watchdog_tick_halts_a_reactor_whose_lock_was_lost() {
+        use super::super::reactor_ownership::{OwnershipCheck, OwnershipWatchdog, ReactorId};
+
+        let registry = EndpointRegistry::new();
+        let mut scheduler = ComputationGraphScheduler::new(registry.clone());
+        let lost = ReactorId::new(Some("acme"), "rx");
+        let fake = Arc::new(FakeOwnership::default());
+        *fake.next_check.lock().unwrap() = Some(OwnershipCheck::Lost(vec![lost.clone()]));
+        scheduler.set_ownership(fake);
+
+        scheduler
+            .load_graph(tenant_decl("pipeline", "rx", Some("acme")))
+            .await
+            .expect("graph should load");
+        assert_eq!(scheduler.reactors.read().await.len(), 1);
+
+        let mut wd = OwnershipWatchdog::new(3);
+        let halted = scheduler.ownership_watchdog_tick(&mut wd).await;
+
+        assert_eq!(halted, vec![lost], "the lost reactor must be halted");
+        assert!(
+            scheduler.reactors.read().await.is_empty(),
+            "a reactor we no longer own must not keep running"
+        );
+        scheduler.shutdown_all().await;
+    }
+
+    /// Sustained inability to verify must eventually halt everything — and must
+    /// NOT halt on the first blip. Both halves matter: halting early makes
+    /// reactive workloads flap, halting never leaves a partitioned replica
+    /// double-processing forever.
+    #[tokio::test]
+    async fn watchdog_tick_halts_everything_after_sustained_indeterminacy() {
+        use super::super::reactor_ownership::{OwnershipCheck, OwnershipWatchdog, ReactorId};
+
+        let registry = EndpointRegistry::new();
+        let mut scheduler = ComputationGraphScheduler::new(registry.clone());
+        let fake = Arc::new(FakeOwnership::default());
+        fake.owned
+            .lock()
+            .unwrap()
+            .push(ReactorId::new(Some("acme"), "rx"));
+        *fake.next_check.lock().unwrap() =
+            Some(OwnershipCheck::Indeterminate("db unreachable".into()));
+        scheduler.set_ownership(fake);
+
+        scheduler
+            .load_graph(tenant_decl("pipeline", "rx", Some("acme")))
+            .await
+            .expect("graph should load");
+
+        let mut wd = OwnershipWatchdog::new(3);
+        assert!(
+            scheduler.ownership_watchdog_tick(&mut wd).await.is_empty(),
+            "first unverifiable tick must be tolerated"
+        );
+        assert!(
+            scheduler.ownership_watchdog_tick(&mut wd).await.is_empty(),
+            "second unverifiable tick must be tolerated"
+        );
+        assert_eq!(
+            scheduler.reactors.read().await.len(),
+            1,
+            "reactor still running while within tolerance"
+        );
+
+        let halted = scheduler.ownership_watchdog_tick(&mut wd).await;
+        assert_eq!(halted.len(), 1, "threshold crossed → presume loss and halt");
+        assert!(scheduler.reactors.read().await.is_empty());
+        scheduler.shutdown_all().await;
     }
 
     /// CLOACI-T-0851: losing ownership must stop the reactor EVEN THOUGH a


### PR DESCRIPTION
Foundation for T-0851 (reactive-layer HA), implementing ADR A-0012: per-reactor
leadership with durable accumulator state. **Draft — this is the first third of
the ticket.** Routing and accumulator persist/restore are not here yet.

## What is in it

**1. Tenant-safe advisory-lock keys** (`reactor_lock_key.rs`, 7 tests)

A-0012 named this as the blocker to resolve before any lease code, and the
hazard is real rather than theoretical: tenants are isolated by **schema within
one database** (`SET LOCAL search_path`, `database/admin.rs`), and advisory
locks are **database-wide** — not schema-scoped. Keying by graph name alone
would have made two tenants' same-named reactors contend for one lock, with
exactly one silently never running.

Two traps, each defended with a test rather than a comment:

* **A seeded hasher would itself be the split-brain bug.** `DefaultHasher` /
  `RandomState` is seeded per PROCESS, so every replica computes a different
  key, every replica wins "the lock", and all of them run the reactor —
  surfacing as an intermittent duplicate, not an error. Hand-rolled FNV-1a with
  fixed constants; the stability test pins exact literals so changing the
  encoding fails loudly instead of splitting brains during a rolling deploy.
* **`save_reactor_state` is a misleading precedent.** It keys checkpoints by
  graph name alone and is CORRECT to, because the DAL is schema-scoped. Locks
  are not. Documented so the next reader does not copy the wrong pattern.

Also length-delimited so ("a","bc") and ("ab","c") cannot collide, and the sign
bit is forced so reactor keys occupy the negative i64 half — disjoint from
hand-picked small positive keys like FLEET_CONTROL_LOCK_KEY.

**2. The ownership session** (`reactor_ownership.rs`, 7 tests)

One dedicated connection per replica carrying ALL of that replica's reactor
locks — O(1) in reactor count. Copying the fleet loop's per-lock connection
would pin one pooled connection per owned reactor for the process lifetime and
exhaust the pool. Reserves one connection per replica; documented as an
operator-visible cost.

`claim` / `release` / `verify_owned`, driving pg_try_advisory_lock /
pg_advisory_unlock / SESSION_HELD_LOCKS_SQL through deadpool's interact,
mirroring with_fleet_leadership.

### A-0012 needs amending, and the code already diverges from it

A-0012 states session-scoped locks need "no lease/heartbeat bookkeeping." True
for failover; NOT sufficient for long-held ownership:

> The ownership connection drops (network blip, PgBouncer recycle, DB restart)
> while the replica keeps running. Postgres releases every lock the session
> held. Another replica legitimately claims the reactor. **The original replica
> never notices and keeps running it.** Two replicas, one reactor, no error
> anywhere.

The fleet loop is immune only because it re-acquires every tick. Ownership that
is ASSUMED rather than re-established must be re-verified. Maintainer decision:
**self-check + halt** — periodically re-assert the locks, stop affected reactors
locally on loss before any re-claim. Loss DETECTION, not lease renewal: no TTL,
no clock assumption, Postgres stays the sole source of truth. (Fencing tokens
considered and deferred — safer, but needs a schema change and touches the
checkpoint write path.)

The ADR has NOT been amended yet. Reasoning is captured in T-0851 and the module
docs, but someone reading A-0012 alone gets a wrong picture.

**3. Unflaking k8s-leader assertion 5** (independently mergeable)

Found by running the lane. It was blocking on `never caught the lock holder
pre-kill`, failing the lane (exit 1) on a CORE assertion for reasons unrelated
to anything under test — a gate that trains people to ignore it.

Root cause was latency, not logic: polling spawned TWO subprocesses per sample
(kubectl get pods + kubectl exec psql), hundreds of ms each, while the fleet
lock is taken and released within a single control tick. The whole window caught
it 6 times.

Fix: move the poll inside Postgres. One exec runs a plpgsql loop sampling
pg_locks every 10ms, returning the instant a holder appears — same predicate,
~1000x the density. Applied to BOTH the pre-kill catch and the post-kill
survivor wait; the latter has the identical race and HARD-FAILS rather than
blocking.

Lock queries now match the FULL key (classid + objid + objsubid) rather than
objid alone. Partial matching fails quietly in both directions: under-match
returns no rows, and a lock query returning no rows PASSES a "never two
holders" assertion — green while proving the absence of what it should observe.
Over-match conflates keys sharing their low 32 bits, which matters because every
reactor key shares its high bits by construction.

## Verification

* 14 unit tests; `cargo check --all-targets` green on both `postgres,macros` and
  `sqlite,macros`.
* Catcher SQL validated against a live Postgres (cloacina-postgres:15432) for
  four behaviours: no holder → empty; live holder → caught immediately;
  exclude_addr → suppresses the known holder; NULL client_addr handled. That
  last one caught a real bug in the first draft — client_addr is NULL for local
  connections and `NULL || '|' || pid` is NULL, so a holder would have existed
  but rendered as nothing and the catcher would have reported "no holder".
* `angreal test e2e k8s-leader` run against real 2-replica k3s BEFORE the fix:
  exit 1, 3/5, assertion 5 blocked. That run also confirmed `objsubid = 1` is
  correct for the bigint form (6 real catches, both pods, never simultaneous) —
  which validates the same assumption baked into SESSION_HELD_LOCKS_SQL.
* Re-run with the fix is in flight at time of writing; expect 4/5, with
  assertion 4 still blocked by design (needs --claiming).

## Not done

Periodic verify task, scheduler wiring, event routing to the owner, accumulator
persist + restore, and the reactor assertions in the k8s-leader lane. Draft until
those land.
